### PR TITLE
Add HS-App theme stylesheet for components

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,3 +20,11 @@ coverage
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.git-hooks
+.storybook
+.vscode
+config
+scripts
+stories
+todos

--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,4 +1,4 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 
-import '@storybook/addon-actions/register';
-import '@storybook/addon-links/register';
+import '@storybook/addon-actions/register'
+import '@storybook/addon-links/register'

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,9 +1,9 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 
-import { configure } from '@storybook/react';
+import { configure } from '@storybook/react'
 
 function loadStories() {
-  require('../stories');
+  require('../stories/index')
 }
 
-configure(loadStories, module);
+configure(loadStories, module)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - npm install
 
 script:
+  - npm run pretty
   - npm test
 
 after_success:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/blue",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
       "afterEach",
       "it",
       "expect",
+      "jasmine",
       "jest",
       "React",
       "react",

--- a/scripts/sass.js
+++ b/scripts/sass.js
@@ -7,36 +7,43 @@ const includePaths = harvester([
   './src/styles'
 ])
 
-// Default .css compile
-sass.render({
-  file: './src/styles/blue.scss',
-  includePaths: includePaths,
-  outputStyle: 'compact'
-}, function (error, result) {
-  if (error) {
-    console.error(error)
-    return process.exit(1)
-  } else {
-    mkdirp('./dist')
-    mkdirp('./dist/css')
-    mkdirp('./dist/scss')
+mkdirp('./dist')
+mkdirp('./dist/css')
+mkdirp('./dist/scss')
 
-    fs.writeFile('./dist/css/blue.css', result.css, function (err) {
-      if (err) {
-        console.error(error)
-        return process.exit(1)
-      }
-      console.log('blue.css created.')
+const files = [
+  'blue',
+  'blue.hs-app'
+]
 
-      fs.writeFile('./dist/scss/blue.scss', result.css, function (err) {
+const renderFile = (fileName) => {
+  // Default .css compile
+  return sass.render({
+    file: `./src/styles/${fileName}.scss`,
+    includePaths: includePaths,
+    outputStyle: 'compact'
+  }, function (error, result) {
+    if (error) {
+      console.error(error)
+      return process.exit(1)
+    } else {
+      fs.writeFile(`./dist/css/${fileName}.css`, result.css, function (err) {
         if (err) {
           console.error(error)
           return process.exit(1)
         }
-        console.log('blue.scss created.')
+        console.log(`${fileName}.css created.`)
 
-        return process.exit(0)
+        fs.writeFile(`./dist/scss/${fileName}.scss`, result.css, function (err) {
+          if (err) {
+            console.error(error)
+            return process.exit(1)
+          }
+          console.log(`${fileName}.scss created.`)
+        })
       })
-    })
-  }
-})
+    }
+  })
+}
+
+files.forEach(file => renderFile(file))

--- a/src/components/Choice/Input.js
+++ b/src/components/Choice/Input.js
@@ -75,7 +75,7 @@ const Input = props => {
         aria-describedby={helpText || undefined}
         aria-invalid={state !== 'error'}
         checked={checked}
-        className='c-InputField c-ChoiceInput__input'
+        className={`c-InputField c-ChoiceInput__input is-${type}`}
         disabled={disabled}
         id={id}
         name={name}

--- a/src/styles/blue.hs-app.scss
+++ b/src/styles/blue.hs-app.scss
@@ -1,5 +1,4 @@
 /* Help Scout: Blue */
 /* Theme: HS-APP */
 
-@import "./blue";
 @import "./themes/hs-app/_index";

--- a/src/styles/blue.hs-app.scss
+++ b/src/styles/blue.hs-app.scss
@@ -1,0 +1,5 @@
+/* Help Scout: Blue */
+/* Theme: HS-APP */
+
+@import "./blue";
+@import "./themes/hs-app/_index";

--- a/src/styles/components/Input/InputBackdrop.scss
+++ b/src/styles/components/Input/InputBackdrop.scss
@@ -1,61 +1,12 @@
 @import "pack/seed-family/_index";
 @import "../../configs/constants";
+@import "../../mixins/backdrop-styles";
 
 .c-InputBackdrop {
   @import "../../configs/color";
   @import "../../resets/base";
   $InputField: ".c-InputField";
   $color-border-focus: _color(blue, 400);
-  $states: $STATES;
-  $this: this();
 
-  background-color: white;
-  border: 1px solid _color(border, ui, dark);
-  border-radius: 4px;
-  bottom: 0;
-  box-shadow: 0 0 0 0 rgba(_color(border), 0);
-  left: 0;
-  position: absolute;
-  right: 0;
-  transition: box-shadow 0.1s ease;
-  top: 0;
-
-  @include parent("#{$InputField}:focus ~ ") {
-    border-color: $color-border-focus;
-    box-shadow: 0 0 0 1px $color-border-focus inset;
-  }
-
-  // Styles
-  @include parent(".is-seamless > ") {
-    border-color: transparent;
-    box-shadow: none;
-    @include parent("#{$InputField}:focus ~ ") {
-      border-color: transparent;
-      box-shadow: none;
-    }
-  }
-
-  &.is-checkbox {
-    box-shadow: 0 0 0 0 rgba(_color(border), 0), 0 0.5px 1px rgba(black, 0.2) inset;
-  }
-
-  // States
-  @each $state in $states {
-    &.is-#{$state} {
-      border-color: _color(state, $state, border-color);
-      @include parent("#{$InputField}:focus ~ ") {
-        border-color: _color(state, $state, border-color);
-        box-shadow: 0 0 0 1px _color(state, $state, border-color) inset;
-      }
-    }
-  }
-
-  // Disabled
-  &.is-disabled {
-    background-color: _color(grey, 200);
-  }
-  // Read-Only
-  &.is-readonly {
-    background-color: _color(grey, 300);
-  }
+  @include backdrop-styles($InputField, $color-border-focus);
 }

--- a/src/styles/mixins/backdrop-styles.scss
+++ b/src/styles/mixins/backdrop-styles.scss
@@ -1,9 +1,10 @@
 @import "../configs/color";
+@import "../configs/constants";
 
-@mixin backdrop-styles($block, $states) {
-  $InputField: ".c-InputField";
-  $color-border-focus: _color(blue, 400);
+@mixin backdrop-styles($InputField, $color-border-focus) {
+  $states: $STATES;
   $this: this();
+
   background-color: white;
   border: 1px solid _color(border, ui, dark);
   border-radius: 4px;
@@ -21,7 +22,7 @@
   }
 
   // Styles
-  @include parent("#{$block}--seamless") {
+  @include parent(".is-seamless > ") {
     border-color: transparent;
     box-shadow: none;
     @include parent("#{$InputField}:focus ~ ") {
@@ -30,18 +31,27 @@
     }
   }
 
+  &.is-checkbox {
+    box-shadow: 0 0 0 0 rgba(_color(border), 0), 0 0.5px 1px rgba(black, 0.2) inset;
+  }
+
   // States
   @each $state in $states {
-    @include parent("#{$block}.is-#{$state} #{$InputField} ~ ") {
+    &.is-#{$state} {
       border-color: _color(state, $state, border-color);
-    }
-    @include parent("#{$block}.is-#{$state} #{$InputField}:focus ~ ") {
-      box-shadow: 0 0 0 1px _color(state, $state, border-color) inset;
+      @include parent("#{$InputField}:focus ~ ") {
+        border-color: _color(state, $state, border-color);
+        box-shadow: 0 0 0 1px _color(state, $state, border-color) inset;
+      }
     }
   }
 
   // Disabled
-  @include parent("#{$block}.is-disabled #{$InputField} ~ ") {
+  &.is-disabled {
     background-color: _color(grey, 200);
+  }
+  // Read-Only
+  &.is-readonly {
+    background-color: _color(grey, 300);
   }
 }

--- a/src/styles/themes/hs-app/__index.scss
+++ b/src/styles/themes/hs-app/__index.scss
@@ -1,0 +1,1 @@
+@import "./components/_index";

--- a/src/styles/themes/hs-app/components/Choice.scss
+++ b/src/styles/themes/hs-app/components/Choice.scss
@@ -1,0 +1,32 @@
+@import "../mixins/visibility";
+
+.c-Choice {
+  @import "../resets/base";
+  
+  .c-InputBackdrop {
+    display: none;
+  }
+}
+
+.c-ChoiceInput {
+  &__input {
+    @include visibility-forced;
+    display: initial;
+    opacity: initial;
+    position: relative !important;
+    top: -2px;
+  
+    &.is-checkbox {
+      -webkit-appearance: checkbox;
+      appearance: checkbox;
+    }
+    &.is-radio {
+      -webkit-appearance: radio;
+      appearance: radio;
+    }
+  }
+
+  &__icon {
+    display: none;
+  }
+}

--- a/src/styles/themes/hs-app/components/HelpText.scss
+++ b/src/styles/themes/hs-app/components/HelpText.scss
@@ -1,0 +1,3 @@
+.c-HelpText {
+  @import "../resets/base";
+}

--- a/src/styles/themes/hs-app/components/Input.scss
+++ b/src/styles/themes/hs-app/components/Input.scss
@@ -1,0 +1,34 @@
+@import "../configs/constants";
+@import "../configs/color";
+
+
+.c-InputWrapper {
+  .c-Label {
+    .c-Text {
+      color: $HS_APP_INPUT_LABEL_COLOR;
+    }
+  }
+}
+
+.c-Input {
+  @import "../resets/base";
+}
+
+.c-InputField {
+  @import "../resets/base";
+
+  &.is-sm {
+    font-size: $HS_APP_INPUT_FONT_SIZE_SM;
+    top: 0;
+  }
+}
+
+.c-InputBackdrop {
+  $InputField: ".c-InputField";
+  $color-border-focus: _color(blue, 500);
+
+  @include backdrop-styles($InputField, $color-border-focus);
+
+  box-shadow: none !important;
+  border-radius: $HS_APP_INPUT_BORDER_RADIUS;
+}

--- a/src/styles/themes/hs-app/components/Text.scss
+++ b/src/styles/themes/hs-app/components/Text.scss
@@ -1,0 +1,3 @@
+.c-Text {
+  @import "../resets/base";
+}

--- a/src/styles/themes/hs-app/components/__index.scss
+++ b/src/styles/themes/hs-app/components/__index.scss
@@ -1,0 +1,4 @@
+@import "./Choice";
+@import "./Input";
+@import "./HelpText";
+@import "./Text";

--- a/src/styles/themes/hs-app/configs/_color.scss
+++ b/src/styles/themes/hs-app/configs/_color.scss
@@ -1,0 +1,1 @@
+@import "../../../configs/color";

--- a/src/styles/themes/hs-app/configs/_constants.scss
+++ b/src/styles/themes/hs-app/configs/_constants.scss
@@ -1,0 +1,11 @@
+@import "./color";
+
+// Global
+$HS_APP_FONT_FAMILY: "Aktiv Grotesk","Helvetica Neue",Helvetica,Arial,sans-serif !global;
+$HS_APP_FONT_SIZE: 14px !global;
+
+// Inputs
+$HS_APP_INPUT_LABEL_COLOR: _color(text) !global;
+$HS_APP_INPUT_BORDER_RADIUS: 3px !global;
+$HS_APP_INPUT_FONT_SIZE: $HS_APP_FONT_SIZE !global;
+$HS_APP_INPUT_FONT_SIZE_SM: 13px !global;

--- a/src/styles/themes/hs-app/mixins/visibility.scss
+++ b/src/styles/themes/hs-app/mixins/visibility.scss
@@ -1,0 +1,11 @@
+@mixin visibility-forced {
+  border: initial !important;
+  box-sizing: border-box;
+  clip: initial !important;
+  height: initial !important;
+  overflow: initial !important;
+  padding: initial !important;
+  position: initial !important;
+  top: initial;
+  width: initial !important;
+}

--- a/src/styles/themes/hs-app/resets/_base.scss
+++ b/src/styles/themes/hs-app/resets/_base.scss
@@ -1,0 +1,11 @@
+@import "../configs/constants";
+
+& {
+  box-sizing: border-box;
+  font-family: $HS_APP_FONT_FAMILY;
+  font-size: $HS_APP_FONT_SIZE;
+
+  * {
+    box-sizing: border-box;
+  }
+}

--- a/stories/Checkbox.js
+++ b/stories/Checkbox.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Checkbox, ChoiceGroup } from '../src/index.js'
+import { Theme } from './addons/theme'
 
 storiesOf('Checkbox', module)
   .add('default', () => (

--- a/stories/Checkbox.js
+++ b/stories/Checkbox.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Checkbox, ChoiceGroup } from '../src/index.js'
-import { Theme } from './addons/theme'
 
 storiesOf('Checkbox', module)
   .add('default', () => (

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,4 +1,5 @@
 import '../src/styles/blue.scss'
+import '../src/styles/blue.hs-app.scss'
 
 import './Animate'
 import './Avatar'


### PR DESCRIPTION
This update adds an `hs-app` stylesheet (.scss/.css) for Blue. The idea for this is to allow for Blue components to be seamlessly dropped into `hs-app` with no/minimal issues in UI consistency.

Typically, it should be up to the consumer of this package (`hs-app`) to write the custom CSS necessary to override Blue, as Blue should be application agnostic. However, I think this approach is fine, and is the easiest/fastest way for us to start integrating into multiple projects.

Minimal adjustments were made to the actual React JS components. Most of these changes are SCSS based, and are isolated within the new `hs-app` theme directory under `src/styles/themes/hs-app`.

The idea for this came about during a call I had with @knicklabs.

To use the `hs-app` theme stylesheet, simply import add it to the project's main .scss in addition to blue.

Example:

```scss
...

@import "blue";      
@import "blue.hs-app";

...
```