### PR TITLE
Improve Portal mount cycle

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -38,6 +38,7 @@ const Modal = props => {
     openPortal,
     path,
     portalIsOpen,
+    portalIsMounted,
     style,
     timeout,
     trigger,

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -5,6 +5,12 @@ import Portal from '../../Portal'
 import Keys from '../../../constants/Keys'
 import { MemoryRouter as Router } from 'react-router'
 
+const MODAL_TEST_TIMEOUT = 280
+const cleanUp = (wrapper) => {
+  if (wrapper) wrapper.unmount()
+  global.document.body.innerHTML = ''
+}
+
 const trigger = (
   <a className='trigger'>Trigger</a>
 )
@@ -52,7 +58,7 @@ describe('Key events', () => {
       expect(document.body.childNodes.length).toBeLessThan(preCloseNodeCount)
       expect(document.getElementsByClassName('c-Modal').length).toBe(0)
       done()
-    }, 500)
+    }, MODAL_TEST_TIMEOUT)
 
     wrapper.unmount()
   })
@@ -110,7 +116,7 @@ describe('Portal', () => {
       wrapper.unmount()
 
       done()
-    }, 500)
+    }, MODAL_TEST_TIMEOUT)
   })
 })
 
@@ -240,5 +246,32 @@ describe('Style', () => {
     wrapper.unmount()
     global.document.body.innerHTML = ''
     done()
+  })
+})
+
+describe('PortalWrapper', () => {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
+
+  test('onBeforeClose callback works', (done) => {
+    const testBody = global.document.createElement('div')
+    global.document.body.appendChild(testBody)
+
+    const mockCallback = jest.fn()
+    const onBeforeClose = (close) => {
+      close()
+      mockCallback()
+    }
+
+    const wrapper = mount(
+      <Modal onBeforeClose={onBeforeClose} isOpen />
+    , { attachTo: testBody })
+
+    wrapper.detach()
+
+    setTimeout(() => {
+      expect(mockCallback.mock.calls.length).toBe(1)
+      cleanUp()
+      done()
+    }, MODAL_TEST_TIMEOUT)
   })
 })

--- a/src/components/Portal/index.js
+++ b/src/components/Portal/index.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types'
 import { default as Container, ID as portalContainerId } from './Container'
 
 export const propTypes = {
-  children: PropTypes.element,
   className: PropTypes.string,
   exact: PropTypes.bool,
   id: PropTypes.string,
@@ -44,6 +43,10 @@ class Portal extends React.Component {
     this.openPortal(this.props)
   }
 
+  componentWillUpdate (nextProps, nextState) {
+    this.mountPortal(nextProps)
+  }
+
   /* istanbul ignore next */
   componentWillReceiveProps (nextProps) {
     if (this.node && this.props.className !== nextProps.className) {
@@ -70,15 +73,29 @@ class Portal extends React.Component {
     return mountSelector || document.body // fallback
   }
 
-  mountPortal (props) {
-    if (this.node) return
-
+  renderPortalContent (props) {
     const {
+      children
+    } = props
+
+    this.portal = ReactDOM.unstable_renderSubtreeIntoContainer(
+      this,
       children,
+      this.node
+    )
+  }
+
+  mountPortal (props) {
+    const {
       className,
       id,
       onOpen
     } = props
+
+    if (this.node) {
+      this.renderPortalContent(props)
+      return
+    }
 
     this.node = document.createElement('div')
     if (className) {
@@ -89,12 +106,7 @@ class Portal extends React.Component {
     }
     // Render to specified target, instead of document
     this.mountSelector.appendChild(this.node)
-
-    this.portal = ReactDOM.unstable_renderSubtreeIntoContainer(
-      this,
-      children,
-      this.node
-    )
+    this.renderPortalContent(props)
 
     if (onOpen) onOpen(this)
 

--- a/src/components/PortalWrapper/README.md
+++ b/src/components/PortalWrapper/README.md
@@ -6,6 +6,7 @@ A PortalWrapper component is a High-Order Component that connects a component wi
 ## Example
 
 ```js
+import Animate from '../Animate'
 import Overlay from '../Overlay'
 import PortalWrapper from '../PortalWrapper'
 
@@ -22,12 +23,14 @@ const MyModal = props => {
   } = props
 
   return (
-    <div className='MyModal'>
-      <div className='MyModalContent'>
-        {children}
+    <Animate sequence='fadeIn down' in={portalIsOpen} wait={300}>
+      <div className='MyModal'>
+        <div className='MyModalContent'>
+          {children}
+        </div>
+        <Overlay onClick={closePortal} />
       </div>
-      <Overlay onClick={closePortal} />
-    </div>
+    </Animate>
   )
 }
 
@@ -35,12 +38,22 @@ export default PortalWrapper(portalOptions)(MyModal)
 ```
 
 
-## Props
+## Options
 
 | Prop | Type | Description |
 | --- | --- | --- |
 | isOpen | boolean | Shows/hides the Portal'ed component. |
 | timeout | number | Delay before the Portal'ed component is unmounted from the DOM. Default is `0`. |
+
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| portalIsOpen | boolean | State of the Portal'ed component being visible. |
+| portalIsMounted | boolean | State of the Portal'ed component exiting in the DOM. |
+
+Note: PortalWrapper also passes props from [Portal](../Portal). The props above are **not** found in Portal.
 
 
 ### Render hooks

--- a/src/components/PortalWrapper/tests/PortalWrapper.test.js
+++ b/src/components/PortalWrapper/tests/PortalWrapper.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import PortalWrapper from '..'
 
+const PORTAL_TEST_TIMEOUT = 250
 const TestButton = props => {
   const handleClick = () => {
     console.log('wee')
@@ -45,5 +46,5 @@ test('Override default ID with options', (done) => {
     wrapper.unmount()
 
     done()
-  }, 50)
+  }, PORTAL_TEST_TIMEOUT)
 })

--- a/stories/Animate.js
+++ b/stories/Animate.js
@@ -1,6 +1,36 @@
-import React from 'react'
+import React, { PureComponent as Component } from 'react'
 import { storiesOf } from '@storybook/react'
 import { Animate } from '../src/index.js'
+
+class AnimateOutExample extends Component {
+  constructor () {
+    super()
+    this.state = {
+      show: true
+    }
+  }
+
+  toggleIn () {
+    this.setState({
+      show: !this.state.show
+    })
+  }
+
+  render () {
+    const { show } = this.state
+    const toggleIn = this.toggleIn.bind(this)
+
+    return (
+      <div>
+        <button onClick={toggleIn}>Toggle Animation</button>
+        <br />
+        <Animate in={show} sequence='fadeIn down' duration={100}>
+          <div className='dont-override-this'>Then, Fade In and Down</div>
+        </Animate>
+      </div>
+    )
+  }
+}
 
 storiesOf('Animate', module)
   .add('default', () => (
@@ -18,4 +48,7 @@ storiesOf('Animate', module)
         <div className='dont-override-this'>Then, Fade In and Down</div>
       </Animate>
     </div>
+  ))
+  .add('animateOut', () => (
+    <AnimateOutExample />
   ))

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -110,6 +110,7 @@ storiesOf('Modal', module)
         <p>onBeforeOpen: 500 delay</p>
         <p>onBeforeClose: 500 delay</p>
         <Modal
+          className='weee'
           onBeforeOpen={onBeforeOpen}
           onOpen={action('Event: onOpen')}
           onBeforeClose={onBeforeClose}


### PR DESCRIPTION
## Improve Portal mount cycle

This update improves the lifecycle callbacks for Portal and PortalWrapper. Portal has been adjusted to allow for re-rendering of child components based on prop changes, which is handy (and necessary) for things like child unmounting animations or `style` prop changes (will come in handy for `Popover`/`Tooltip`).

A new prop from Portal has been exposed in PortalWrapper called `isMounted`. It is similar to `isOpen`, but it's state is changed slightly before `isOpen`, allowing for child components to execute callbacks that need to happen before the Portal child is removed from the DOM (like Animations).

##### Example

```jsx
import Animate from '../Animate'
import Overlay from '../Overlay'
import PortalWrapper from '../PortalWrapper'

const portalOptions = {
  id: 'MyModal',
  timeout: 400
}

const MyModal = props => {
  const {
    children,
    closePortal,
    portalIsOpen
  } = props

  return (
    <Animate sequence='fadeIn down' in={portalIsOpen} wait={300}>
      <div className='MyModal'>
        <div className='MyModalContent'>
          {children}
        </div>
        <Overlay onClick={closePortal} />
      </div>
    </Animate>
  )
}

export default PortalWrapper(portalOptions)(MyModal)
```

Previous component APIs are not affected, therefore nothing is required for the user/consumer of Blue components.

Tests + README documentation has been updated.