### PR TITLE
Choice: Fix ID generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/blue",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/Checkbox/index.js
+++ b/src/components/Checkbox/index.js
@@ -14,7 +14,7 @@ const Checkbox = props => {
   )
 
   return (
-    <Choice className={componentClassName} id='Checkbox' type='checkbox' {...rest} />
+    <Choice className={componentClassName} componentID='Checkbox' type='checkbox' {...rest} />
   )
 }
 

--- a/src/components/Choice/Input.js
+++ b/src/components/Choice/Input.js
@@ -6,6 +6,7 @@ import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 
 const propTypes = {
+  align: PropTypes.string,
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
   id: PropTypes.string,
@@ -28,6 +29,7 @@ const defaultProps = {
 
 const Input = props => {
   const {
+    align,
     checked,
     disabled,
     helpText,
@@ -44,6 +46,7 @@ const Input = props => {
 
   const className = classNames(
     'c-ChoiceInput',
+    align && `is-${align}`,
     disabled && `is-disabled`,
     readOnly && `is-readonly`,
     state && `is-${state}`,

--- a/src/components/Choice/README.md
+++ b/src/components/Choice/README.md
@@ -33,6 +33,7 @@ Choose an anchor:
 | --- | --- | --- |
 | autoFocus | boolean | Automatically focuses the input. |
 | className | string | Custom class names to be added to the component. |
+| componentID | string | Namespace for the input ID. Default is `Choice`. |
 | disabled | boolean | Disable the input. |
 | helpText | string | Displays text underneath input. |
 | id | string | ID for the input. |

--- a/src/components/Choice/index.js
+++ b/src/components/Choice/index.js
@@ -10,8 +10,10 @@ import { createUniqueIDFactory } from '../../utilities/id'
 import { noop } from '../../utilities/other'
 
 export const propTypes = {
+  align: PropTypes.string,
   checked: PropTypes.bool,
   className: PropTypes.string,
+  componentID: PropTypes.string,
   disabled: PropTypes.bool,
   helpText: PropTypes.string,
   hideLabel: PropTypes.bool,
@@ -44,9 +46,18 @@ const uniqueID = createUniqueIDFactory('Choice')
 class Choice extends Component {
   constructor (props) {
     super()
+
     this.state = {
-      checked: props.checked
+      checked: props.checked,
+      id: props.id || uniqueID(props.componentID || 'Choice')
     }
+  }
+
+  componentWillReceiveProps (newProps) {
+    this.setState({
+      checked: newProps.checked,
+      id: newProps.id || this.state.id
+    })
   }
 
   handleOnChange (value, checked) {
@@ -56,10 +67,14 @@ class Choice extends Component {
 
   render () {
     const {
+      align,
+      children,
       className,
+      componentID,
       disabled,
       helpText,
       hideLabel,
+      id,
       label,
       onBlur,
       onFocus,
@@ -70,9 +85,7 @@ class Choice extends Component {
       value,
       ...rest
     } = this.props
-    const { checked } = this.state
-
-    const choiceID = uniqueID()
+    const { checked, id: choiceID } = this.state
 
     const componentClassName = classNames(
       'c-Choice',
@@ -86,16 +99,16 @@ class Choice extends Component {
 
     const handleOnChange = this.handleOnChange.bind(this)
 
-    const labelTextMarkup = hideLabel ? (
+    let labelTextMarkup = hideLabel ? (
       <VisuallyHidden>{label}</VisuallyHidden>
     ) : (
       <Text muted={disabled}>{label}</Text>
     )
 
-    const labelMarkup = label ? (
+    const labelMarkup = children || label ? (
       <Flexy.Block>
         <span className='c-Choice__label-text'>
-          {labelTextMarkup}
+          {children || labelTextMarkup}
         </span>
       </Flexy.Block>
     ) : null
@@ -111,10 +124,11 @@ class Choice extends Component {
     return (
       <div className={componentClassName} {...rest}>
         <label htmlFor={choiceID} className='c-Choice__label'>
-          <Flexy align='left' gap='sm'>
+          <Flexy just='left' gap='sm' align={align}>
             <Flexy.Item>
               <span className='c-Choice__control'>
                 <Input
+                  align={align}
                   checked={checked}
                   disabled={disabled}
                   helpText={helpText}

--- a/src/components/Choice/tests/Choice.test.js
+++ b/src/components/Choice/tests/Choice.test.js
@@ -15,6 +15,21 @@ describe('ClassName', () => {
   })
 })
 
+describe('ID', () => {
+  test('Has default componentID', () => {
+    const wrapper = shallow(<Choice />)
+
+    expect(wrapper.state().id).toContain('Choice')
+  })
+
+  test('Can override default componentID', () => {
+    const wrapper = shallow(<Choice componentID='milk' />)
+
+    expect(wrapper.state().id).toContain('milk')
+    expect(wrapper.state().id).not.toContain('Choice')
+  })
+})
+
 describe('Autofocus', () => {
   test('Does not autoFocus by default', () => {
     const wrapper = mount(<Choice />)
@@ -29,6 +44,39 @@ describe('Autofocus', () => {
     const input = wrapper.find('input')
 
     expect(input.prop('autoFocus')).toBeTruthy()
+    wrapper.unmount()
+  })
+})
+
+describe('Children', () => {
+  test('Can render child component', () => {
+    const wrapper = mount(
+      <Choice checked>
+        <div className='milk'>Was a bad choice</div>
+      </Choice>
+    )
+    const input = wrapper.find('input')
+    const o = wrapper.find('.milk')
+
+    expect(input.prop('autoFocus')).toBeTruthy()
+    expect(o.length).toBeTruthy()
+    expect(o.text()).toContain('bad choice')
+    wrapper.unmount()
+  })
+
+  test('Can render child component, instead of label', () => {
+    const wrapper = mount(
+      <Choice checked label='news-team-assemble'>
+        <div className='milk'>Was a bad choice</div>
+      </Choice>
+    )
+    const input = wrapper.find('input')
+    const o = wrapper.find('.milk')
+
+    expect(input.prop('autoFocus')).toBeTruthy()
+    expect(o.length).toBeTruthy()
+    expect(o.text()).toContain('bad choice')
+    expect(wrapper.html()).not.toContain('news-team')
     wrapper.unmount()
   })
 })

--- a/src/components/Choice/tests/ChoiceInput.test.js
+++ b/src/components/Choice/tests/ChoiceInput.test.js
@@ -145,3 +145,13 @@ describe('Type', () => {
     wrapper.unmount()
   })
 })
+
+describe('Styles', () => {
+  test('Can apply align styles', () => {
+    const wrapper = mount(<Input align='top' />)
+    const o = wrapper.find('.c-Flexy')
+
+    expect(o.hasClass('is-top')).toBeTruthy()
+    wrapper.unmount()
+  })
+})

--- a/src/components/ChoiceGroup/index.js
+++ b/src/components/ChoiceGroup/index.js
@@ -41,6 +41,7 @@ class ChoiceGroup extends Component {
   constructor (props) {
     super()
     this.state = {
+      id: uniqueID(),
       selectedValue: props.value ? [].concat(props.value) : []
     }
     this.multiSelect = true
@@ -73,8 +74,9 @@ class ChoiceGroup extends Component {
   }
 
   handleOnChange (value, checked) {
+    if (typeof value === 'object' && value.target) return
+
     const { multiSelect } = this.state
-    // console.log('change', value)
     const selectedValue = multiSelect ? this.getMultiSelectValue(value) : [value]
 
     this.setState({ selectedValue })
@@ -91,7 +93,7 @@ class ChoiceGroup extends Component {
       name,
       ...rest
     } = this.props
-    const { multiSelect, selectedValue } = this.state
+    const { id, multiSelect, selectedValue } = this.state
 
     const componentClassName = classNames(
       'c-ChoiceGroup',
@@ -99,7 +101,6 @@ class ChoiceGroup extends Component {
       className
     )
     const handleOnChange = this.handleOnChange.bind(this)
-    const id = uniqueID()
 
     const choiceMarkup = children ? React.Children.map(children, (child, index) => {
       return (

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -53,6 +53,7 @@ class Input extends Component {
   constructor (props) {
     super()
     this.state = {
+      id: props.id || uniqueID(),
       height: null,
       value: props.value
     }
@@ -93,7 +94,7 @@ class Input extends Component {
       ...rest
     } = this.props
 
-    const { height, value } = this.state
+    const { height, id: inputID, value } = this.state
 
     const handleOnChange = this.handleOnChange.bind(this)
     const handleExpandingResize = this.handleExpandingResize.bind(this)
@@ -110,7 +111,6 @@ class Input extends Component {
       className
     )
 
-    const inputID = id || uniqueID()
     const fieldClassName = classNames('c-InputField', size && `is-${size}`)
 
     // Ignoring as height calculation isn't possible with JSDOM

--- a/src/components/PortalWrapper/index.js
+++ b/src/components/PortalWrapper/index.js
@@ -26,6 +26,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
     constructor (props) {
       super()
       this.state = Object.assign({}, props, options, {
+        id: uniqueID(),
         isMounted: props.isOpen
       })
     }
@@ -93,12 +94,11 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
         ...rest
       } = this.props
       // Remapping open/mount state for ComposedComponent
-      const { isOpen: portalIsMounted, isMounted: portalIsOpen } = this.state
+      const { id, isOpen: portalIsMounted, isMounted: portalIsOpen } = this.state
 
       const openPortal = this.openPortal.bind(this)
       const handleOnClose = this.handleOnClose.bind(this)
 
-      const id = uniqueID()
       const uniqueIndex = parseInt(id.replace(options.id, ''), 10)
       const zIndex = options.zIndex ? options.zIndex + uniqueIndex : null
 

--- a/src/components/Radio/index.js
+++ b/src/components/Radio/index.js
@@ -14,7 +14,7 @@ const Radio = props => {
   )
 
   return (
-    <Choice className={componentClassName} id='Radio' type='radio' {...rest} />
+    <Choice className={componentClassName} componentID='Radio' type='radio' {...rest} />
   )
 }
 

--- a/src/styles/components/Choice/ChoiceInput.scss
+++ b/src/styles/components/Choice/ChoiceInput.scss
@@ -1,3 +1,4 @@
+@import "pack/seed-family/_index";
 @import "pack/seed-this/_index";
 @import "../../mixins/visually-hidden";
 @import "../../configs/constants";
@@ -38,6 +39,10 @@
     .c-InputBackdrop {
       border-radius: 50%;
     }
+  }
+
+  &.is-top {
+    top: 2px;
   }
 
   @each $state in $states {

--- a/src/styles/components/Input/Input.scss
+++ b/src/styles/components/Input/Input.scss
@@ -47,4 +47,9 @@
       resize: vertical;
     }
   }
+
+  &.is-seamless {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }

--- a/src/styles/mixins/backdrop-styles.scss
+++ b/src/styles/mixins/backdrop-styles.scss
@@ -24,6 +24,7 @@
 
   // Styles
   @include parent(".is-seamless > ") {
+    background: transparent;
     border-color: transparent;
     box-shadow: none;
     @include parent("#{$InputField}:focus ~ ") {

--- a/src/utilities/id.js
+++ b/src/utilities/id.js
@@ -2,5 +2,9 @@
 // https://github.com/Shopify/javascript-utilities/blob/master/src/other.ts
 export function createUniqueIDFactory (prefix = '') {
   let index = 1
-  return () => `${prefix}${index++}`
+  return (prefixOverride) => {
+    const namespace = prefixOverride || prefix
+
+    return `${namespace}${index++}`
+  }
 }

--- a/stories/Checkbox.js
+++ b/stories/Checkbox.js
@@ -1,10 +1,16 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Checkbox, ChoiceGroup } from '../src/index.js'
+import { Checkbox, ChoiceGroup, Heading, Text } from '../src/index.js'
 
 storiesOf('Checkbox', module)
   .add('default', () => (
     <Checkbox label='Label' helpText='Help description' />
+  ))
+  .add('custom content', () => (
+    <Checkbox label='Label' align='top'>
+      <Heading size='h3' style={{lineHeight: 1, paddingBottom: 4}}>Heading</Heading>
+      <Text>Text</Text>
+    </Checkbox>
   ))
   .add('group', () => (
     <ChoiceGroup>


### PR DESCRIPTION
## Choice: Fix ID generation 🐛 

This update fixes the `uniqueID()` generation for the `Choice` component, which indirectly fixes it for `Checkbox` and `Radio`. The same fix was also applied to `Input` and `PortalWrapper`.

This issue was the element's ID was being regenerated everytime there was a prop change, which is incorrect. It should only be generated once. The solution was to generate and store the uniqueID in the component state, instead of creating it in the render hook.

## Better uniqueID creation 🚀 

The uniqueID creation factory function has also been enhanced to accept a prefix override namespace.