### PR TITLE
Fix path on import for color config

### DIFF
--- a/src/styles/components/Icon.scss
+++ b/src/styles/components/Icon.scss
@@ -1,7 +1,7 @@
 @import "pack/seed-dash/_index";
 
 .c-Icon {
-  @import "configs/color";
+  @import "../configs/color";
   $sizes: (12, 14, 16, 18, 20, 24);
   $default-size: 20;
 


### PR DESCRIPTION
The path to the color configuration in the CSS for the icon component was incorrect. This PR is to switch it to the correct path. 