### PR TITLE
ProgressBar: Add accessibility aria tags

### DIFF
--- a/src/components/ProgressBar/README.md
+++ b/src/components/ProgressBar/README.md
@@ -14,6 +14,7 @@ A ProgressBar component visualizes the progression of a task. This component is 
 
 | Prop | Type | Description |
 | --- | --- | --- |
+| description | string | Description of the progress bar (for accessibility). |
 | onChange | function | Callback when component value updates. Returns value as percent. |
 | size | string | Determines the size of the input. |
 | value | number/string | Progress value to visualize in component. |

--- a/src/components/ProgressBar/index.js
+++ b/src/components/ProgressBar/index.js
@@ -4,6 +4,7 @@ import { classNames } from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 
 export const propTypes = {
+  description: PropTypes.string,
   onChange: PropTypes.func,
   size: PropTypes.string,
   value: PropTypes.oneOfType([
@@ -42,6 +43,7 @@ class ProgressBar extends Component {
   render () {
     const {
       className,
+      description,
       size,
       value,
       ...rest
@@ -57,7 +59,15 @@ class ProgressBar extends Component {
     }
 
     return (
-      <div className={componentClassName} {...rest}>
+      <div
+        className={componentClassName}
+        role='progressbar'
+        aria-valuenow={value}
+        aria-valuemin='0'
+        aria-valuemax='100'
+        aria-valuetext={description}
+        {...rest}
+      >
         <div className='c-ProgressBar__bar' style={progresBarStyle} />
       </div>
     )

--- a/src/components/ProgressBar/tests/ProgressBar.test.js
+++ b/src/components/ProgressBar/tests/ProgressBar.test.js
@@ -2,6 +2,24 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import ProgressBar from '..'
 
+describe('Accessibility', () => {
+  test('Has the correct aria tags', () => {
+    const wrapper = shallow(<ProgressBar value={20} description='Loading stuff!' />)
+    const props = wrapper.props()
+
+    expect(props['aria-valuenow']).toBe(20)
+    expect(props['aria-valuemin']).toBe('0')
+    expect(props['aria-valuemax']).toBe('100')
+    expect(props['aria-valuetext']).toBe('Loading stuff!')
+  })
+
+  test('Accepts additional classNames', () => {
+    const wrapper = shallow(<ProgressBar className='mugatu' />)
+
+    expect(wrapper.hasClass('mugatu')).toBeTruthy()
+  })
+})
+
 describe('ClassName', () => {
   test('Has the correct CSS class', () => {
     const wrapper = shallow(<ProgressBar />)

--- a/src/styles/components/ProgressBar.scss
+++ b/src/styles/components/ProgressBar.scss
@@ -6,13 +6,13 @@
   $height: 6px;
   $sizes: (
     lg: (
-      height: 16px,
-    ),
-    md: (
       height: 10px,
     ),
-    sm: (
+    md: (
       height: $height,
+    ),
+    sm: (
+      height: 2px,
     ),
   );
   background-color: _color(grey, 300);


### PR DESCRIPTION
## ProgressBar: Add accessibility aria tags

This update adds the `role="progressbar"` tag, as well as `aria-valuenow`, `aria-valuemin`, `aria-valuemax` and `aria-valuetext`.

The following code:

```
<ProgressBar value={20} />
```

Will render:

```html
<div data-reactroot="" class="c-ProgressBar" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">
  <div class="c-ProgressBar__bar" style="width: 50%;"></div>
</div>
```

Follow up for https://github.com/helpscout/blue/pull/30