### PR TITLE
CSS: Create hs-app dedicated stylesheet without duplicate styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/blue",
-  "version": "0.0.13",
+  "version": "0.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14144,23 +14144,6 @@
         "seed-config": "0.1.1"
       }
     },
-    "seed-color-scheme-helpscout": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/seed-color-scheme-helpscout/-/seed-color-scheme-helpscout-0.0.3.tgz",
-      "integrity": "sha1-gmfvaizHVad1gaimWvJ/tKZzrEA=",
-      "dev": true,
-      "requires": {
-        "seed-color-scheme": "0.0.2"
-      },
-      "dependencies": {
-        "seed-color-scheme": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/seed-color-scheme/-/seed-color-scheme-0.0.2.tgz",
-          "integrity": "sha1-QN4soNtEyzvIRGGzJmQ5ruv/w+c=",
-          "dev": true
-        }
-      }
-    },
     "seed-config": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/seed-config/-/seed-config-0.1.1.tgz",
@@ -14266,38 +14249,6 @@
         "seed-packfinder": "0.0.3"
       }
     },
-    "seed-input": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/seed-input/-/seed-input-0.0.7.tgz",
-      "integrity": "sha1-WeZTnrLTfXOOQ2eQ28PQAJAp/dE=",
-      "dev": true,
-      "requires": {
-        "sass-pathfinder": "0.0.5",
-        "seed-border": "0.0.10",
-        "seed-control": "0.0.4",
-        "seed-dash": "0.0.1",
-        "seed-publish": "0.1.1",
-        "seed-states": "0.0.4"
-      },
-      "dependencies": {
-        "seed-control": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/seed-control/-/seed-control-0.0.4.tgz",
-          "integrity": "sha1-BP++Dqe0G7u+7/Tr5VJpv2jSZpY=",
-          "dev": true,
-          "requires": {
-            "sass-pathfinder": "0.0.5",
-            "seed-dash": "0.0.1"
-          }
-        },
-        "seed-dash": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/seed-dash/-/seed-dash-0.0.1.tgz",
-          "integrity": "sha1-/yHArmMzDsY6ik4+Db9Ka3ooh6I=",
-          "dev": true
-        }
-      }
-    },
     "seed-link": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/seed-link/-/seed-link-0.0.3.tgz",
@@ -14329,47 +14280,6 @@
       "resolved": "https://registry.npmjs.org/seed-props/-/seed-props-0.3.1.tgz",
       "integrity": "sha1-QZSb/Sn4DR3T0nYTFyE/EVp8/sE=",
       "dev": true
-    },
-    "seed-publish": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/seed-publish/-/seed-publish-0.1.1.tgz",
-      "integrity": "sha1-j4w47Tb/RN8BSpdzQdSFP1n1GCA=",
-      "dev": true
-    },
-    "seed-states": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/seed-states/-/seed-states-0.0.4.tgz",
-      "integrity": "sha1-g1lVFUKLX2kLBXYkBBqR3JMKx6E=",
-      "dev": true,
-      "requires": {
-        "sass-pathfinder": "0.0.3",
-        "seed-color-scheme": "0.0.2",
-        "seed-color-scheme-helpscout": "0.0.3",
-        "seed-dash": "0.0.1"
-      },
-      "dependencies": {
-        "sass-pathfinder": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/sass-pathfinder/-/sass-pathfinder-0.0.3.tgz",
-          "integrity": "sha1-fJPBtDprqCP0IEN1kNngTITOft0=",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "seed-color-scheme": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/seed-color-scheme/-/seed-color-scheme-0.0.2.tgz",
-          "integrity": "sha1-QN4soNtEyzvIRGGzJmQ5ruv/w+c=",
-          "dev": true
-        },
-        "seed-dash": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/seed-dash/-/seed-dash-0.0.1.tgz",
-          "integrity": "sha1-/yHArmMzDsY6ik4+Db9Ka3ooh6I=",
-          "dev": true
-        }
-      }
     },
     "seed-this": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "seed-flexy": "0.3.4",
     "seed-grid": "0.4.0",
     "seed-harvester": "0.1.5",
-    "seed-input": "0.0.7",
     "seed-link": "0.0.3",
     "seed-this": "0.0.5",
     "standard": "10.0.2",

--- a/scripts/sass.js
+++ b/scripts/sass.js
@@ -13,7 +13,8 @@ mkdirp('./dist/scss')
 
 const files = [
   'blue',
-  'blue.hs-app'
+  'blue.hs-app',
+  'blue.hs-app.slim'
 ]
 
 const renderFile = (fileName) => {

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -48,11 +48,11 @@ const Button = props => {
   } = props
 
   const componentClassName = classNames(
-    'c-Button',
-    size && `c-Button--${size}`,
+    'c-button',
+    size && `c-button--${size}`,
     state && `is-${state}`,
-    plain && 'c-Button--link',
-    primary && 'c-Button--primary',
+    plain && 'c-button--link',
+    primary && 'c-button--primary',
     props.className
   )
 

--- a/src/components/Button/tests/Button.test.js
+++ b/src/components/Button/tests/Button.test.js
@@ -7,7 +7,7 @@ describe('ClassNames', () => {
     const wrapper = shallow(<Button className='foo bar baz'>Click Me</Button>)
     const classNames = wrapper.prop('className')
 
-    expect(classNames).toContain('c-Button')
+    expect(classNames).toContain('c-button')
     expect(classNames).toContain('foo')
     expect(classNames).toContain('bar')
     expect(classNames).toContain('baz')
@@ -19,8 +19,8 @@ describe('Types', () => {
     const primary = shallow(<Button primary>Primary</Button>)
     const plain = shallow(<Button plain>Plain</Button>)
 
-    expect(primary.prop('className')).toContain('c-Button--primary')
-    expect(plain.prop('className')).toContain('c-Button--link')
+    expect(primary.prop('className')).toContain('c-button--primary')
+    expect(plain.prop('className')).toContain('c-button--link')
   })
 
   test('Creates a button with type="submit"', () => {
@@ -36,9 +36,9 @@ describe('Sizes', () => {
     const md = shallow(<Button size='md'>Medium</Button>)
     const sm = shallow(<Button size='sm'>Small</Button>)
 
-    expect(lg.prop('className')).toContain('c-Button--lg')
-    expect(md.prop('className')).toContain('c-Button--md')
-    expect(sm.prop('className')).toContain('c-Button--sm')
+    expect(lg.prop('className')).toContain('c-button--lg')
+    expect(md.prop('className')).toContain('c-button--md')
+    expect(sm.prop('className')).toContain('c-button--sm')
   })
 })
 

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -36,7 +36,7 @@ const Card = props => {
   } = props
 
   const componentClassName = classNames(
-    'c-Card',
+    'c-card',
     (onClick || href) && 'is-clickable',
     (onClick || hover || href) && 'is-hoverable',
     seamless && 'is-seamless',

--- a/src/components/Card/tests/Card.test.js
+++ b/src/components/Card/tests/Card.test.js
@@ -6,7 +6,7 @@ describe('ClassName', () => {
   test('Has default className', () => {
     const wrapper = shallow(<Card />)
 
-    expect(wrapper.prop('className')).toBe('c-Card')
+    expect(wrapper.prop('className')).toBe('c-card')
   })
 
   test('Accepts custom className', () => {

--- a/src/components/CardBlock/index.js
+++ b/src/components/CardBlock/index.js
@@ -11,8 +11,8 @@ const CardBlock = props => {
   const { size, ...rest } = props
 
   const className = classNames(
-    'c-CardBlock',
-    size && `c-CardBlock--${size}`,
+    'c-card__block',
+    size && `c-card__block--${size}`,
     props.className
   )
 

--- a/src/components/CardBlock/tests/CardBlock.test.js
+++ b/src/components/CardBlock/tests/CardBlock.test.js
@@ -6,7 +6,7 @@ describe('ClassName', () => {
   test('Has default className', () => {
     const wrapper = shallow(<CardBlock />)
 
-    expect(wrapper.prop('className')).toBe('c-CardBlock')
+    expect(wrapper.prop('className')).toBe('c-card__block')
   })
 
   test('Accepts custom className', () => {
@@ -57,14 +57,14 @@ describe('Styles', () => {
     const wrapper = shallow(<CardBlock />)
     const classNames = wrapper.prop('className')
 
-    expect(classNames).not.toContain('c-CardBlock--sm')
-    expect(classNames).not.toContain('c-CardBlock--md')
-    expect(classNames).not.toContain('c-CardBlock--lg')
+    expect(classNames).not.toContain('c-card__block--sm')
+    expect(classNames).not.toContain('c-card__block--md')
+    expect(classNames).not.toContain('c-card__block--lg')
   })
 
   test('Renders size styles, if specified', () => {
     const wrapper = shallow(<CardBlock size='sm' />)
 
-    expect(wrapper.prop('className')).toContain('c-CardBlock--sm')
+    expect(wrapper.prop('className')).toContain('c-card__block--sm')
   })
 })

--- a/src/components/Choice/tests/ChoiceInput.test.js
+++ b/src/components/Choice/tests/ChoiceInput.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { mount, shallow } from 'enzyme'
 import Input from '..'
+import Flexy from '../../Flexy'
 
 describe('ClassName', () => {
   test('Has default className', () => {
@@ -149,7 +150,7 @@ describe('Type', () => {
 describe('Styles', () => {
   test('Can apply align styles', () => {
     const wrapper = mount(<Input align='top' />)
-    const o = wrapper.find('.c-Flexy')
+    const o = wrapper.find(Flexy)
 
     expect(o.hasClass('is-top')).toBeTruthy()
     wrapper.unmount()

--- a/src/components/Flexy/Block.js
+++ b/src/components/Flexy/Block.js
@@ -9,7 +9,7 @@ const Block = props => {
   } = props
 
   const componentClassName = classNames(
-    'c-Flexy__block',
+    'o-flexy__block',
     className
   )
 

--- a/src/components/Flexy/Flexy.js
+++ b/src/components/Flexy/Flexy.js
@@ -22,10 +22,10 @@ const Flexy = props => {
   } = props
 
   const componentClassName = classNames(
-    'c-Flexy',
+    'o-flexy',
     align && `is-${align}`,
-    gap && `c-Flexy--gap-${gap}`,
-    just && `c-Flexy--just-${just}`,
+    gap && `o-flexy--gap-${gap}`,
+    just && `o-flexy--just-${just}`,
     className
   )
 

--- a/src/components/Flexy/Item.js
+++ b/src/components/Flexy/Item.js
@@ -9,7 +9,7 @@ const Item = props => {
   } = props
 
   const componentClassName = classNames(
-    'c-Flexy__item',
+    'o-flexy__item',
     className
   )
 

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -26,7 +26,7 @@ const Link = props => {
   const {
     className, external, to, href, ...rest } = props
 
-  const componentClassName = classNames('c-Link', className)
+  const componentClassName = classNames('c-link', className)
 
   const target = external ? '_blank' : undefined
   const rel = external ? 'noopener noreferrer' : undefined

--- a/src/components/Link/tests/Link.test.js
+++ b/src/components/Link/tests/Link.test.js
@@ -6,7 +6,7 @@ describe('ClassName', () => {
   test('Has default component className', () => {
     const wrapper = shallow(<Link />)
 
-    expect(wrapper.prop('className')).toContain('c-Link')
+    expect(wrapper.prop('className')).toContain('c-link')
   })
 
   test('Applies custom className if specified', () => {

--- a/src/styles/blue.hs-app.slim.scss
+++ b/src/styles/blue.hs-app.slim.scss
@@ -1,0 +1,5 @@
+/* Help Scout: Blue */
+/* Theme: HS-APP */
+
+@import "./components/_slim";
+@import "./themes/hs-app/_index";

--- a/src/styles/components/Button.scss
+++ b/src/styles/components/Button.scss
@@ -1,6 +1,5 @@
-$seed-button-namespace: "c-Button" !default;
 @import "pack/seed-button/_index";
 
-button.c-Button {
+button.c-button {
   @import "../resets/base";
 }

--- a/src/styles/components/Card.scss
+++ b/src/styles/components/Card.scss
@@ -8,7 +8,7 @@ $seed-card-border: 1px solid rgba(_color(border, ui, dark), 0.7);
   @import "../resets/base";
   box-shadow: #{
     0 0 0 0 rgba(black, 0)
-  };
+    };
   color: currentColor;
   display: block;
   padding: 16px;

--- a/src/styles/components/Card.scss
+++ b/src/styles/components/Card.scss
@@ -1,15 +1,14 @@
 @import "../configs/_color";
-$seed-card-namespace: "c-Card";
-$seed-card-block-namespace: "c-CardBlock";
+$seed-card-namespace: "c-card";
 $seed-card-border: 1px solid rgba(_color(border, ui, dark), 0.7);
 // Import Seed Pack
 @import "pack/seed-card/_index";
 
-.c-Card {
+.c-card {
   @import "../resets/base";
   box-shadow: #{
     0 0 0 0 rgba(black, 0)
-    };
+  };
   color: currentColor;
   display: block;
   padding: 16px;

--- a/src/styles/components/Flexy.scss
+++ b/src/styles/components/Flexy.scss
@@ -1,8 +1,6 @@
-$seed-flexy-namespace: c-Flexy;
-
 @import "pack/seed-flexy/_index";
 
-.c-Flexy {
+.o-flexy {
   $alignments: (
     top: flex-start,
     middle: center,

--- a/src/styles/components/Link.scss
+++ b/src/styles/components/Link.scss
@@ -1,9 +1,8 @@
 // Config
-$seed-link-namespace: "c-Link";
 $seed-link-include-a-selector: false;
 
 @import "pack/seed-link/_index";
 
-.c-Link {
+.c-link {
   @import "../resets/base";
 }

--- a/src/styles/components/__slim.scss
+++ b/src/styles/components/__slim.scss
@@ -1,0 +1,29 @@
+// Special import for hs-app
+
+@import "./Animate/_index";
+@import "./Avatar";
+@import "./AvatarStack";
+@import "./Badge";
+// @import "./Button";
+@import "./Card";
+@import "./Checkbox";
+@import "./Choice/_index";
+@import "./CloseButton";
+// @import "./Flexy";
+// @import "./Grid";
+@import "./FormGroup/_index";
+@import "./Heading";
+@import "./HelpText";
+@import "./Icon";
+@import "./Image";
+@import "./Input/_index";
+@import "./Label";
+// @import "./Link";
+@import "./LoadingDots";
+@import "./Modal";
+@import "./Overlay";
+@import "./ProgressBar";
+@import "./Select/_index";
+@import "./Scrollable";
+@import "./Text";
+@import "./VisuallyHidden";


### PR DESCRIPTION
## CSS: Create hs-app dedicated stylesheet without duplicate styles

This update adds a new `blue.hs-app.slim.scss` file that only includes not within `hs-app`. This will reduce the overall build size of `hs-app`'s CSS.

The approach I took was to comment out all of the component imports in the dedicated slim file. It's not ideal, as you'd have to update 2 .scss files everytime a new component style is added. However, it's the simplest solution for now.

To integration into hs-app, simply import the slim file:

```
@import "blue.hs-app.slim";
```

No need to import the base Blue styles + hs-app theme (which was the previous approach)

In addition to this, the components that leverage seed styles have had their classNames restored to the default classNames found in Seed.

Example:
`c-Link` -> `c-link`

CC'ing @knicklabs ❤️ 

Resolves: https://github.com/helpscout/blue/issues/29