### PR TITLE
Add RouteWrapper higher order component to add `fetch` and `to` attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/blue",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "private": false,
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -2,10 +2,23 @@
 
 Actionable HTML buttons with basic styling
 
-## Example
+## RouteWrapper
+
+This component is extended by the `RouteWrapper` higher order component, and can be used similarly to a [`react-router` `<Link>`](https://reacttraining.com/react-router/web/api/Link) component by using the `to` prop. It also has an optional `fetch` property which can specify a promise-returning function which will be invoked before the `to` route is navigated
+
+
+## Examples
 
 ```html
 <Button primary onClick={() => console.log('Hello world')>Click me!</Button>
+```
+
+```html
+<Button primary to="path/to/route">Click me!</Button>
+```
+
+```html
+<Button primary fetch={fetchData} to="path/to/route">Click me!</Button>
 ```
 
 ## Props
@@ -23,3 +36,5 @@ Actionable HTML buttons with basic styling
 | size | string | Sets the size of the button. Can be one of `"sm"`, `"md"` or `"lg"`. |
 | state | string | Applies state styles to the button. Can be one of `"success"`, `"error"` or `"warning"`. |
 | submit | boolean | Sets the `type` of the button to `"submit"`. |
+| to | string | React Router path to navigate on click. |
+| fetch | function| function which returns a promise, will be invoked before routing the `to` route |

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -35,6 +35,7 @@ const Button = props => {
   const {
     accessibilityLabel,
     children,
+    className,
     disabled,
     onBlur,
     onClick,
@@ -53,7 +54,7 @@ const Button = props => {
     state && `is-${state}`,
     plain && 'c-Button--link',
     primary && 'c-Button--primary',
-    props.className
+    className
   )
 
   const type = submit ? 'submit' : 'button'

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
+import RouteWrapper from '../RouteWrapper'
 
 export const propTypes = {
   accessibilityLabel: PropTypes.string,
@@ -34,7 +35,6 @@ const Button = props => {
   const {
     accessibilityLabel,
     children,
-    className,
     disabled,
     onBlur,
     onClick,
@@ -77,4 +77,4 @@ const Button = props => {
 Button.propTypes = propTypes
 Button.defaultProps = defaultProps
 
-export default Button
+export default RouteWrapper(Button)

--- a/src/components/Button/tests/Button.test.js
+++ b/src/components/Button/tests/Button.test.js
@@ -2,9 +2,13 @@ import React from 'react'
 import { mount, shallow } from 'enzyme'
 import Button from '..'
 
+// Since we now wrap Link in a HOC, we have to use `.first.shallow()` to test.
+// See https://github.com/airbnb/enzyme/issues/539#issuecomment-239497107
+const wrap = (...args) => shallow(...args).first().shallow()
+
 describe('ClassNames', () => {
   test('Accepts custom className', () => {
-    const wrapper = shallow(<Button className='foo bar baz'>Click Me</Button>)
+    const wrapper = wrap(<Button className='foo bar baz'>Click Me</Button>)
     const classNames = wrapper.prop('className')
 
     expect(classNames).toContain('c-Button')
@@ -16,15 +20,15 @@ describe('ClassNames', () => {
 
 describe('Types', () => {
   test('Adds the respective classNames', () => {
-    const primary = shallow(<Button primary>Primary</Button>)
-    const plain = shallow(<Button plain>Plain</Button>)
+    const primary = wrap(<Button primary>Primary</Button>)
+    const plain = wrap(<Button plain>Plain</Button>)
 
     expect(primary.prop('className')).toContain('c-Button--primary')
     expect(plain.prop('className')).toContain('c-Button--link')
   })
 
   test('Creates a button with type="submit"', () => {
-    const button = shallow(<Button submit>Submit</Button>)
+    const button = wrap(<Button submit>Submit</Button>)
 
     expect(button.prop('type')).toBe('submit')
   })
@@ -32,9 +36,9 @@ describe('Types', () => {
 
 describe('Sizes', () => {
   test('Adds the respective classNames', () => {
-    const lg = shallow(<Button size='lg'>Large</Button>)
-    const md = shallow(<Button size='md'>Medium</Button>)
-    const sm = shallow(<Button size='sm'>Small</Button>)
+    const lg = wrap(<Button size='lg'>Large</Button>)
+    const md = wrap(<Button size='md'>Medium</Button>)
+    const sm = wrap(<Button size='sm'>Small</Button>)
 
     expect(lg.prop('className')).toContain('c-Button--lg')
     expect(md.prop('className')).toContain('c-Button--md')
@@ -44,9 +48,9 @@ describe('Sizes', () => {
 
 describe('States', () => {
   test('Adds the respective classNames', () => {
-    const success = shallow(<Button state='success'>Success</Button>)
-    const error = shallow(<Button state='error'>Error</Button>)
-    const warning = shallow(<Button state='warning'>Warning</Button>)
+    const success = wrap(<Button state='success'>Success</Button>)
+    const error = wrap(<Button state='error'>Error</Button>)
+    const warning = wrap(<Button state='warning'>Warning</Button>)
 
     expect(success.prop('className')).toContain('is-success')
     expect(error.prop('className')).toContain('is-error')
@@ -60,5 +64,75 @@ describe('States', () => {
 
     expect(disabledButton.prop('disabled')).toBe(true)
     expect(callback).not.toBeCalled()
+  })
+})
+
+describe('RouteWrapper', () => {
+  let options
+  let push
+  let history
+  let preventDefault
+  let clickEvent
+
+  beforeEach(() => {
+    push = jest.fn()
+    history = { push }
+    options = {
+      context: {
+        router: { history }
+      }
+    }
+    preventDefault = jest.fn()
+    clickEvent = { preventDefault }
+  })
+
+  test('Specifying a `to` sets up router navigation, overrides default click', done => {
+    const route = '/some/route/'
+    const wrapper = wrap(<Button to={route}>Gator</Button>, options)
+    wrapper.simulate('click', clickEvent)
+    expect(preventDefault).toHaveBeenCalled()
+    setTimeout(() => {
+      expect(push).toHaveBeenCalledWith(route)
+      done()
+    })
+  })
+
+  test('`to` router navigation is skipped on ctrl+click', done => {
+    const route = '/some/route/'
+    const wrapper = wrap(<Button to={route}>Gator</Button>, options)
+    expect(wrapper.node.type).toBe('button')
+    clickEvent.ctrlKey = true
+    wrapper.simulate('click', clickEvent)
+    expect(preventDefault).not.toHaveBeenCalled()
+    setTimeout(() => {
+      expect(push).not.toHaveBeenCalled()
+      done()
+    })
+  })
+
+  test('`to` router navigation is skipped on cmd+click', done => {
+    const route = '/some/route/'
+    const wrapper = wrap(<Button to={route}>Gator</Button>, options)
+    expect(wrapper.node.type).toBe('button')
+    clickEvent.metaKey = true
+    wrapper.simulate('click', clickEvent)
+    expect(preventDefault).not.toHaveBeenCalled()
+    setTimeout(() => {
+      expect(push).not.toHaveBeenCalled()
+      done()
+    })
+  })
+
+  test('Can fetch data and trigger a route asynchronously', done => {
+    const fetch = () => Promise.resolve()
+    const to = 'some/route'
+    const wrapper = wrap(<Button fetch={fetch} to={to} >Gator</Button>, options)
+    expect(wrapper.node.type).toBe('button')
+    wrapper.simulate('click', clickEvent)
+    expect(preventDefault).toHaveBeenCalled()
+    setTimeout(() => {
+      expect(push).toHaveBeenCalledWith(to)
+      done()
+    })
   })
 })

--- a/src/components/Link/README.md
+++ b/src/components/Link/README.md
@@ -8,12 +8,12 @@ A Link component is a light-weight wrapper for the default HTML `<a>` selector. 
 You're my boy, <Link href="https://github.com/helpscout/blue">Blue</Link>!
 ```
 
-### React Router Link
+### Router Link
 
-This component can be transformed into a [`react-router` `<Link>`](https://reacttraining.com/react-router/web/api/Link) component by using the `to` prop.
+This component is extended by the `RouteWrapper` higher order component, and can be used similarly to a [`react-router` `<Link>`](https://reacttraining.com/react-router/web/api/Link) component by using the `to` prop. It also has an optional `fetch` property which can specify a promise-returning function which will be invoked before the `to` route is navigated
 
 ```html
-You're my boy, <Link to="/blue">Blue</Link>!
+You're my boy, <Link fetch={fetchBlueData} to="/blue">Blue</Link>!
 ```
 
 
@@ -27,4 +27,5 @@ You're my boy, <Link to="/blue">Blue</Link>!
 | onFocus | function | Callback function when the component is focused. |
 | external | bool | Opens link in a new tab. |
 | href | string | Address for the link. Default is `#`. |
-| to | string | [`react-router`](https://github.com/ReactTraining/react-router) Address for the link. |
+| to | string | React Router path to navigate on click. |
+| fetch | function| function which returns a promise, will be invoked before routing the `to` route |

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link as RouteLink } from 'react-router-dom'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
+import RouteWrapper from '../RouteWrapper'
 
 export const propTypes = {
   className: PropTypes.string,
@@ -24,30 +24,21 @@ const defaultProps = {
 
 const Link = props => {
   const {
-    className, external, to, href, ...rest } = props
+    className, external, href, ...rest } = props
 
   const componentClassName = classNames('c-Link', className)
 
   const target = external ? '_blank' : undefined
   const rel = external ? 'noopener noreferrer' : undefined
 
-  // Note: If we're going to support React Router, then the `to` prop
-  // should render React Router's <Link> component.
-
-  const linkMarkup = to ? (
-    <RouteLink className={componentClassName} target={target} rel={rel} to={to} {...rest}>
-      {props.children}
-    </RouteLink>
-  ) : (
+  return (
     <a className={componentClassName} target={target} rel={rel} href={href} {...rest}>
       {props.children}
     </a>
   )
-
-  return linkMarkup
 }
 
 Link.propTypes = propTypes
 Link.defaultProps = defaultProps
 
-export default Link
+export default RouteWrapper(Link)

--- a/src/components/Link/tests/Link.test.js
+++ b/src/components/Link/tests/Link.test.js
@@ -2,16 +2,20 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import Link from '..'
 
+// Since we now wrap Link in a HOC, we have to use `.first.shallow()` to test.
+// See https://github.com/airbnb/enzyme/issues/539#issuecomment-239497107
+const wrap = (...args) => shallow(...args).first().shallow()
+
 describe('ClassName', () => {
   test('Has default component className', () => {
-    const wrapper = shallow(<Link />)
+    const wrapper = wrap(<Link />)
 
     expect(wrapper.prop('className')).toContain('c-Link')
   })
 
   test('Applies custom className if specified', () => {
     const className = 'gator'
-    const wrapper = shallow(<Link className={className} />)
+    const wrapper = wrap(<Link className={className} />)
 
     expect(wrapper.prop('className')).toContain(className)
   })
@@ -21,7 +25,7 @@ describe('Click', () => {
   test('Can trigger onClick callback', () => {
     let value = false
     const onClick = () => { value = true }
-    const wrapper = shallow(<Link onClick={onClick} />)
+    const wrapper = wrap(<Link onClick={onClick} />)
 
     wrapper.simulate('click')
 
@@ -31,7 +35,7 @@ describe('Click', () => {
 
 describe('Content', () => {
   test('Renders child content', () => {
-    const wrapper = shallow(<Link>Gator</Link>)
+    const wrapper = wrap(<Link>Gator</Link>)
 
     expect(wrapper.text()).toBe('Gator')
   })
@@ -39,14 +43,14 @@ describe('Content', () => {
 
 describe('Href', () => {
   test('Has an href of # by default', () => {
-    const wrapper = shallow(<Link>Gator</Link>)
+    const wrapper = wrap(<Link>Gator</Link>)
 
     expect(wrapper.prop('href')).toBe('#')
   })
 
   test('Can set link href, if specified', () => {
     const url = 'https://www.helpscout.net'
-    const wrapper = shallow(<Link href={url}>Gator</Link>)
+    const wrapper = wrap(<Link href={url}>Gator</Link>)
 
     expect(wrapper.prop('href')).toBe(url)
   })
@@ -54,24 +58,76 @@ describe('Href', () => {
 
 describe('External', () => {
   test('Adds external <a> attributes if external is specified', () => {
-    const wrapper = shallow(<Link external>Link</Link>)
+    const wrapper = wrap(<Link external>Link</Link>)
 
     expect(wrapper.prop('target')).toBe('_blank')
     expect(wrapper.prop('rel')).toContain('noopener noreferrer')
   })
 })
 
-describe('Route', () => {
-  test('Is a standard <a> tag by default', () => {
-    const wrapper = shallow(<Link href='/gator'>Gator</Link>)
+describe('RouteWrapper', () => {
+  let options
+  let push
+  let history
+  let preventDefault
+  let clickEvent
 
-    expect(wrapper.node.type).toBe('a')
+  beforeEach(() => {
+    push = jest.fn()
+    history = { push }
+    options = {
+      context: {
+        router: { history }
+      }
+    }
+    preventDefault = jest.fn()
+    clickEvent = { preventDefault }
   })
 
-  test('Becomes a react-router-dom Link if to is defined', () => {
-    const wrapper = shallow(<Link to='/gator'>Gator</Link>)
+  test('Specifying a `to` sets up router navigation, overrides default click', done => {
+    const route = '/some/route/'
+    const wrapper = wrap(<Link href='/gator' to={route}>Gator</Link>, options)
+    wrapper.simulate('click', clickEvent)
+    expect(preventDefault).toHaveBeenCalled()
+    setTimeout(() => {
+      expect(push).toHaveBeenCalledWith(route)
+      done()
+    })
+  })
+  test('`to` router navigation is skipped on ctrl+click', done => {
+    const route = '/some/route/'
+    const wrapper = wrap(<Link href='/gator' to={route}>Gator</Link>, options)
+    clickEvent.ctrlKey = true
+    wrapper.simulate('click', clickEvent)
+    expect(preventDefault).not.toHaveBeenCalled()
+    setTimeout(() => {
+      expect(push).not.toHaveBeenCalled()
+      done()
+    })
+  })
 
-    expect(wrapper.node.type).not.toBe('a')
-    expect(typeof wrapper.node.type).toBe('function')
+  test('`to` router navigation is skipped on cmd+click', done => {
+    const route = '/some/route/'
+    const wrapper = wrap(<Link href='/gator' to={route}>Gator</Link>, options)
+    clickEvent.metaKey = true
+    wrapper.simulate('click', clickEvent)
+    expect(preventDefault).not.toHaveBeenCalled()
+    setTimeout(() => {
+      expect(push).not.toHaveBeenCalled()
+      done()
+    })
+  })
+
+  test('Can fetch data and trigger a route asynchronously', done => {
+    const fetch = () => Promise.resolve()
+    const to = 'some/route'
+    const wrapper = wrap(<Link fetch={fetch} to={to} >Gator</Link>, options)
+    expect(wrapper.node.type).toBe('a')
+    wrapper.simulate('click', clickEvent)
+    expect(preventDefault).toHaveBeenCalled()
+    setTimeout(() => {
+      expect(push).toHaveBeenCalledWith(to)
+      done()
+    })
   })
 })

--- a/src/components/RouteWrapper/README.md
+++ b/src/components/RouteWrapper/README.md
@@ -1,0 +1,24 @@
+# RouterWrapper
+
+RouterWrapper is a higher-order component which wraps a Component and adds two new props:
+* `to` - a `<Route>` path which clicks will route to if clickes, same as a React-router `<Link>`
+* `fetch` - a function which returns a promise, which will be invoked before the `to` path is routed
+
+
+## Example
+
+```javascript
+class Blue extends Component { ... }
+Blue = RouteWrapper(Blue)
+```
+
+```html
+You're my boy, <Blue fetch={fetchData} to="path/to/route" \>!
+```
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| to | string | React Router path to navigate on click. |
+| fetch | function| function which returns a promise, will be invoked before routing the `to` route |

--- a/src/components/RouteWrapper/index.js
+++ b/src/components/RouteWrapper/index.js
@@ -14,16 +14,20 @@ const RouteWrapper = (WrappedComponent) => {
     render () {
       const { fetch = () => Promise.resolve(), to, ...rest } = this.props
       if (to) {
-        const history = this.context.router.history
-        rest.onClick = (e) => {
-          if (e && (e.metaKey || e.ctrlKey)) {
-            // Allow ctrl+clicks to function normally
-            return
+        if (this.context && this.context.router) {
+          const history = this.context.router.history
+          rest.onClick = (e) => {
+            if (e && (e.metaKey || e.ctrlKey)) {
+              // Allow ctrl+clicks to function normally
+              return
+            }
+            e && e.preventDefault()
+            fetch().then(() => {
+              history.push(to)
+            })
           }
-          e && e.preventDefault()
-          fetch().then(() => {
-            history.push(to)
-          })
+        } else {
+          console.error('The `to` attribute can only be used in the the context of a React Router.')
         }
       }
       return <WrappedComponent {...rest} />

--- a/src/components/RouteWrapper/index.js
+++ b/src/components/RouteWrapper/index.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+/**
+ * Adds `fetch` and `to` attributes to a Component, allowing clicks to route,
+ * optionally fetching data asynchronously first
+ *
+ * @param WrappedComponent
+ * @return function
+ * @constructor
+ */
+const RouteWrapper = (WrappedComponent) => {
+  class Component extends React.Component {
+    render () {
+      const { fetch = () => Promise.resolve(), to, ...rest } = this.props
+      if (to) {
+        const history = this.context.router.history
+        rest.onClick = (e) => {
+          if (e && (e.metaKey || e.ctrlKey)) {
+            // Allow ctrl+clicks to function normally
+            return
+          }
+          e && e.preventDefault()
+          fetch().then(() => {
+            history.push(to)
+          })
+        }
+      }
+      return <WrappedComponent {...rest} />
+    }
+  }
+
+  Component.contextTypes = {
+    router: PropTypes.object
+  }
+
+  Component.propTypes = {
+    fetch: PropTypes.func,
+    start: PropTypes.func,
+    to: PropTypes.string
+  }
+  return Component
+}
+
+export default RouteWrapper

--- a/src/components/RouteWrapper/tests/RouteWrapper.test.js
+++ b/src/components/RouteWrapper/tests/RouteWrapper.test.js
@@ -58,4 +58,14 @@ describe('Route fetching', () => {
       done()
     })
   })
+
+  test('Rendering with a `to` but _not_ inside a `<Router>` context should log an error', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const to = 'some/route'
+    // No Router in the context!
+    wrap(<RouteWrappedPig to={to} />)
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockReset()
+    errorSpy.mockRestore()
+  })
 })

--- a/src/components/RouteWrapper/tests/RouteWrapper.test.js
+++ b/src/components/RouteWrapper/tests/RouteWrapper.test.js
@@ -1,0 +1,61 @@
+import React, { Component } from 'react'
+import { shallow } from 'enzyme'
+import RouteWrapper from '..'
+
+// Since we now wrap Link in a HOC, we have to use `.first.shallow()` to test.
+// See https://github.com/airbnb/enzyme/issues/539#issuecomment-239497107
+const wrap = (...args) => shallow(...args).first().shallow()
+
+describe('Route fetching', () => {
+  let options
+  let push
+  let history
+  let preventDefault
+  let clickEvent
+
+  beforeEach(() => {
+    push = jest.fn()
+    history = { push }
+    options = {
+      context: {
+        router: { history }
+      }
+    }
+    preventDefault = jest.fn()
+    clickEvent = { preventDefault }
+  })
+
+  class SomePig extends Component {
+    render () {
+      return (<div {...this.props}>Some pig!</div>)
+    }
+  }
+  const RouteWrappedPig = RouteWrapper(SomePig)
+
+  test('Can fetch data and trigger a route asynchronously', done => {
+    const fetch = () => {
+      return Promise.resolve()
+    }
+    const to = 'some/route'
+    const wrapper = wrap(<RouteWrappedPig fetch={fetch} to={to} />, options)
+    expect(wrapper.node.type).toBe('div')
+    wrapper.simulate('click', clickEvent)
+    expect(preventDefault).toHaveBeenCalled()
+    setTimeout(() => {
+      expect(push).toHaveBeenCalledWith(to)
+      done()
+    })
+  })
+
+  test('Specifying a `to` but no `fetch()` routes correctly', done => {
+    const to = 'some/other/route'
+    const wrapper = wrap(<RouteWrappedPig to={to} />, options)
+    expect(wrapper.node.type).toBe('div')
+    wrapper.simulate('click', clickEvent)
+    expect(preventDefault).toHaveBeenCalled()
+    setTimeout(() => {
+      expect(push).toHaveBeenCalledWith(to)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
## Feature
In beacon embed, we had a problem where we wanted to fetch some data from the server before navigating to a new <Route>. To make this easier, this Pull Request creates a Higher Order Component, `RouteWrapper`, which wraps around components and adds `fetch` and `to` properties. The `to` property works like the `to` on a React Router `<Link>`, but the `fetch` property lets you specify a thunk-returning function to fetch data before triggering the route specified in `to`. 

The `<Link>` and `<Button>` components have been wrapped with `RouteWrapper`, which means we can now do things like:
```javascript
<Link fetch="fetchArticle" to={`docs/articles/${id}`}>
<Button fetch="fetchArticles" to="docs/articles">
<Button to="synchronous/route/path">
```