### PR TITLE
Implement specified enum propTypes

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import VisuallyHidden from '../VisuallyHidden'
 import classNames from '../../utilities/classNames'
 import { nameToInitials } from '../../utilities/strings'
+import { standardSizeTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   borderColor: PropTypes.string,
@@ -10,7 +11,7 @@ export const propTypes = {
   className: PropTypes.string,
   image: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   name: PropTypes.string.isRequired,
-  size: PropTypes.string
+  size: standardSizeTypes
 }
 
 const defaultProps = {

--- a/src/components/AvatarStack/index.js
+++ b/src/components/AvatarStack/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
 import {
   default as Avatar,
-  propTypes as avatarTypes,
+  propTypes as avatarTypes
 } from '../Avatar'
 import { standardSizeTypes } from '../../constants/propTypes'
 

--- a/src/components/AvatarStack/index.js
+++ b/src/components/AvatarStack/index.js
@@ -1,13 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
-import { default as Avatar, propTypes as avatarTypes } from '../Avatar'
+import {
+  default as Avatar,
+  propTypes as avatarTypes,
+} from '../Avatar'
+import { standardSizeTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   avatars: PropTypes.arrayOf(PropTypes.shape(avatarTypes)),
   borderColor: PropTypes.string,
   max: PropTypes.number,
-  size: PropTypes.string
+  size: standardSizeTypes
 }
 
 const defaultProps = {

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
+import { statusTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   className: PropTypes.string,
   size: PropTypes.string,
-  status: PropTypes.string,
+  status: statusTypes,
   white: PropTypes.bool
 }
 

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
+import { standardSizeTypes, stateTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   accessibilityLabel: PropTypes.string,
@@ -12,8 +13,8 @@ export const propTypes = {
   onFocus: PropTypes.func,
   plain: PropTypes.bool,
   primary: PropTypes.bool,
-  size: PropTypes.string,
-  state: PropTypes.string,
+  size: standardSizeTypes,
+  state: stateTypes,
   submit: PropTypes.bool
 }
 

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
+import { blockSelectorTagTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   className: PropTypes.string,
@@ -11,7 +12,7 @@ export const propTypes = {
   onClick: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   onFocus: PropTypes.func,
   seamless: PropTypes.bool,
-  selector: PropTypes.string
+  selector: blockSelectorTagTypes
 }
 
 const defaultProps = {

--- a/src/components/CardBlock/index.js
+++ b/src/components/CardBlock/index.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
+import { standardSizeTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   className: PropTypes.string,
-  size: PropTypes.string
+  size: standardSizeTypes
 }
 
 const CardBlock = props => {

--- a/src/components/Choice/Input.js
+++ b/src/components/Choice/Input.js
@@ -4,6 +4,7 @@ import Backdrop from '../Input/Backdrop'
 import Icon from '../Icon'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
+import { stateTypes } from '../../constants/propTypes'
 
 const propTypes = {
   align: PropTypes.string,
@@ -16,7 +17,7 @@ const propTypes = {
   onFocus: PropTypes.func,
   name: PropTypes.string,
   readOnly: PropTypes.bool,
-  state: PropTypes.string,
+  state: stateTypes,
   type: PropTypes.string,
   value: PropTypes.string
 }
@@ -62,7 +63,7 @@ const Input = props => {
   const iconTypeMarkup = type === 'radio' ? (
     <div className='c-ChoiceInput__radio' />
   ) : (
-    <Icon name='check' size={12} />
+    <Icon name='check' size='12' />
   )
 
   const iconMarkup = checked ? (

--- a/src/components/Choice/index.js
+++ b/src/components/Choice/index.js
@@ -8,9 +8,11 @@ import VisuallyHidden from '../VisuallyHidden'
 import classNames from '../../utilities/classNames'
 import { createUniqueIDFactory } from '../../utilities/id'
 import { noop } from '../../utilities/other'
+import { stateTypes } from '../../constants/propTypes'
+import { alignTypes, typeTypes } from './propTypes'
 
 export const propTypes = {
-  align: PropTypes.string,
+  align: alignTypes,
   checked: PropTypes.bool,
   className: PropTypes.string,
   componentID: PropTypes.string,
@@ -24,8 +26,8 @@ export const propTypes = {
   onFocus: PropTypes.func,
   name: PropTypes.string,
   readOnly: PropTypes.bool,
-  state: PropTypes.string,
-  type: PropTypes.string,
+  state: stateTypes,
+  type: typeTypes,
   value: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,

--- a/src/components/Choice/propTypes.js
+++ b/src/components/Choice/propTypes.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types'
+
+export const alignTypes = PropTypes.oneOf([
+  'top',
+  ''
+])
+
+export const typeTypes = PropTypes.oneOf([
+  'checkbox',
+  'radio',
+  ''
+])

--- a/src/components/ChoiceGroup/index.js
+++ b/src/components/ChoiceGroup/index.js
@@ -5,12 +5,7 @@ import classNames from '../../utilities/classNames'
 import FormGroup from '../FormGroup'
 import { createUniqueIDFactory } from '../../utilities/id'
 import { noop } from '../../utilities/other'
-
-const valuePropType = PropTypes.oneOfType([
-  PropTypes.string,
-  PropTypes.number,
-  PropTypes.bool
-])
+import { valueTypes } from './propTypes'
 
 export const propTypes = {
   className: PropTypes.string,
@@ -24,8 +19,8 @@ export const propTypes = {
   multiSelect: PropTypes.bool,
   name: PropTypes.string,
   value: PropTypes.oneOfType([
-    PropTypes.arrayOf(valuePropType),
-    valuePropType
+    PropTypes.arrayOf(valueTypes),
+    valueTypes
   ])
 }
 

--- a/src/components/ChoiceGroup/propTypes.js
+++ b/src/components/ChoiceGroup/propTypes.js
@@ -1,0 +1,7 @@
+import PropTypes from 'prop-types'
+
+export const valueTypes = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.number,
+  PropTypes.bool
+])

--- a/src/components/Flexy/Flexy.js
+++ b/src/components/Flexy/Flexy.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types'
 import Block from './Block'
 import Item from './Item'
 import classNames from '../../utilities/classNames'
+import { alignTypes, gapTypes, justTypes } from './propTypes'
 
 export const propTypes = {
-  align: PropTypes.string,
+  align: alignTypes,
   className: PropTypes.string,
-  gap: PropTypes.string,
-  just: PropTypes.string
+  gap: gapTypes,
+  just: justTypes
 }
 
 const Flexy = props => {

--- a/src/components/Flexy/Item.js
+++ b/src/components/Flexy/Item.js
@@ -3,7 +3,7 @@ import classNames from '../../utilities/classNames'
 import PropTypes from 'prop-types'
 
 export const propTypes = {
-  inline: PropTypes.bool,
+  inline: PropTypes.bool
 }
 
 const Item = props => {

--- a/src/components/Flexy/Item.js
+++ b/src/components/Flexy/Item.js
@@ -1,15 +1,21 @@
 import React from 'react'
 import classNames from '../../utilities/classNames'
+import PropTypes from 'prop-types'
+
+export const propTypes = {
+  inline: PropTypes.bool,
+}
 
 const Item = props => {
   const {
     children,
     className,
+    inline,
     ...rest
   } = props
 
   const componentClassName = classNames(
-    'o-flexy__item',
+    inline ? 'o-flexy__inline-item' : 'o-flexy__item',
     className
   )
 
@@ -19,5 +25,7 @@ const Item = props => {
     </div>
   )
 }
+
+Item.propTypes = propTypes
 
 export default Item

--- a/src/components/Flexy/propTypes.js
+++ b/src/components/Flexy/propTypes.js
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types'
+
+export const alignTypes = PropTypes.oneOf([
+  'top',
+  'middle',
+  'bottom',
+  ''
+])
+
+export const gapTypes = PropTypes.oneOf([
+  'xl',
+  'lg',
+  'md',
+  'sm',
+  'xs',
+  ''
+])
+
+export const justTypes = PropTypes.oneOf([
+  'default',
+  'left',
+  'center',
+  'right',
+  ''
+])

--- a/src/components/Flexy/test/Block.test.js
+++ b/src/components/Flexy/test/Block.test.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Flexy from '..'
+
+describe('ClassName', () => {
+  test('Has default className', () => {
+    const wrapper = shallow(<Flexy.Block />)
+
+    expect(wrapper.hasClass('o-flexy__block')).toBeTruthy()
+  })
+
+  test('Applies custom className if specified', () => {
+    const customClass = 'piano-key-neck-tie'
+    const wrapper = shallow(<Flexy.Block className={customClass} />)
+
+    expect(wrapper.prop('className')).toContain(customClass)
+  })
+})
+
+describe('Children', () => {
+  test('Renders child content', () => {
+    const wrapper = shallow(<Flexy.Block><div className='child'>Hello</div></Flexy.Block>)
+    const el = wrapper.find('div.child')
+
+    expect(el.text()).toContain('Hello')
+  })
+})

--- a/src/components/Flexy/test/Flexy.test.js
+++ b/src/components/Flexy/test/Flexy.test.js
@@ -2,82 +2,46 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import Flexy from '..'
 
-describe('Flexy', () => {
-  describe('ClassName', () => {
-    test('Applies custom className if specified', () => {
-      const customClass = 'piano-key-neck-tie'
-      const wrapper = shallow(<Flexy className={customClass} />)
+describe('ClassName', () => {
+  test('Has default className', () => {
+    const wrapper = shallow(<Flexy />)
 
-      expect(wrapper.prop('className')).toContain(customClass)
-    })
+    expect(wrapper.hasClass('o-flexy')).toBeTruthy()
   })
 
-  describe('Children', () => {
-    test('Renders child content', () => {
-      const wrapper = shallow(<Flexy><div className='child'>Hello</div></Flexy>)
-      const el = wrapper.find('div.child')
+  test('Applies custom className if specified', () => {
+    const customClass = 'piano-key-neck-tie'
+    const wrapper = shallow(<Flexy className={customClass} />)
 
-      expect(el.text()).toContain('Hello')
-    })
-  })
-
-  describe('Styles', () => {
-    test('Applies vertical alignment styles', () => {
-      const wrapper = shallow(<Flexy align='top'><Flexy.Item>Hello</Flexy.Item></Flexy>)
-
-      expect(wrapper.prop('className')).toContain('top')
-    })
-
-    test('Applies horizontal alignment styles', () => {
-      const wrapper = shallow(<Flexy just='right'><Flexy.Item>Hello</Flexy.Item></Flexy>)
-
-      expect(wrapper.prop('className')).toContain('right')
-    })
-
-    test('Applies spacing styles', () => {
-      const wrapper = shallow(<Flexy gap='lg'><Flexy.Item>Hello</Flexy.Item></Flexy>)
-
-      expect(wrapper.prop('className')).toContain('gap-lg')
-    })
+    expect(wrapper.prop('className')).toContain(customClass)
   })
 })
 
-describe('Block', () => {
-  describe('ClassName', () => {
-    test('Applies custom className if specified', () => {
-      const customClass = 'piano-key-neck-tie'
-      const wrapper = shallow(<Flexy.Block className={customClass} />)
+describe('Children', () => {
+  test('Renders child content', () => {
+    const wrapper = shallow(<Flexy><div className='child'>Hello</div></Flexy>)
+    const el = wrapper.find('div.child')
 
-      expect(wrapper.prop('className')).toContain(customClass)
-    })
-  })
-
-  describe('Children', () => {
-    test('Renders child content', () => {
-      const wrapper = shallow(<Flexy.Block><div className='child'>Hello</div></Flexy.Block>)
-      const el = wrapper.find('div.child')
-
-      expect(el.text()).toContain('Hello')
-    })
+    expect(el.text()).toContain('Hello')
   })
 })
 
-describe('Item', () => {
-  describe('ClassName', () => {
-    test('Applies custom className if specified', () => {
-      const customClass = 'piano-key-neck-tie'
-      const wrapper = shallow(<Flexy.Item className={customClass} />)
+describe('Styles', () => {
+  test('Applies vertical alignment styles', () => {
+    const wrapper = shallow(<Flexy align='top'><Flexy.Item>Hello</Flexy.Item></Flexy>)
 
-      expect(wrapper.prop('className')).toContain(customClass)
-    })
+    expect(wrapper.prop('className')).toContain('top')
   })
 
-  describe('Children', () => {
-    test('Renders child content', () => {
-      const wrapper = shallow(<Flexy.Item><div className='child'>Hello</div></Flexy.Item>)
-      const el = wrapper.find('div.child')
+  test('Applies horizontal alignment styles', () => {
+    const wrapper = shallow(<Flexy just='right'><Flexy.Item>Hello</Flexy.Item></Flexy>)
 
-      expect(el.text()).toContain('Hello')
-    })
+    expect(wrapper.prop('className')).toContain('right')
+  })
+
+  test('Applies spacing styles', () => {
+    const wrapper = shallow(<Flexy gap='lg'><Flexy.Item>Hello</Flexy.Item></Flexy>)
+
+    expect(wrapper.prop('className')).toContain('gap-lg')
   })
 })

--- a/src/components/Flexy/test/Item.test.js
+++ b/src/components/Flexy/test/Item.test.js
@@ -19,7 +19,6 @@ describe('ClassName', () => {
 
 describe('Inline', () => {
   test('Applies inline className if specified', () => {
-    const customClass = 'piano-key-neck-tie'
     const wrapper = shallow(<Flexy.Item inline />)
 
     expect(wrapper.hasClass('o-flexy__inline-item')).toBeTruthy()

--- a/src/components/Flexy/test/Item.test.js
+++ b/src/components/Flexy/test/Item.test.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Flexy from '..'
+
+describe('ClassName', () => {
+  test('Has default className', () => {
+    const wrapper = shallow(<Flexy.Item />)
+
+    expect(wrapper.hasClass('o-flexy__item')).toBeTruthy()
+  })
+
+  test('Applies custom className if specified', () => {
+    const customClass = 'piano-key-neck-tie'
+    const wrapper = shallow(<Flexy.Item className={customClass} />)
+
+    expect(wrapper.prop('className')).toContain(customClass)
+  })
+})
+
+describe('Inline', () => {
+  test('Applies inline className if specified', () => {
+    const customClass = 'piano-key-neck-tie'
+    const wrapper = shallow(<Flexy.Item inline />)
+
+    expect(wrapper.hasClass('o-flexy__inline-item')).toBeTruthy()
+    expect(wrapper.hasClass('o-flexy__item')).not.toBeTruthy()
+  })
+})
+
+describe('Children', () => {
+  test('Renders child content', () => {
+    const wrapper = shallow(<Flexy.Item><div className='child'>Hello</div></Flexy.Item>)
+    const el = wrapper.find('div.child')
+
+    expect(el.text()).toContain('Hello')
+  })
+})

--- a/src/components/Heading/index.js
+++ b/src/components/Heading/index.js
@@ -1,13 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
+import { sizeTypes } from './propTypes'
 
 export const propTypes = {
   className: PropTypes.string,
   disableSelect: PropTypes.bool,
   light: PropTypes.bool,
   selector: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-  size: PropTypes.string
+  size: sizeTypes
 }
 
 const defaultProps = {

--- a/src/components/Heading/propTypes.js
+++ b/src/components/Heading/propTypes.js
@@ -9,5 +9,5 @@ export const sizeTypes = PropTypes.oneOf([
   'h6',
   'big',
   'small',
-  '',
+  ''
 ])

--- a/src/components/Heading/propTypes.js
+++ b/src/components/Heading/propTypes.js
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types'
+
+export const sizeTypes = PropTypes.oneOf([
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'big',
+  'small',
+  '',
+])

--- a/src/components/HelpText/README.md
+++ b/src/components/HelpText/README.md
@@ -15,6 +15,7 @@ A HelpText component is a light-weight text wrapper enhanced with a collection o
 | --- | --- | --- |
 | className | string | Custom class names to be added to the component. |
 | muted | boolean  | Changes text color to a light grey. |
+| size | string | Adjust text size. |
 | state | string | Changes the text color based on state. |
 
 

--- a/src/components/HelpText/index.js
+++ b/src/components/HelpText/index.js
@@ -2,16 +2,18 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
 import Text from '../Text'
+import { sizeTypes } from '../Text/propTypes'
+import { stateTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   className: PropTypes.string,
   muted: PropTypes.bool,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  state: PropTypes.string
+  size: sizeTypes,
+  state: stateTypes
 }
 
 const defaultProps = {
-  size: 13
+  size: '13'
 }
 
 const HelpText = props => {

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -4,6 +4,7 @@ import ICONS from './icons'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 import VisuallyHidden from '../VisuallyHidden'
+import { sizeTypes } from './propTypes'
 
 export const propTypes = {
   center: PropTypes.bool,
@@ -13,7 +14,7 @@ export const propTypes = {
   muted: PropTypes.bool,
   name: PropTypes.string.isRequired,
   onClick: PropTypes.func,
-  size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  size: sizeTypes,
   title: PropTypes.string
 }
 

--- a/src/components/Icon/propTypes.js
+++ b/src/components/Icon/propTypes.js
@@ -1,0 +1,11 @@
+import PropTypes from 'prop-types'
+
+export const sizeTypes = PropTypes.oneOf([
+  '12',
+  '14',
+  '16',
+  '18',
+  '20',
+  '24',
+  ''
+])

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -7,7 +7,6 @@ export const propTypes = {
   className: PropTypes.string,
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   src: PropTypes.string.isRequired,
-  style: PropTypes.object,
   title: PropTypes.string,
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 }

--- a/src/components/Input/Backdrop.js
+++ b/src/components/Input/Backdrop.js
@@ -1,13 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
+import { stateTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   checkbox: PropTypes.bool,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   readOnly: PropTypes.bool,
-  state: PropTypes.string
+  state: stateTypes
 }
 
 const Backdrop = props => {

--- a/src/components/Input/Static.js
+++ b/src/components/Input/Static.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
+import { standardSizeTypes } from '../../constants/propTypes'
+import { staticAlignTypes } from './propTypes'
 
 export const propTypes = {
-  align: PropTypes.string,
-  size: PropTypes.string
+  align: staticAlignTypes,
+  size: standardSizeTypes
 }
 
 const Static = props => {

--- a/src/components/Input/Static.js
+++ b/src/components/Input/Static.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
 import { standardSizeTypes } from '../../constants/propTypes'
 import { staticAlignTypes } from './propTypes'

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -8,6 +8,7 @@ import Static from './Static'
 import classNames from '../../utilities/classNames'
 import { createUniqueIDFactory } from '../../utilities/id'
 import { noop } from '../../utilities/other'
+import { standardSizeTypes, stateTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   autoFocus: PropTypes.bool,
@@ -26,8 +27,8 @@ export const propTypes = {
   readOnly: PropTypes.bool,
   resizable: PropTypes.bool,
   seamless: PropTypes.bool,
-  size: PropTypes.string,
-  state: PropTypes.string,
+  size: standardSizeTypes,
+  state: stateTypes,
   suffix: PropTypes.string,
   type: PropTypes.string,
   value: PropTypes.string

--- a/src/components/Input/propTypes.js
+++ b/src/components/Input/propTypes.js
@@ -1,0 +1,8 @@
+import PropTypes from 'prop-types'
+
+export const staticAlignTypes = PropTypes.oneOf([
+  'left',
+  'center',
+  'right',
+  ''
+])

--- a/src/components/Label/index.js
+++ b/src/components/Label/index.js
@@ -2,11 +2,12 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
 import Text from '../Text'
+import { stateTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   className: PropTypes.string,
   for: PropTypes.string,
-  state: PropTypes.string
+  state: stateTypes
 }
 
 const Label = props => {

--- a/src/components/ProgressBar/index.js
+++ b/src/components/ProgressBar/index.js
@@ -2,11 +2,12 @@ import React, { PureComponent as Component } from 'react'
 import PropTypes from 'prop-types'
 import { classNames } from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
+import { standardSizeTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   description: PropTypes.string,
   onChange: PropTypes.func,
-  size: PropTypes.string,
+  size: standardSizeTypes,
   value: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -5,6 +5,7 @@ import HelpText from '../HelpText'
 import Label from '../Label'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
+import { standardSizeTypes, stateTypes } from '../../constants/propTypes'
 
 export const optionType = PropTypes.oneOfType([
   PropTypes.shape({
@@ -42,8 +43,8 @@ export const propTypes = {
   onFocus: PropTypes.func,
   placeholder: PropTypes.string,
   prefix: PropTypes.string,
-  size: PropTypes.string,
-  state: PropTypes.string,
+  size: standardSizeTypes,
+  state: stateTypes,
   value: PropTypes.string
 }
 

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -17,7 +17,7 @@ A Text component is a light-weight text wrapper enhanced with a collection of ae
 | disableSelect | boolean | Disables text selection. |
 | faint | boolean | Changes text color to a very light grey. |
 | muted | boolean  | Changes text color to a light grey. |
-| size | number | Adjust text size. |
+| size | string | Adjust text size. |
 | subtle | boolean | Changes text color to a lighter grey. |
 | state | string | Changes the text color based on state. |
 | truncate | boolean | Enables CSS truncation for text. |

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -1,14 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { sizeTypes } from './propTypes'
 import classNames from '../../utilities/classNames'
+import { stateTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   className: PropTypes.string,
   disableSelect: PropTypes.bool,
   faint: PropTypes.bool,
   muted: PropTypes.bool,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  state: PropTypes.string,
+  size: sizeTypes,
+  state: stateTypes,
   subtle: PropTypes.bool,
   truncate: PropTypes.bool
 }

--- a/src/components/Text/propTypes.js
+++ b/src/components/Text/propTypes.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types'
+
+export const sizeTypes = PropTypes.oneOf([
+  '11',
+  '12',
+  '13',
+  '14',
+  '15',
+  '20',
+  '48',
+  ''
+])

--- a/src/components/Text/tests/Text.test.js
+++ b/src/components/Text/tests/Text.test.js
@@ -28,10 +28,10 @@ describe('Styles', () => {
 
   test('Applies sizing styles if specified', () => {
     const wrapper13 = shallow(<Text size='13' />)
-    const wrapper18 = shallow(<Text size='18' />)
+    const wrapper20 = shallow(<Text size='20' />)
 
     expect(wrapper13.prop('className')).toContain('is-13')
-    expect(wrapper18.prop('className')).toContain('is-18')
+    expect(wrapper20.prop('className')).toContain('is-20')
   })
 
   test('Applies disableSelect styles if specified', () => {

--- a/src/constants/propTypes.js
+++ b/src/constants/propTypes.js
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types'
+
+export const standardSizeTypes = PropTypes.oneOf([
+  'lg',
+  'md',
+  'sm',
+  ''
+])
+
+export const statusTypes = PropTypes.oneOf([
+  'error',
+  'info',
+  'success',
+  'warning',
+  ''
+])
+
+export const stateTypes = PropTypes.oneOf([
+  'error',
+  'success',
+  'warning',
+  ''
+])
+
+export const blockSelectorTagTypes = PropTypes.oneOf([
+  'div',
+  'span',
+  'a',
+  'p',
+  ''
+])


### PR DESCRIPTION
## Implement specified enum propTypes

This update provides most components with a specific range of acceptable values.

For example, the states (`string`) that we use in Blue are `error`, `success`, `warning`. Components with a `state` prop should only accept these values, as other values will fall to render the correct styling.

To be things easier (and more consistent), I've added `constants/propTypes.js` that contain an export of common propTypes, such as state or size.