### PR TITLE
SidebarCollapsibleCard: Toggle open with prop change

### DIFF
--- a/src/components/PortalWrapper/index.js
+++ b/src/components/PortalWrapper/index.js
@@ -80,7 +80,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
       }
     }
 
-    getChildContext() {
+    getChildContext () {
       return {
         closePortal: this.closePortal.bind(this)
       }

--- a/src/components/SidebarCollapsibleCard/index.js
+++ b/src/components/SidebarCollapsibleCard/index.js
@@ -29,6 +29,12 @@ class SidebarCollapsibleCard extends Component {
     }
   }
 
+  componentWillUpdate (nextProps, nextState) {
+    if (this.props.isOpen !== nextProps.isOpen) {
+      this.handleToggleOpen()
+    }
+  }
+
   handleToggleOpen () {
     this.setState({ isOpen: !this.state.isOpen })
   }

--- a/src/components/SidebarCollapsibleCard/tests/SidebarCollapsibleCard.test.js
+++ b/src/components/SidebarCollapsibleCard/tests/SidebarCollapsibleCard.test.js
@@ -41,6 +41,19 @@ describe('Open', () => {
 
     expect(wrapper.hasClass('is-open')).not.toBeTruthy()
   })
+
+  test('Can change state by updating isOpen prop', () => {
+    const wrapper = shallow(<SidebarCollapsibleCard />)
+    wrapper.setProps({ isOpen: true })
+
+    expect(wrapper.hasClass('is-open')).toBeTruthy()
+    expect(wrapper.state().isOpen).toBeTruthy()
+
+    wrapper.setProps({ isOpen: false })
+
+    expect(wrapper.hasClass('is-open')).not.toBeTruthy()
+    expect(wrapper.state().isOpen).not.toBeTruthy()
+  })
 })
 
 describe('Header/Title', () => {

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -47,7 +47,7 @@ storiesOf('Modal', module)
   ))
   .add('custom close trigger', () => {
     class Contents extends React.Component {
-      render() {
+      render () {
         return (
           <p>
             <button onClick={this.context.closePortal}>Close me</button>


### PR DESCRIPTION
## SidebarCollapsibleCard: Toggle open with prop change

This update allows for the `SidebarCollapsibleCard` open state to be influenced by the prop change of `isOpen`, allowing for more programmatic control from a parent component/container.