### PR TITLE
Move `bind(this)` to `constructor()` method for Components

### DIFF
--- a/src/components/Choice/index.js
+++ b/src/components/Choice/index.js
@@ -53,6 +53,8 @@ class Choice extends Component {
       checked: props.checked,
       id: props.id || uniqueID(props.componentID || 'Choice')
     }
+
+    this.handleOnChange = this.handleOnChange.bind(this)
   }
 
   componentWillReceiveProps (newProps) {
@@ -99,7 +101,7 @@ class Choice extends Component {
       className
     )
 
-    const handleOnChange = this.handleOnChange.bind(this)
+    const handleOnChange = this.handleOnChange
 
     let labelTextMarkup = hideLabel ? (
       <VisuallyHidden>{label}</VisuallyHidden>

--- a/src/components/ChoiceGroup/index.js
+++ b/src/components/ChoiceGroup/index.js
@@ -40,6 +40,7 @@ class ChoiceGroup extends Component {
       selectedValue: props.value ? [].concat(props.value) : []
     }
     this.multiSelect = true
+    this.handleOnChange = this.handleOnChange.bind(this)
   }
 
   componentWillMount () {
@@ -95,7 +96,7 @@ class ChoiceGroup extends Component {
       (multiSelectSetting || multiSelect) && 'is-multi-select',
       className
     )
-    const handleOnChange = this.handleOnChange.bind(this)
+    const handleOnChange = this.handleOnChange
 
     const choiceMarkup = children ? React.Children.map(children, (child, index) => {
       return (

--- a/src/components/Input/Resizer.js
+++ b/src/components/Input/Resizer.js
@@ -28,6 +28,10 @@ const defaultProps = {
 }
 
 class Resizer extends Component {
+  constructor () {
+    super()
+    this.handleOnResize = this.handleOnResize.bind(this)
+  }
   componentDidMount () {
     this.handleOnResize()
   }
@@ -74,7 +78,7 @@ class Resizer extends Component {
 
   render () {
     const { contents, minimumLines } = this.props
-    const handleOnResize = this.handleOnResize.bind(this)
+    const handleOnResize = this.handleOnResize
 
     const minimumLinesMarkup = minimumLines
       ? <div

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -58,6 +58,8 @@ class Input extends Component {
       height: null,
       value: props.value
     }
+    this.handleOnChange = this.handleOnChange.bind(this)
+    this.handleExpandingResize = this.handleExpandingResize.bind(this)
   }
 
   handleOnChange (e) {
@@ -97,8 +99,8 @@ class Input extends Component {
 
     const { height, id: inputID, value } = this.state
 
-    const handleOnChange = this.handleOnChange.bind(this)
-    const handleExpandingResize = this.handleExpandingResize.bind(this)
+    const handleOnChange = this.handleOnChange
+    const handleExpandingResize = this.handleExpandingResize
 
     const componentClassName = classNames(
       'c-Input',

--- a/src/components/Portal/index.js
+++ b/src/components/Portal/index.js
@@ -36,6 +36,8 @@ class Portal extends React.Component {
     this.isOpening = false
     this.isOpen = false
     this.isClosing = false
+    this.mountPortal = this.mountPortal.bind(this)
+    this.unmountPortal = this.unmountPortal.bind(this)
   }
 
   componentDidMount () {
@@ -139,7 +141,7 @@ class Portal extends React.Component {
       onBeforeOpen
     } = props
 
-    const mountPortal = this.mountPortal.bind(this)
+    const mountPortal = this.mountPortal
 
     if (onBeforeOpen) {
       /* istanbul ignore next */
@@ -158,7 +160,7 @@ class Portal extends React.Component {
       onBeforeClose
     } = props
 
-    const unmountPortal = this.unmountPortal.bind(this)
+    const unmountPortal = this.unmountPortal
 
     if (onBeforeClose) {
       /* istanbul ignore next */

--- a/src/components/PortalWrapper/index.js
+++ b/src/components/PortalWrapper/index.js
@@ -30,6 +30,9 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
         id: uniqueID(),
         isMounted: props.isOpen
       })
+      this.closePortal = this.closePortal.bind(this)
+      this.openPortal = this.openPortal.bind(this)
+      this.handleOnClose = this.handleOnClose.bind(this)
     }
 
     componentDidMount () {
@@ -82,7 +85,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
 
     getChildContext () {
       return {
-        closePortal: this.closePortal.bind(this)
+        closePortal: this.closePortal
       }
     }
 
@@ -103,8 +106,8 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
       // Remapping open/mount state for ComposedComponent
       const { id, isOpen: portalIsMounted, isMounted: portalIsOpen } = this.state
 
-      const openPortal = this.openPortal.bind(this)
-      const handleOnClose = this.handleOnClose.bind(this)
+      const openPortal = this.openPortal
+      const handleOnClose = this.handleOnClose
 
       const uniqueIndex = parseInt(id.replace(options.id, ''), 10)
       const zIndex = options.zIndex ? options.zIndex + uniqueIndex : null

--- a/src/components/SidebarCollapsibleCard/index.js
+++ b/src/components/SidebarCollapsibleCard/index.js
@@ -27,6 +27,7 @@ class SidebarCollapsibleCard extends Component {
       id: props.id || uniqueID(),
       isOpen: props.isOpen
     }
+    this.handleToggleOpen = this.handleToggleOpen.bind(this)
   }
 
   componentWillUpdate (nextProps, nextState) {
@@ -62,7 +63,7 @@ class SidebarCollapsibleCard extends Component {
       className
     )
 
-    const handleToggleOpen = this.handleToggleOpen.bind(this)
+    const handleToggleOpen = this.handleToggleOpen
 
     const displayHeader = () => {
       if (header) return header

--- a/stories/Animate.js
+++ b/stories/Animate.js
@@ -8,6 +8,7 @@ class AnimateOutExample extends Component {
     this.state = {
       show: true
     }
+    this.toggleIn = this.toggleIn.bind(this)
   }
 
   toggleIn () {
@@ -18,7 +19,7 @@ class AnimateOutExample extends Component {
 
   render () {
     const { show } = this.state
-    const toggleIn = this.toggleIn.bind(this)
+    const toggleIn = this.toggleIn
 
     return (
       <div>

--- a/stories/Collapsible.js
+++ b/stories/Collapsible.js
@@ -6,6 +6,7 @@ class SampleComponent extends Component {
   constructor () {
     super()
     this.state = { open: false }
+    this.handleToggleOpen = this.handleToggleOpen.bind(this)
   }
 
   handleToggleOpen () {
@@ -15,7 +16,7 @@ class SampleComponent extends Component {
   render () {
     const { children, ...rest } = this.props
     const { open } = this.state
-    const handleToggleOpen = this.handleToggleOpen.bind(this)
+    const handleToggleOpen = this.handleToggleOpen
 
     return (
       <div>


### PR DESCRIPTION
## Move `bind(this)` to `constructor()` method for Components

This update moves the instantiation of `bind(this)` from the `render()` method to `constructor()` for non-Stateless components. This is done for performance + best practice reasons.

Thanks to @brettjonesdev for the tip!