### PR TITLE
Add an `initials` attribute to the `<Avatar>` component. 

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -11,6 +11,7 @@ export const propTypes = {
   className: PropTypes.string,
   image: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   name: PropTypes.string.isRequired,
+  initials: PropTypes.string,
   size: standardSizeTypes
 }
 
@@ -28,6 +29,7 @@ const Avatar = props => {
     size,
     ...rest
   } = props
+  let { initials } = props
 
   const componentClassName = classNames(
     'c-Avatar',
@@ -36,7 +38,7 @@ const Avatar = props => {
     className
   )
 
-  const initials = nameToInitials(name)
+  initials = initials || nameToInitials(name)
   const imageStyle = image ? { backgroundImage: `url('${image}')` } : null
 
   const text = count || initials

--- a/src/components/Avatar/tests/Avatar.test.js
+++ b/src/components/Avatar/tests/Avatar.test.js
@@ -8,6 +8,13 @@ const classNames = {
 }
 
 describe('Name', () => {
+  test('Uses the `initials` attribute if specified', () => {
+    const wrapper = shallow(<Avatar name='Ron Burgandy' initials='XY' />)
+    const title = wrapper.find(classNames.initials)
+
+    expect(title.text()).toBe('XY')
+  })
+
   test('Initializes first/last name to two letters', () => {
     const wrapper = shallow(<Avatar name='Ron Burgandy' />)
     const title = wrapper.find(classNames.initials)

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -23,8 +23,7 @@ const defaultProps = {
 }
 
 const Link = props => {
-  const {
-    className, external, href, ...rest } = props
+  const { className, external, href, ...rest } = props
 
   const componentClassName = classNames('c-link', className)
 


### PR DESCRIPTION
Beacon API is going to be specifying an `initials` attribute, which we want to use to override the default `<Avatar>` initials parsing from the `name` attribute. This PR adds an `initials` property to the `Avatar` component. 