### PR TITLE
Fix `initials` attribute being passed down to `<Avatar>` <div>

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -26,10 +26,10 @@ const Avatar = props => {
     count,
     image,
     name,
+    initials,
     size,
     ...rest
   } = props
-  let { initials } = props
 
   const componentClassName = classNames(
     'c-Avatar',
@@ -38,10 +38,9 @@ const Avatar = props => {
     className
   )
 
-  initials = initials || nameToInitials(name)
   const imageStyle = image ? { backgroundImage: `url('${image}')` } : null
 
-  const text = count || initials
+  const text = count || initials || nameToInitials(name)
 
   const contentMarkup = image
     ? (

--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -62,7 +62,7 @@ const Avatar = props => {
   } : null
 
   return (
-    <div className={componentClassName} {...rest}>
+    <div className={componentClassName} title={name} {...rest}>
       <div className='c-Avatar__crop' style={styles}>
         {contentMarkup}
       </div>

--- a/src/components/Avatar/tests/Avatar.test.js
+++ b/src/components/Avatar/tests/Avatar.test.js
@@ -3,6 +3,7 @@ import { mount, shallow } from 'enzyme'
 import Avatar from '..'
 
 const classNames = {
+  root: '.c-Avatar',
   image: '.c-Avatar__photo',
   initials: '.c-Avatar__title'
 }
@@ -42,6 +43,12 @@ describe('Name', () => {
 
     expect(title.text()).toBe('Elf')
   })
+
+  test('Sets `title` attribute to the `name`', () => {
+    const wrapper = shallow(<Avatar name='Bobby McGee' />)
+    const root = wrapper.find(classNames.root)
+    expect(root.prop('title')).toBe('Bobby McGee')
+  })
 })
 
 describe('Image', () => {
@@ -74,6 +81,12 @@ describe('Image', () => {
     const initials = wrapper.find(classNames.initials)
 
     expect(initials.exists()).toBeFalsy()
+  })
+
+  test('Sets `title` attribute to the `name`', () => {
+    const wrapper = shallow(<Avatar name='Bobby McGee' />)
+    const root = wrapper.find(classNames.root)
+    expect(root.prop('title')).toBe('Bobby McGee')
   })
 })
 


### PR DESCRIPTION
Bug fix - `initials` was being passed down into the `Avatar`'s `div`. 