### PR TITLE
Extend timeout values for Portal.test.js

### DIFF
--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -31,6 +31,7 @@ describe('Trigger', () => {
     expect(el.text()).toBe('Trigger')
 
     wrapper.unmount()
+    cleanUp()
   })
 
   test('Automatically receives click event', () => {
@@ -40,6 +41,7 @@ describe('Trigger', () => {
     expect(el.prop('onClick')).toBeInstanceOf(Function)
 
     wrapper.unmount()
+    cleanUp()
   })
 })
 
@@ -57,10 +59,10 @@ describe('Key events', () => {
     setTimeout(() => {
       expect(document.body.childNodes.length).toBeLessThan(preCloseNodeCount)
       expect(document.getElementsByClassName('c-Modal').length).toBe(0)
+      wrapper.unmount()
+      cleanUp()
       done()
     }, MODAL_TEST_TIMEOUT)
-
-    wrapper.unmount()
   })
 })
 
@@ -89,6 +91,7 @@ describe('Portal', () => {
     expect(modal.exists()).toBeFalsy()
 
     wrapper.unmount()
+    cleanUp()
   })
 
   test('Renders at the body', () => {
@@ -102,6 +105,7 @@ describe('Portal', () => {
     expect(modal.classList).toContain('c-Modal')
 
     wrapper.unmount()
+    cleanUp()
   })
 
   test('Does not render by default', (done) => {
@@ -114,7 +118,7 @@ describe('Portal', () => {
       expect(portal).not.toBeTruthy()
 
       wrapper.unmount()
-
+      cleanUp()
       done()
     }, MODAL_TEST_TIMEOUT)
   })
@@ -138,9 +142,9 @@ describe('Route', () => {
 
     expect(modal).toBeTruthy()
 
+    wrapper.unmount()
     wrapper.detach()
-    global.document.body.removeChild(testBody)
-    global.document.body.innerHTML = ''
+    cleanUp()
     done()
   })
 
@@ -162,9 +166,9 @@ describe('Route', () => {
 
     expect(modal).toBeTruthy()
 
+    wrapper.unmount()
     wrapper.detach()
-    global.document.body.removeChild(testBody)
-    global.document.body.innerHTML = ''
+    cleanUp()
     done()
   })
 
@@ -185,9 +189,9 @@ describe('Route', () => {
 
     expect(modal).toBeFalsy()
 
+    wrapper.unmount()
     wrapper.detach()
-    global.document.body.removeChild(testBody)
-    global.document.body.innerHTML = ''
+    cleanUp()
     done()
   })
 })
@@ -207,7 +211,7 @@ describe('Style', () => {
     expect(html).toContain('red')
 
     wrapper.unmount()
-    global.document.body.innerHTML = ''
+    cleanUp()
     done()
   })
 
@@ -227,7 +231,7 @@ describe('Style', () => {
     expect(html).toContain('2000')
 
     wrapper.unmount()
-    global.document.body.innerHTML = ''
+    cleanUp()
     done()
   })
 
@@ -244,7 +248,7 @@ describe('Style', () => {
     expect(html).toContain('2000')
 
     wrapper.unmount()
-    global.document.body.innerHTML = ''
+    cleanUp()
     done()
   })
 })
@@ -266,11 +270,12 @@ describe('PortalWrapper', () => {
       <Modal onBeforeClose={onBeforeClose} isOpen />
     , { attachTo: testBody })
 
-    wrapper.detach()
+    wrapper.unmount()
 
     setTimeout(() => {
       expect(mockCallback.mock.calls.length).toBe(1)
       cleanUp()
+      wrapper.detach()
       done()
     }, MODAL_TEST_TIMEOUT)
   })

--- a/src/components/Portal/tests/Portal.test.js
+++ b/src/components/Portal/tests/Portal.test.js
@@ -2,6 +2,9 @@ import React from 'react'
 import { mount } from 'enzyme'
 import Portal from '..'
 
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000
+const PORTAL_TEST_TIMEOUT = 300
+
 const cleanUp = (wrapper) => {
   if (wrapper) wrapper.unmount()
   global.document.body.innerHTML = ''
@@ -37,7 +40,7 @@ test('Is removed from the body on unmount', (done) => {
     expect(document.getElementsByClassName('brick').length).toBe(0)
     cleanUp()
     done()
-  }, 10)
+  }, PORTAL_TEST_TIMEOUT)
 })
 
 test('Can add custom className', () => {
@@ -171,8 +174,6 @@ describe('renderTo', () => {
 })
 
 describe('Events', () => {
-  jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
-
   test('onBeforeOpen callback works', () => {
     const mockCallback = jest.fn()
     const onBeforeOpen = (open) => {
@@ -242,7 +243,7 @@ describe('Events', () => {
       expect(mockCallback.mock.calls.length).toBe(1)
       cleanUp()
       done()
-    }, 100)
+    }, PORTAL_TEST_TIMEOUT)
   })
 
   test('onClose callback works', (done) => {
@@ -262,7 +263,7 @@ describe('Events', () => {
       expect(mockCallback.mock.calls.length).toBe(1)
       cleanUp()
       done()
-    }, 100)
+    }, PORTAL_TEST_TIMEOUT)
   })
 
   test('onBeforeClose + onClose callback works', (done) => {
@@ -287,6 +288,6 @@ describe('Events', () => {
       expect(mockCallback.mock.calls.length).toBe(2)
       cleanUp()
       done()
-    }, 100)
+    }, PORTAL_TEST_TIMEOUT)
   })
 })

--- a/src/components/Portal/tests/Portal.test.js
+++ b/src/components/Portal/tests/Portal.test.js
@@ -87,9 +87,9 @@ describe('renderTo', () => {
     expect(custom).toContain('champ')
     expect(custom).toContain('BRICK')
 
+    wrapper.unmount()
     wrapper.detach()
-    global.document.body.removeChild(testBody)
-    global.document.body.innerHTML = ''
+    cleanUp()
   })
 
   test('Can render to custom DOM element, if specified', () => {
@@ -111,9 +111,9 @@ describe('renderTo', () => {
     expect(body).toContain('champ')
     expect(body).toContain('BRICK')
 
+    wrapper.unmount()
     wrapper.detach()
-    global.document.body.removeChild(testBody)
-    global.document.body.innerHTML = ''
+    cleanUp()
   })
 
   test('Can render to Portal.Container, if exists', () => {
@@ -138,9 +138,9 @@ describe('renderTo', () => {
     expect(custom).toContain('champ')
     expect(custom).toContain('BRICK')
 
+    wrapper.unmount()
     wrapper.detach()
-    global.document.body.removeChild(testBody)
-    global.document.body.innerHTML = ''
+    cleanUp()
   })
 
   test('Fallsback to document.body if custom selector doesn\'t exist', () => {
@@ -167,9 +167,9 @@ describe('renderTo', () => {
     expect(portal).toBeTruthy()
     expect(portal.innerHTML).toContain('BRICK')
 
+    wrapper.unmount()
     wrapper.detach()
-    global.document.body.removeChild(testBody)
-    global.document.body.innerHTML = ''
+    cleanUp()
   })
 })
 
@@ -237,11 +237,12 @@ describe('Events', () => {
       </Portal>
     , { attachTo: testBody })
 
-    wrapper.detach()
+    wrapper.unmount()
 
     setTimeout(() => {
       expect(mockCallback.mock.calls.length).toBe(1)
       cleanUp()
+      wrapper.detach()
       done()
     }, PORTAL_TEST_TIMEOUT)
   })
@@ -257,11 +258,12 @@ describe('Events', () => {
       </Portal>
     , { attachTo: testBody })
 
-    wrapper.detach()
+    wrapper.unmount()
 
     setTimeout(() => {
       expect(mockCallback.mock.calls.length).toBe(1)
       cleanUp()
+      wrapper.detach()
       done()
     }, PORTAL_TEST_TIMEOUT)
   })
@@ -282,10 +284,11 @@ describe('Events', () => {
       </Portal>
     , { attachTo: testBody })
 
-    wrapper.detach()
+    wrapper.unmount()
 
     setTimeout(() => {
       expect(mockCallback.mock.calls.length).toBe(2)
+      wrapper.detach()
       cleanUp()
       done()
     }, PORTAL_TEST_TIMEOUT)


### PR DESCRIPTION
## Extend timeout values for Portal.test.js

Extending times from `100ms` to `300ms`. Ideally, we wouldn't use timeouts for these. Maybe there's an enzyme hook I can tap into to test mount/unmount related things?

It's tricky though, since these tests check for `document` related things, outside of the `Portal` react component.