### PR TITLE
Add hint text to input component

### DIFF
--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -29,6 +29,7 @@ An Input component is an enhanced version of the default HTML `<input>`. Input c
 | className | string | Custom class names to be added to the component. |
 | disabled | boolean | Disable the input. |
 | helpText | string | Displays text underneath input. |
+| hintText | string | Displays text above input. |
 | id | string | ID for the input. |
 | label | string | Label for the input. |
 | multiline | boolean or number | Transforms input into an auto-expanding textarea. |

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -14,6 +14,7 @@ export const propTypes = {
   autoFocus: PropTypes.bool,
   className: PropTypes.string,
   disabled: PropTypes.bool,
+  hintText: PropTypes.string,
   helpText: PropTypes.string,
   id: PropTypes.string,
   label: PropTypes.string,
@@ -78,6 +79,7 @@ class Input extends Component {
       className,
       disabled,
       helpText,
+      hintText,
       id,
       inputRef,
       label,
@@ -153,6 +155,12 @@ class Input extends Component {
       </HelpText>
       : null
 
+    const hintTextMarkup = hintText
+      ? <HelpText state={state}>
+        {hintText}
+      </HelpText>
+      : null
+
     const inputElement = React.createElement(multiline ? 'textarea' : 'input', {
       ...rest,
       className: fieldClassName,
@@ -174,6 +182,7 @@ class Input extends Component {
     return (
       <div className='c-InputWrapper'>
         {labelMarkup}
+        {hintTextMarkup}
         <div className={componentClassName}>
           {prefixMarkup}
           {inputElement}

--- a/src/components/Input/tests/Input.test.js
+++ b/src/components/Input/tests/Input.test.js
@@ -163,6 +163,24 @@ describe('Multiline', () => {
   })
 })
 
+describe('HelpText', () => {
+  test('Adds helpText if specified', () => {
+    const wrapper = mount(<Input helpText='Help text' />)
+    const helpText = wrapper.find('div').last()
+    expect(helpText.exists()).toBeTruthy()
+    expect(helpText.text()).toBe('Help text')
+  })
+})
+
+describe('HintText', () => {
+  test('Adds hintText if specified', () => {
+    const wrapper = mount(<Input hintText='Hint text' />)
+    const hintText = wrapper.find('div').first()
+    expect(hintText.exists()).toBeTruthy()
+    expect(hintText.text()).toBe('Hint text')
+  })
+})
+
 describe('Label', () => {
   test('Adds label if specified', () => {
     const wrapper = mount(<Input label='Channel' />)

--- a/stories/Input.js
+++ b/stories/Input.js
@@ -4,6 +4,8 @@ import { Input } from '../src/index.js'
 
 storiesOf('Input', module)
   .add('default', () => <Input />)
+  .add('helptext', () => <Input helpText="This text appears below the input" />)
+  .add('hinttext', () => <Input hintText="This text appears above the input" />)
   .add('multiline', () => <Input multiline placeholder='This is a textarea!' autoFocus />)
   .add('multiline + resizable', () => <Input multiline={3} resizable autoFocus placeholder='This is a resizable textarea!' />)
   .add('label', () => <Input label='Labelled' autoFocus />)
@@ -15,7 +17,7 @@ storiesOf('Input', module)
   .add('states', () => (
     <div>
       <Input state='error' autoFocus /><br />
-      <Input state='success' helpText="You're Awesome!" autoFocus /><br />
+      <Input state='success' helpText="You're Awesome!" hintText="You're awesome!" autoFocus /><br />
       <Input state='warning' autoFocus />
     </div>
   ))


### PR DESCRIPTION
It may be desirable to have text appear above and/or below the input but currently it is only possible to configure the input to have text appear below it via the `helpText` prop.

This PR adds a `hintText` prop that can be used to configure the input to have text appear above it, as shown below.

![Screenshot](https://d1ax1i5f2y3x71.cloudfront.net/items/3i2H212B2q2o1O2L3l28/Image%202017-10-02%20at%204.59.23%20PM.png?X-CloudApp-Visitor-Id=2338876&v=9211b72f)