### PR TITLE
Resolve Blue dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,13 @@
   "dependencies": {
     "@shopify/javascript-utilities": "2.0.0",
     "lodash.includes": "4.3.0",
+    "object-assign": "4.1.1",
+    "emoji-mart": "^1.0.1",
     "react-router-dom": "^4",
-    "react-transition-group": "2.2.0"
+    "react-sortable-hoc": "^0.6.7",
+    "react-transition-group": "2.2.0",
+    "promise": "7.1.1",
+    "whatwg-fetch": "2.0.3"
   },
   "devDependencies": {
     "@storybook/addon-options": "^3.2.4",
@@ -60,7 +65,6 @@
     "coveralls": "2.13.1",
     "css-loader": "0.28.4",
     "dotenv": "4.0.0",
-    "emoji-mart": "^1.0.1",
     "enzyme": "2.9.1",
     "eslint": "3.19.0",
     "eslint-config-react-app": "^1.0.5",
@@ -80,11 +84,9 @@
     "node-sass": "4.5.3",
     "np": "2.16.0",
     "nyc": "11.1.0",
-    "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.0.0",
     "postcss-loader": "2.0.6",
     "postcss-scss": "1.0.2",
-    "promise": "7.1.1",
     "raw-loader": "0.5.1",
     "react": "15.6.1",
     "react-dev-utils": "^3.0.2",
@@ -92,7 +94,6 @@
     "react-error-overlay": "^1.0.9",
     "react-router": "4.2.0",
     "react-router-dom": "4.2.2",
-    "react-sortable-hoc": "^0.6.7",
     "react-test-renderer": "15.6.1",
     "rgb-hex": "2.1.0",
     "sass-loader": "6.0.6",
@@ -117,8 +118,7 @@
     "webpack": "2.6.1",
     "webpack-dev-server": "2.5.0",
     "webpack-manifest-plugin": "1.1.0",
-    "webpack-node-externals": "1.6.0",
-    "whatwg-fetch": "2.0.3"
+    "webpack-node-externals": "1.6.0"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
Move project dependencies to dependencies instead of devDependencies.
Some of these items are used by polyfill.js (by create-react-app).

Others are being used by Blue components.

Spotted by @lgariepy 