### PR TITLE
Prevent default on SidebarCollapsibleCard link click

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea/

--- a/src/components/SidebarCollapsibleCard/index.js
+++ b/src/components/SidebarCollapsibleCard/index.js
@@ -39,7 +39,8 @@ class SidebarCollapsibleCard extends Component {
     }
   }
 
-  handleToggleOpen () {
+  handleToggleOpen (e) {
+    e.preventDefault()
     this.setState({ isOpen: !this.state.isOpen })
   }
 

--- a/src/components/SidebarCollapsibleCard/index.js
+++ b/src/components/SidebarCollapsibleCard/index.js
@@ -40,7 +40,7 @@ class SidebarCollapsibleCard extends Component {
   }
 
   handleToggleOpen (e) {
-    e.preventDefault()
+    e && e.preventDefault()
     this.setState({ isOpen: !this.state.isOpen })
   }
 


### PR DESCRIPTION
Currently, when I click on the toggle on the `SidebarCollapsibleCard` component, the browser navigates to "#". This is a quick fix to prevent that behavior.

I also added a new line to .gitignore, for those of us who are using PHPStorm (me 😄 )