### PR TITLE
Add scrollableRef to Scrollable and Modal

### DIFF
--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -26,11 +26,13 @@ A Modal component presents content within a container on top of the application'
 
 | Prop | Type | Description |
 | --- | --- | --- |
+| onScroll | function | Callback function when inner Scrollable is scrolled. |
 | className | string | Custom class names to be added to the component. |
 | closeIcon | boolean | Shows/hides the component's close icon UI. |
 | exact | boolean | Used with `path` and React Router. Renders if path matches _exactly_ |
 | isOpen | boolean | Shows/hides the component. |
 | path | string | Renders component based on a [React Router path](https://reacttraining.com/react-router/web/api/Route/path-string). |
+| scrollableRef | function | Retrieves the scrollable node. |
 | trigger | element | The UI the user clicks to trigger the modal. |
 
 

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -7,16 +7,21 @@ import Overlay from '../Overlay'
 import PortalWrapper from '../PortalWrapper'
 import Scrollable from '../Scrollable'
 import classNames from '../../utilities/classNames'
+import { noop } from '../../utilities/other'
 import { propTypes as portalTypes } from '../Portal'
 
 export const propTypes = Object.assign({}, portalTypes, {
   closeIcon: PropTypes.bool,
+  scrollableRef: PropTypes.func,
+  onScroll: PropTypes.func,
   trigger: PropTypes.element
 })
 
 const defaultProps = {
   closeIcon: true,
-  isOpen: false
+  isOpen: false,
+  onScroll: noop,
+  scrollableRef: noop
 }
 
 const modalBaseZIndex = 1040
@@ -36,9 +41,11 @@ const Modal = props => {
     isOpen,
     openPortal,
     onClose,
+    onScroll,
     path,
     portalIsOpen,
     portalIsMounted,
+    scrollableRef,
     style,
     timeout,
     trigger,
@@ -68,7 +75,13 @@ const Modal = props => {
         <Animate sequence='fadeIn down' in={portalIsOpen} wait={300}>
           <Card seamless>
             {closeMarkup}
-            <Scrollable fade rounded className='c-Modal__scrollable'>
+            <Scrollable
+              className='c-Modal__scrollable'
+              fade
+              rounded
+              onScroll={onScroll}
+              scrollableRef={scrollableRef}
+            >
               {children}
             </Scrollable>
           </Card>

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -1,11 +1,13 @@
-import React from 'react'
+import React, {PureComponent as Component} from 'react'
 import { shallow, mount } from 'enzyme'
-import Modal from '..'
+import { default as Modal, ModalComponent } from '..'
 import Portal from '../../Portal'
+import Scrollable from '../../Scrollable'
 import Keys from '../../../constants/Keys'
 import { MemoryRouter as Router } from 'react-router'
 
 const MODAL_TEST_TIMEOUT = 500
+
 const cleanUp = (wrapper) => {
   if (wrapper) wrapper.unmount()
   global.document.body.innerHTML = ''
@@ -278,5 +280,40 @@ describe('PortalWrapper', () => {
       wrapper.detach()
       done()
     }, MODAL_TEST_TIMEOUT)
+  })
+})
+
+describe('Integration: Scrollable', () => {
+  class MyComponent extends Component {
+    constructor () {
+      super()
+      this.scrollable = null
+    }
+    render () {
+      return (
+        <ModalComponent
+          scrollableRef={node => { this.scrollable = node }}
+          {...this.props}
+        />
+      )
+    }
+  }
+
+  test('Can pass scrollableRef to parent', () => {
+    const wrapper = mount(<MyComponent />)
+    const n = wrapper.find('.c-Scrollable__content').node
+    const o = wrapper.instance()
+
+    expect(o.scrollable).toBe(n)
+  })
+
+  test('Can fire onScroll callback', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<MyComponent onScroll={spy} />)
+    const o = wrapper.find(Scrollable)
+
+    o.node.props.onScroll()
+
+    expect(spy).toHaveBeenCalled()
   })
 })

--- a/src/components/Scrollable/README.md
+++ b/src/components/Scrollable/README.md
@@ -22,3 +22,4 @@ A Scrollable component is light-weight wrapper that enables scrolling for conten
 | className | string | Custom class names to be added to the component. |
 | fade | boolean | Adds a "fade-to-white" visual experience while scrolling. |
 | rounded | boolean | Enables rounded corners for the top fade element. |
+| scrollableRef | function | Retrieves the scrollable node. |

--- a/src/components/Scrollable/index.js
+++ b/src/components/Scrollable/index.js
@@ -7,10 +7,12 @@ export const propTypes = {
   className: PropTypes.string,
   fade: PropTypes.bool,
   onScroll: PropTypes.func,
-  rounded: PropTypes.bool
+  rounded: PropTypes.bool,
+  scrollableRef: PropTypes.func
 }
 const defaultProps = {
-  onScroll: noop
+  onScroll: noop,
+  scrollableRef: noop
 }
 
 class Scrollable extends Component {
@@ -31,6 +33,7 @@ class Scrollable extends Component {
       fade,
       onScroll,
       rounded,
+      scrollableRef,
       ...rest
     } = this.props
 
@@ -50,7 +53,11 @@ class Scrollable extends Component {
     return (
       <div className={componentClassName} {...rest}>
         {fadeMarkup}
-        <div className='c-Scrollable__content' onScroll={handleOnScroll}>
+        <div
+          className='c-Scrollable__content'
+          onScroll={handleOnScroll}
+          ref={scrollableRef}
+        >
           {children}
         </div>
       </div>

--- a/src/components/Scrollable/tests/Scrollable.test.js
+++ b/src/components/Scrollable/tests/Scrollable.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {PureComponent as Component} from 'react'
 import { mount, shallow } from 'enzyme'
 import Scrollable from '..'
 
@@ -54,5 +54,29 @@ describe('Events', () => {
     o.handleOnScroll()
 
     expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('scrollableRef', () => {
+  class MyComponent extends Component {
+    constructor () {
+      super()
+      this.scrollable = null
+    }
+    render () {
+      return (
+        <Scrollable
+          scrollableRef={node => { this.scrollable = node }}
+        />
+      )
+    }
+  }
+
+  test('Can pass scrollableRef to parent', () => {
+    const wrapper = mount(<MyComponent />)
+    const n = wrapper.find('.c-Scrollable__content').node
+    const o = wrapper.instance()
+
+    expect(o.scrollable).toBe(n)
   })
 })

--- a/src/utilities/node.js
+++ b/src/utilities/node.js
@@ -3,7 +3,11 @@ import { isNodeEnv } from './other'
 export const Element = window.Element
 
 export const isNodeElement = (node) => {
-  return node && (node instanceof Element || node === document)
+  return node && (
+    node instanceof Element ||
+    node.nodeType === 1 || // Thanks Brett! <3
+    node === document
+  )
 }
 
 export const getNodeScope = (nodeScope) => {

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { storiesOf } from '@storybook/react'
-import { Heading, Modal, Link, Scrollable } from '../src/index.js'
+import { Heading, Modal, Link } from '../src/index.js'
 import { MemoryRouter } from 'react-router'
 import { Route } from 'react-router-dom'
 

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -34,33 +34,6 @@ storiesOf('Modal', module)
       </div>
     </Modal>
   ))
-  .add('custom Scrollable', () => (
-    <Modal trigger={<Link>Open dis modal</Link>}>
-      <Scrollable>
-        <div>
-          <Heading>Title</Heading>
-          <p>
-            Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-          </p>
-          <p>
-            Tenderloin bacon chicken jowl cupim, sausage shank spare ribs kielbasa. Flank corned beef kevin pastrami short ribs pork andouille turkey sirloin strip steak. Shank tri-tip porchetta beef ribs salami. Pork chop tail kielbasa, turkey pork loin filet mignon chicken jowl alcatra hamburger salami cupim.
-          </p>
-          <p>
-            Corned beef pork belly cupim turkey, filet mignon bresaola short ribs sirloin brisket. Fatback turkey strip steak tenderloin pig ham hock salami cow filet mignon ribeye. Brisket drumstick capicola rump. Biltong jowl prosciutto fatback bresaola strip steak pork chop shankle tri-tip shank salami pancetta ham hock. Cupim kielbasa doner salami, meatball capicola filet mignon pastrami.
-          </p>
-          <p>
-            Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-          </p>
-          <p>
-            Tenderloin bacon chicken jowl cupim, sausage shank spare ribs kielbasa. Flank corned beef kevin pastrami short ribs pork andouille turkey sirloin strip steak. Shank tri-tip porchetta beef ribs salami. Pork chop tail kielbasa, turkey pork loin filet mignon chicken jowl alcatra hamburger salami cupim.
-          </p>
-          <p>
-            Corned beef pork belly cupim turkey, filet mignon bresaola short ribs sirloin brisket. Fatback turkey strip steak tenderloin pig ham hock salami cow filet mignon ribeye. Brisket drumstick capicola rump. Biltong jowl prosciutto fatback bresaola strip steak pork chop shankle tri-tip shank salami pancetta ham hock. Cupim kielbasa doner salami, meatball capicola filet mignon pastrami.
-          </p>
-        </div>
-      </Scrollable>
-    </Modal>
-  ))
   .add('open', () => (
     <Modal isOpen trigger={<Link>Clicky</Link>}>
       <div>

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { storiesOf } from '@storybook/react'
-import { Heading, Modal, Link } from '../src/index.js'
+import { Heading, Modal, Link, Scrollable } from '../src/index.js'
 import { MemoryRouter } from 'react-router'
 import { Route } from 'react-router-dom'
 
@@ -32,6 +32,33 @@ storiesOf('Modal', module)
           Corned beef pork belly cupim turkey, filet mignon bresaola short ribs sirloin brisket. Fatback turkey strip steak tenderloin pig ham hock salami cow filet mignon ribeye. Brisket drumstick capicola rump. Biltong jowl prosciutto fatback bresaola strip steak pork chop shankle tri-tip shank salami pancetta ham hock. Cupim kielbasa doner salami, meatball capicola filet mignon pastrami.
         </p>
       </div>
+    </Modal>
+  ))
+  .add('custom Scrollable', () => (
+    <Modal trigger={<Link>Open dis modal</Link>}>
+      <Scrollable>
+        <div>
+          <Heading>Title</Heading>
+          <p>
+            Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
+          </p>
+          <p>
+            Tenderloin bacon chicken jowl cupim, sausage shank spare ribs kielbasa. Flank corned beef kevin pastrami short ribs pork andouille turkey sirloin strip steak. Shank tri-tip porchetta beef ribs salami. Pork chop tail kielbasa, turkey pork loin filet mignon chicken jowl alcatra hamburger salami cupim.
+          </p>
+          <p>
+            Corned beef pork belly cupim turkey, filet mignon bresaola short ribs sirloin brisket. Fatback turkey strip steak tenderloin pig ham hock salami cow filet mignon ribeye. Brisket drumstick capicola rump. Biltong jowl prosciutto fatback bresaola strip steak pork chop shankle tri-tip shank salami pancetta ham hock. Cupim kielbasa doner salami, meatball capicola filet mignon pastrami.
+          </p>
+          <p>
+            Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
+          </p>
+          <p>
+            Tenderloin bacon chicken jowl cupim, sausage shank spare ribs kielbasa. Flank corned beef kevin pastrami short ribs pork andouille turkey sirloin strip steak. Shank tri-tip porchetta beef ribs salami. Pork chop tail kielbasa, turkey pork loin filet mignon chicken jowl alcatra hamburger salami cupim.
+          </p>
+          <p>
+            Corned beef pork belly cupim turkey, filet mignon bresaola short ribs sirloin brisket. Fatback turkey strip steak tenderloin pig ham hock salami cow filet mignon ribeye. Brisket drumstick capicola rump. Biltong jowl prosciutto fatback bresaola strip steak pork chop shankle tri-tip shank salami pancetta ham hock. Cupim kielbasa doner salami, meatball capicola filet mignon pastrami.
+          </p>
+        </div>
+      </Scrollable>
     </Modal>
   ))
   .add('open', () => (


### PR DESCRIPTION
## Add scrollableRef to Scrollable and Modal

* Add `scrollableRef` prop to Scrollable and Modal to expose the scrollable DOM node
* Add `onScroll` callback for Modal
* Make `isNodeElement()` util more robust