### PR TITLE
Modal: Fix Scrollable padding within a Modal

### DIFF
--- a/src/styles/components/Modal.scss
+++ b/src/styles/components/Modal.scss
@@ -26,7 +26,9 @@
   }
 
   &__scrollable {
-    padding: 20px;
+    .c-Scrollable__content {
+      padding: 20px;
+    }
   }
 
   &__close {


### PR DESCRIPTION
This update adds padding to the correct selector (`.c-Scrollable__content`) instead of `.c-Scrollable`.