### PR TITLE
Card: Integrate Link component for href/to props

### DIFF
--- a/src/components/Card/Block.js
+++ b/src/components/Card/Block.js
@@ -1,15 +1,23 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import classNames from '../../utilities/classNames'
 import Scrollable from '../Scrollable'
+import classNames from '../../utilities/classNames'
+import { noop } from '../../utilities/other'
 import { standardSizeTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   bgMuted: PropTypes.bool,
   className: PropTypes.string,
   scrollable: PropTypes.bool,
+  scrollableRef: PropTypes.func,
+  onScroll: PropTypes.func,
   flex: PropTypes.bool,
   size: standardSizeTypes
+}
+
+const defaultProps = {
+  onScroll: noop,
+  scrollableRef: noop
 }
 
 const Block = props => {
@@ -17,7 +25,9 @@ const Block = props => {
     bgMuted,
     className,
     children,
+    onScroll,
     scrollable,
+    scrollableRef,
     flex,
     size,
     ...rest
@@ -39,21 +49,26 @@ const Block = props => {
     scrollable && 'is-scrollable'
   )
 
-  const blockMarkup = scrollable ? (
-    <Scrollable className={scrollableClassName}>
-      <div className={componentClassName} {...rest}>
-        {children}
-      </div>
-    </Scrollable>
-  ) : (
+  const contentMarkup = (
     <div className={componentClassName} {...rest}>
       {children}
     </div>
   )
 
-  return blockMarkup
+  const componentMarkup = scrollable ? (
+    <Scrollable
+      className={scrollableClassName}
+      onScroll={onScroll}
+      scrollableRef={scrollableRef}
+    >
+      {contentMarkup}
+    </Scrollable>
+  ) : contentMarkup
+
+  return componentMarkup
 }
 
 Block.propTypes = propTypes
+Block.defaultProps = defaultProps
 
 export default Block

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -2,59 +2,9 @@
 
 A Card component is used to encapsulate pieces of UI that share a common concept or action.
 
+## Components
 
-### Example
+The Card component is comprised of smaller components:
 
-```html
-<Card>
-  You're my boy, Blue!
-</Card>
-```
-
-### Props
-
-| Prop | Type | Description |
-| --- | --- | --- |
-| borderless | boolean | Removes the border from the component. |
-| onBlur | function | Callback when the component is blurred. |
-| onClick | boolean or function | Callback when the component is clicked. |
-| onFocus | function | Callback when the component is focused. |
-| className | string | Custom class names to be added to the component. |
-| flex | boolean | Adds flexbox styles to the component. |
-| hover | boolean | Adds a hover style to the component. |
-| href | string | Adds an `href` to the component. Transforms it into an `<a>` tag. |
-| seamless | boolean | Removes the padding within the component. |
-| selector | string | Determines the HTML tag for the component. Default is `div`. |
-
-
-
-## Card.Block
-
-A Card.Block component is used to section content within a [`<Card>`](../Card).
-
-Note: It is highly recommended the `seamless` prop is used for the container `<Card>`. This allows for the `<Card.Block>` components to flow all the way to the inner-edges of `<Card>`.
-
-
-### Example
-
-```html
-<Card seamless>
-  <Card.Block>
-    Frank "The Tank"
-  </Card.Block>
-  <Card.Block>
-    You're my boy, Blue!
-  </Card.Block>
-</Card>
-```
-
-
-### Props
-
-| Prop | Type | Description |
-| --- | --- | --- |
-| bgMuted | boolean | Applies a muted background to the component. |
-| className | string | Custom class names to be added to the component. |
-| flex | boolean | Adds flexbox styles to the component. |
-| scrollable | boolean | Integrates [Scrollable](../Scrollable) into the component. |
-| size | string | Adjusts the size of the component. Default is `md`. |
+* [Card](./docs/Card.md)
+* [Block](./docs/Block.md)

--- a/src/components/Card/docs/Block.md
+++ b/src/components/Card/docs/Block.md
@@ -23,8 +23,10 @@ Note: It is highly recommended the `seamless` prop is used for the container `<C
 
 | Prop | Type | Description |
 | --- | --- | --- |
+| onScroll | function | Callback function when inner Scrollable is scrolled. |
 | bgMuted | boolean | Applies a muted background to the component. |
 | className | string | Custom class names to be added to the component. |
 | flex | boolean | Adds flexbox styles to the component. |
 | scrollable | boolean | Integrates [Scrollable](../Scrollable) into the component. |
+| scrollableRef | function | Retrieves the scrollable node. |
 | size | string | Adjusts the size of the component. Default is `md`. |

--- a/src/components/Card/docs/Block.md
+++ b/src/components/Card/docs/Block.md
@@ -1,0 +1,30 @@
+## Card.Block
+
+A Card.Block component is used to section content within a [`<Card>`](../Card).
+
+Note: It is highly recommended the `seamless` prop is used for the container `<Card>`. This allows for the `<Card.Block>` components to flow all the way to the inner-edges of `<Card>`.
+
+
+## Example
+
+```html
+<Card seamless>
+  <Card.Block>
+    Frank "The Tank"
+  </Card.Block>
+  <Card.Block>
+    You're my boy, Blue!
+  </Card.Block>
+</Card>
+```
+
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| bgMuted | boolean | Applies a muted background to the component. |
+| className | string | Custom class names to be added to the component. |
+| flex | boolean | Adds flexbox styles to the component. |
+| scrollable | boolean | Integrates [Scrollable](../Scrollable) into the component. |
+| size | string | Adjusts the size of the component. Default is `md`. |

--- a/src/components/Card/docs/Card.md
+++ b/src/components/Card/docs/Card.md
@@ -30,12 +30,10 @@ If a `to` or `href` prop is passed into the Card component, it will render the [
 | onBlur | function | Callback when the component is blurred. |
 | onClick | boolean or function | Callback when the component is clicked. |
 | onFocus | function | Callback when the component is focused. |
-| onScroll | function | Callback function when inner Scrollable is scrolled. |
 | borderless | boolean | Removes the border from the component. |
 | className | string | Custom class names to be added to the component. |
 | flex | boolean | Adds flexbox styles to the component. |
 | hover | boolean | Adds a hover style to the component. |
 | href | string | Adds an `href` to the component. Transforms it into an `<a>` tag. |
-| scrollableRef | function | Retrieves the scrollable node. |
 | seamless | boolean | Removes the padding within the component. |
 | selector | string | Determines the HTML tag for the component. Default is `div`. |

--- a/src/components/Card/docs/Card.md
+++ b/src/components/Card/docs/Card.md
@@ -1,0 +1,41 @@
+# Card
+
+A Card component is used to encapsulate pieces of UI that share a common concept or action.
+
+
+## Example
+
+```html
+<Card>
+  You're my boy, Blue!
+</Card>
+```
+
+
+## Link
+
+If a `to` or `href` prop is passed into the Card component, it will render the [Link](../../../Link) component, which provides additional link-based props.
+
+```html
+<Card href='https://www.helpscout.net/'>
+  You're my boy, Blue!
+</Card>
+```
+
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| onBlur | function | Callback when the component is blurred. |
+| onClick | boolean or function | Callback when the component is clicked. |
+| onFocus | function | Callback when the component is focused. |
+| onScroll | function | Callback function when inner Scrollable is scrolled. |
+| borderless | boolean | Removes the border from the component. |
+| className | string | Custom class names to be added to the component. |
+| flex | boolean | Adds flexbox styles to the component. |
+| hover | boolean | Adds a hover style to the component. |
+| href | string | Adds an `href` to the component. Transforms it into an `<a>` tag. |
+| scrollableRef | function | Retrieves the scrollable node. |
+| seamless | boolean | Removes the padding within the component. |
+| selector | string | Determines the HTML tag for the component. Default is `div`. |

--- a/src/components/Card/docs/Card.md
+++ b/src/components/Card/docs/Card.md
@@ -14,7 +14,7 @@ A Card component is used to encapsulate pieces of UI that share a common concept
 
 ## Link
 
-If a `to` or `href` prop is passed into the Card component, it will render the [Link](../../../Link) component, which provides additional link-based props.
+If a `to` or `href` prop is passed into the Card component, it will render the [Link](../../Link) component, which provides additional link-based props.
 
 ```html
 <Card href='https://www.helpscout.net/'>

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { default as Link, propTypes as linkPropTypes } from '../Link'
+import Block from './Block'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 import { blockSelectorTagTypes } from '../../constants/propTypes'
-import Block from './Block'
 
-export const propTypes = {
+export const propTypes = Object.assign({}, linkPropTypes, {
   borderless: PropTypes.bool,
   className: PropTypes.string,
   floating: PropTypes.bool,
@@ -13,16 +14,16 @@ export const propTypes = {
   hover: PropTypes.bool,
   href: PropTypes.string,
   onBlur: PropTypes.func,
-  onClick: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+  onClick: PropTypes.func,
   onFocus: PropTypes.func,
   seamless: PropTypes.bool,
   selector: blockSelectorTagTypes
-}
+})
 
 const defaultProps = {
   hover: false,
   onBlur: noop,
-  onClick: false,
+  onClick: noop,
   onFocus: noop,
   seamless: false,
   selector: 'div'
@@ -40,13 +41,16 @@ const Card = props => {
     onClick,
     seamless,
     selector,
+    to,
     ...rest
   } = props
 
+  const hasOnClick = onClick !== noop
+
   const componentClassName = classNames(
     'c-Card',
-    (onClick || href) && 'is-clickable',
-    (onClick || hover || href) && 'is-hoverable',
+    (hasOnClick || href || to) && 'is-clickable',
+    (hasOnClick || hover || href || to) && 'is-hoverable',
     borderless && 'is-borderless',
     floating && 'is-floating',
     flex && 'is-flex',
@@ -54,10 +58,18 @@ const Card = props => {
     className
   )
 
-  const selectorTag = href ? 'a' : selector
-
-  const element = React.createElement(
-    selectorTag,
+  const element = href || to ? (
+    <Link
+      block
+      className={componentClassName}
+      href={href}
+      to={to}
+      {...rest}
+    >
+      {children}
+    </Link>
+  ) : React.createElement(
+    selector,
     {
       ...rest,
       className: componentClassName,

--- a/src/components/Card/tests/Card.Block.test.js
+++ b/src/components/Card/tests/Card.Block.test.js
@@ -7,13 +7,13 @@ describe('ClassName', () => {
   test('Has default className', () => {
     const wrapper = shallow(<CardBlock />)
 
-    expect(wrapper.prop('className')).toBe('c-Card__block')
+    expect(wrapper.hasClass('c-Card__block')).toBeTruthy()
   })
 
   test('Accepts custom className', () => {
     const wrapper = shallow(<CardBlock className='not-metro-man' />)
 
-    expect(wrapper.prop('className')).toContain('not-metro-man')
+    expect(wrapper.hasClass('not-metro-man')).toBeTruthy()
   })
 })
 
@@ -25,31 +25,27 @@ describe('Content', () => {
   })
 
   test('Render child components', () => {
-    const wrapper = mount(
+    const wrapper = shallow(
       <CardBlock className='mega'>
         <CardBlock className='mind'>
           Megamind
         </CardBlock>
       </CardBlock>
     )
+    const o = wrapper.find('.mind')
 
-    const innerCardBlock = wrapper.childAt(0)
-
-    expect(innerCardBlock.exists()).toBeTruthy()
-    expect(innerCardBlock.prop('className')).toContain('mind')
-    expect(innerCardBlock.text()).toBe('Megamind')
+    expect(o.length).toBeTruthy()
   })
 })
 
 describe('Click', () => {
   test('Can trigger onClick callback', () => {
-    let value = false
-    const onClick = () => { value = true }
-    const wrapper = shallow(<CardBlock onClick={onClick} />)
+    const spy = jest.fn()
+    const wrapper = shallow(<CardBlock onClick={spy} />)
 
     wrapper.simulate('click')
 
-    expect(value).toBeTruthy()
+    expect(spy).toHaveBeenCalled()
   })
 })
 
@@ -62,16 +58,12 @@ describe('Scrollable', () => {
   })
 
   test('Renders Scrollable if specified', () => {
-    const wrapper = mount(<CardBlock scrollable />)
+    const wrapper = shallow(<CardBlock scrollable />)
     const o = wrapper.find(Scrollable)
-    const n = wrapper.find('.c-Card__block')
 
     expect(o.length).toBe(1)
     expect(o.hasClass('c-Card__block')).toBeTruthy()
     expect(o.hasClass('is-scrollable')).toBeTruthy()
-    expect(n.length).toBe(2)
-
-    wrapper.unmount()
   })
 
   test('Renders Scrollable with flex if specified', () => {
@@ -81,6 +73,23 @@ describe('Scrollable', () => {
     expect(o.length).toBe(1)
     expect(o.hasClass('is-scrollable')).toBeTruthy()
     expect(o.hasClass('is-flex')).toBeTruthy()
+  })
+
+  test('Can fire onScroll callback, if specified', () => {
+    const spy = jest.fn()
+    const wrapper = shallow(<CardBlock scrollable onScroll={spy} />)
+    const o = wrapper.find(Scrollable)
+
+    o.node.props.onScroll()
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('Can retreive scrollableRef', () => {
+    const spy = jest.fn()
+    mount(<CardBlock scrollable scrollableRef={spy} />)
+
+    expect(spy).toHaveBeenCalled()
   })
 })
 

--- a/src/components/Card/tests/Card.test.js
+++ b/src/components/Card/tests/Card.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { mount, shallow } from 'enzyme'
 import Card from '..'
+import Link from '../../Link'
 
 describe('ClassName', () => {
   test('Has default className', () => {
@@ -13,6 +14,45 @@ describe('ClassName', () => {
     const wrapper = shallow(<Card className='not-metro-man' />)
 
     expect(wrapper.prop('className')).toContain('not-metro-man')
+  })
+})
+
+describe('Block', () => {
+  test('Does not render a Card.Block by default', () => {
+    const wrapper = shallow(<Card />)
+    const o = wrapper.find(Card.Block)
+
+    expect(o.length).toBeFalsy()
+  })
+
+  test('Can render a Card.Block', () => {
+    const wrapper = shallow(
+      <Card>
+        <Card.Block>
+          MegaMind
+        </Card.Block>
+      </Card>
+      )
+    const o = wrapper.find(Card.Block)
+
+    expect(o.length).toBe(1)
+    expect(o.node.props.children).toBe('MegaMind')
+  })
+
+  test('Can render a multiple Card.Block', () => {
+    const wrapper = shallow(
+      <Card>
+        <Card.Block>
+          Mega
+        </Card.Block>
+        <Card.Block>
+          Mind
+        </Card.Block>
+      </Card>
+      )
+    const o = wrapper.find(Card.Block)
+
+    expect(o.length).toBe(2)
   })
 })
 
@@ -43,18 +83,56 @@ describe('Content', () => {
 describe('Link', () => {
   const link = 'https://www.helpscout.net'
 
-  test('Renders an `a` selector if href is specified', () => {
-    const wrapper = shallow(<Card href={link} />)
-
-    expect(wrapper.node.type).toBe('a')
-    expect(wrapper.prop('href')).toBe(link)
-  })
-
   test('Adds link styles if href is specified', () => {
     const wrapper = shallow(<Card href={link} />)
 
     expect(wrapper.prop('className')).toContain('is-clickable')
     expect(wrapper.prop('className')).toContain('is-hoverable')
+  })
+
+  test('Renders a Link component if href is defined', () => {
+    const wrapper = shallow(<Card href={link} />)
+    const o = wrapper.find(Link)
+
+    expect(o.length).toBe(1)
+    expect(o.node.props.block).toBeTruthy()
+    expect(o.node.props.href).toBe(link)
+  })
+
+  test('Renders a Link component if to is defined', () => {
+    const wrapper = shallow(<Card to={link} />)
+    const o = wrapper.find(Link)
+
+    expect(o.length).toBe(1)
+    expect(o.node.props.block).toBeTruthy()
+    expect(o.node.props.to).toBe(link)
+  })
+
+  test('Renders a Link component with target="_blank"', () => {
+    const wrapper = shallow(<Card href={link} external />)
+    const o = wrapper.find(Link)
+    const p = o.node.props
+
+    expect(o.length).toBe(1)
+    expect(p.block).toBeTruthy()
+    expect(p.href).toBe(link)
+    expect(p.external).toBeTruthy()
+    expect(o.html()).toContain('_blank')
+  })
+
+  test('Renders a Link, with a Card.Block child', () => {
+    const wrapper = shallow(
+      <Card href={link}>
+        <Card.Block>MegaMind</Card.Block>
+      </Card>
+    )
+    const b = wrapper.find(Card.Block)
+    const o = wrapper.find(Link)
+
+    expect(o.length).toBe(1)
+    expect(o.node.props.children.type).toBe(Card.Block)
+    expect(b.length).toBe(1)
+    expect(b.node.props.children).toBe('MegaMind')
   })
 })
 

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -5,6 +5,7 @@ import { noop } from '../../utilities/other'
 import RouteWrapper from '../RouteWrapper'
 
 export const propTypes = {
+  block: PropTypes.bool,
   className: PropTypes.string,
   external: PropTypes.bool,
   href: PropTypes.string,
@@ -23,16 +24,27 @@ const defaultProps = {
 }
 
 const Link = props => {
-  const { className, external, href, ...rest } = props
+  const {
+    block,
+    children,
+    className,
+    external,
+    href,
+    ...rest
+  } = props
 
-  const componentClassName = classNames('c-link', className)
+  const componentClassName = classNames(
+    'c-Link',
+    block && 'is-block',
+    className
+  )
 
   const target = external ? '_blank' : undefined
   const rel = external ? 'noopener noreferrer' : undefined
 
   return (
     <a className={componentClassName} target={target} rel={rel} href={href} {...rest}>
-      {props.children}
+      {children}
     </a>
   )
 }

--- a/src/components/Link/tests/Link.test.js
+++ b/src/components/Link/tests/Link.test.js
@@ -10,7 +10,7 @@ describe('ClassName', () => {
   test('Has default component className', () => {
     const wrapper = wrap(<Link />)
 
-    expect(wrapper.prop('className')).toContain('c-link')
+    expect(wrapper.prop('className')).toContain('c-Link')
   })
 
   test('Applies custom className if specified', () => {
@@ -130,5 +130,13 @@ describe('RouteWrapper', () => {
       expect(push).toHaveBeenCalledWith(to)
       done()
     })
+  })
+})
+
+describe('Styles', () => {
+  test('Sets block styles, if defined', () => {
+    const wrapper = wrap(<Link block />)
+
+    expect(wrapper.hasClass('is-block')).toBeTruthy()
   })
 })

--- a/src/styles/components/Card/Card.scss
+++ b/src/styles/components/Card/Card.scss
@@ -4,7 +4,7 @@ $seed-card-border: 1px solid rgba(_color(border, ui, dark), 0.7);
 // Import Seed Pack
 @import "pack/seed-card/_index";
 
-.c-card {
+.#{$seed-card-namespace} {
   @import "../../resets/base";
   box-shadow: #{
     0 0 0 0 rgba(black, 0)

--- a/src/styles/components/Link.scss
+++ b/src/styles/components/Link.scss
@@ -1,8 +1,14 @@
 // Config
+$seed-link-namespace: "c-Link";
 $seed-link-include-a-selector: false;
 
 @import "pack/seed-link/_index";
 
-.c-link {
+.#{seed-link-namespace} {
   @import "../resets/base";
+
+  // Modifiers
+  &.is-block {
+    display: block;
+  }
 }


### PR DESCRIPTION
## Card: Integrate Link component for href/to props

### Updates

This update enhances the Card component to render a Link component if href/to is provided. This allows for Card to use react-router, if needed.

Card.Block has also been enhanced with the new Scrollable props, specificaly scrollableRef and onScroll.

Lastly, the Link component receives a new prop (`block`), that provides it with the ability to render as `display: block`.

### Bug fixes
* Card CSS className has been resolved
* Link c-link has been renamed to c-Link