### PR TITLE
Card: Link variant has a background-color

### DIFF
--- a/src/styles/components/Card/Card.scss
+++ b/src/styles/components/Card/Card.scss
@@ -6,15 +6,22 @@ $seed-card-border: 1px solid rgba(_color(border, ui, dark), 0.7);
 
 .#{$seed-card-namespace} {
   @import "../../resets/base";
+  $background-color: white;
+
   box-shadow: #{
     0 0 0 0 rgba(black, 0)
     };
+  background-color: $background-color;
   color: currentColor;
   display: block;
   padding: 16px;
   text-decoration: none;
 
   // Modifiers
+  &.c-Link {
+    background-color: $background-color;
+  }
+
   &.is-borderless {
     border: none;
   }


### PR DESCRIPTION
## Card: Link variant has a background-color

This update ensures that went the Card component becomes a wrapper for Link, that it has a background-color.

Previously, the CSS for Link was reseting the background-color to transparent.