### PR TITLE
SidebarCollapsibleCard: Improve Sortable interactions

### DIFF
--- a/src/components/Collapsible/README.md
+++ b/src/components/Collapsible/README.md
@@ -18,6 +18,8 @@ A Collapsible component provides content with the ability to collapse or expand.
 | --- | --- | --- |
 | className | string | Custom class names to be added to the component. |
 | duration | number | Time (ms) for the expand/collapse animation. |
+| durationOpen | number | Time (ms) for the expand animation. |
+| durationClose | number | Time (ms) for the collapse animation. |
 | isOpen | boolean | Opens/collapses the component. |
 | onClose | function | Callback function when the component closes. |
 | onOpen | function | Callback function when the component opens. |

--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
 import { requestAnimationFrame, noop } from '../../utilities/other'
 
-const propTypes = {
+export const propTypes = {
   duration: PropTypes.number,
+  durationOpen: PropTypes.number,
+  durationClose: PropTypes.number,
   isOpen: PropTypes.bool,
   onOpen: PropTypes.func,
   onClose: PropTypes.func
@@ -121,11 +123,23 @@ class Collapsible extends Component {
     return `${height || 0}px`
   }
 
+  getTransitionDuration () {
+    const {duration, durationOpen, durationClose} = this.props
+    const {animationState} = this.state
+    const openDuration = durationOpen !== undefined ? durationOpen : duration
+    const closeDuration = durationClose !== undefined ? durationClose : duration
+    const isOpening = animationState.indexOf('closing') < 0
+
+    return isOpening ? openDuration : closeDuration
+  }
+
   render () {
     const {
       className,
       children,
       duration,
+      durationOpen,
+      durationClose,
       isOpen,
       onOpen,
       onClose,
@@ -151,7 +165,7 @@ class Collapsible extends Component {
 
     const collapseStyle = {
       height: displayHeight,
-      transitionDuration: `${duration}ms`
+      transitionDuration: `${this.getTransitionDuration()}ms`
     }
     const componentStyle = style ? Object.assign({}, style, collapseStyle) : collapseStyle
 

--- a/src/components/Collapsible/tests/Collapsible.test.js
+++ b/src/components/Collapsible/tests/Collapsible.test.js
@@ -147,3 +147,28 @@ describe('AnimationState', () => {
     expect(wrapper.state().animationState).toBe('measuring')
   })
 })
+
+describe('Duration', () => {
+  test('Duration can be set', () => {
+    const wrapper = mount(<Collapsible duration={1000} />)
+    const o = wrapper.instance()
+
+    expect(o.getTransitionDuration()).toBe(1000)
+  })
+
+  test('Duration can be overridden by durationOpen', () => {
+    const wrapper = mount(<Collapsible duration={1000} durationOpen={300} />)
+    const o = wrapper.instance()
+    wrapper.setState({animationState: 'open'})
+
+    expect(o.getTransitionDuration()).toBe(300)
+  })
+
+  test('Duration can be overridden by durationClose', () => {
+    const wrapper = mount(<Collapsible duration={1000} durationClose={100} />)
+    const o = wrapper.instance()
+    wrapper.setState({animationState: 'closing'})
+
+    expect(o.getTransitionDuration()).toBe(100)
+  })
+})

--- a/src/components/SidebarCollapsibleCard/README.md
+++ b/src/components/SidebarCollapsibleCard/README.md
@@ -40,6 +40,7 @@ This component can be drag sortable using the [Sortable](../Sortable) component.
 <Sortable
   useDragHandle
   hideDragHandles
+  pressDelay={100}
 >
   <SidebarCollapsibleCard title='Zoolander 2'>
     <dl>
@@ -60,6 +61,8 @@ This component can be drag sortable using the [Sortable](../Sortable) component.
 </Sortable>
 ```
 
+Note: In order for this component to play nicely with [Sortable](../Sortable), a `pressDelay` prop must be defined (recommended minimum of `100`). This allows for the collapse timing to synchronize with the Sortable item height calculations.
+
 
 
 ## Props
@@ -72,6 +75,8 @@ This component can be drag sortable using the [Sortable](../Sortable) component.
 | isOpen | boolean | Opens/collapses the component. |
 | onClose | function | Callback function when the component closes. |
 | onOpen | function | Callback function when the component opens. |
+| onSortStart | function | Callback function when component starts being sorted. |
+| onSortEnd | function | Callback function when component stops being sorted. |
 | sortable | boolean | Renders the drag handler for sorting. See [Sortable](../Sortable) |
 | style | string | Custom styles to be added to the component. |
 | title | string | Title for the header in this component. |

--- a/src/components/SidebarCollapsibleCard/index.js
+++ b/src/components/SidebarCollapsibleCard/index.js
@@ -1,23 +1,31 @@
 import React, {PureComponent as Component} from 'react'
 import PropTypes from 'prop-types'
 import { default as Collapsible, propTypes as collapsibleTypes } from '../Collapsible'
+import EventListener from '../EventListener'
 import Flexy from '../Flexy'
 import Heading from '../Heading'
 import SortableDragHandle from '../Sortable/DragHandle'
 import Icon from '../Icon'
 import { createUniqueIDFactory } from '../../utilities/id'
+import { noop } from '../../utilities/other'
 import classNames from '../../utilities/classNames'
 
 export const propTypes = Object.assign({}, collapsibleTypes, {
   header: PropTypes.element,
   title: PropTypes.string,
   isOpen: PropTypes.bool,
-  sortable: PropTypes.bool
+  sortable: PropTypes.bool,
+  onSortStart: PropTypes.func,
+  onSortEnd: PropTypes.func
 })
 
 export const defaultProps = {
   duration: 200,
+  durationOpen: 200,
+  durationClose: 100,
   isOpen: false,
+  onSortStart: noop,
+  onSortEnd: noop,
   sortable: false
 }
 
@@ -30,7 +38,11 @@ class SidebarCollapsibleCard extends Component {
       id: props.id || uniqueID(),
       isOpen: props.isOpen
     }
+    this._prevIsOpen = props.isOpen
+    this.isSorting = false
     this.handleToggleOpen = this.handleToggleOpen.bind(this)
+    this.handleOnSortStart = this.handleOnSortStart.bind(this)
+    this.handleOnSortEnd = this.handleOnSortEnd.bind(this)
   }
 
   componentWillUpdate (nextProps, nextState) {
@@ -44,14 +56,34 @@ class SidebarCollapsibleCard extends Component {
     this.setState({ isOpen: !this.state.isOpen })
   }
 
+  handleOnSortStart () {
+    const { onSortStart } = this.props
+    this._prevIsOpen = this.state.isOpen
+    this.isSorting = true
+    this.setState({ isOpen: false })
+    onSortStart()
+  }
+
+  handleOnSortEnd () {
+    const { onSortEnd } = this.props
+    if (!this.isSorting) return
+    this.setState({ isOpen: this._prevIsOpen })
+    this.isSorting = false
+    onSortEnd()
+  }
+
   render () {
     const {
       children,
       className,
       duration,
+      durationOpen,
+      durationClose,
       header,
       onClose,
       onOpen,
+      onSortStart,
+      onSortEnd,
       isOpen,
       sortable,
       title,
@@ -69,6 +101,8 @@ class SidebarCollapsibleCard extends Component {
     )
 
     const handleToggleOpen = this.handleToggleOpen
+    const handleOnSortStart = this.handleOnSortStart
+    const handleOnSortEnd = this.handleOnSortEnd
 
     const displayHeader = () => {
       if (header) return header
@@ -87,12 +121,16 @@ class SidebarCollapsibleCard extends Component {
     const headerMarkup = displayHeader()
     const dragHandleMarkup = sortable ? (
       <Flexy.Item>
-        <SortableDragHandle className='c-SidebarCollapsibleCard__drag-handle' />
+        <SortableDragHandle
+          className='c-SidebarCollapsibleCard__drag-handle'
+          onDragStart={handleOnSortStart}
+        />
       </Flexy.Item>
     ) : null
 
     return (
       <div className={componentClassName} {...rest} role='presentation' id={cardId}>
+        <EventListener event='mouseup' handler={handleOnSortEnd} />
         <a href='#' className='c-SidebarCollapsibleCard__header' onClick={handleToggleOpen} role='heading' aria-expanded={open} aria-controls={regionId}>
           <Flexy gap='sm'>
             <Flexy.Block>
@@ -107,6 +145,8 @@ class SidebarCollapsibleCard extends Component {
         <div className='c-SidebarCollapsibleCard__body' role='region' id={regionId}>
           <Collapsible
             duration={duration}
+            durationOpen={durationOpen}
+            durationClose={durationClose}
             onOpen={onOpen}
             onClose={onClose}
             isOpen={open}

--- a/src/components/Sortable/DragHandle.js
+++ b/src/components/Sortable/DragHandle.js
@@ -1,11 +1,23 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import {SortableHandle} from 'react-sortable-hoc'
 import Icon from '../Icon'
 import classNames from '../../utilities/classNames'
+import { noop } from '../../utilities/other'
+
+export const propTypes = {
+  onDragStart: PropTypes.func
+}
+
+const defaultProps = {
+  onDragStart: noop
+}
 
 const DragHandle = SortableHandle((props) => {
   const {
     className,
+    onDragStart,
+    onDragEnd,
     ...rest
   } = props
 
@@ -13,11 +25,19 @@ const DragHandle = SortableHandle((props) => {
     'c-SortableDragHandle',
     className
   )
+
   return (
-    <div className={componentClassName} {...rest}>
+    <div
+      className={componentClassName}
+      onMouseDown={onDragStart}
+      {...rest}
+    >
       <Icon name='drag' size='14' ignoreClick={false} />
     </div>
   )
 })
+
+DragHandle.propTypes = propTypes
+DragHandle.defaultProps = defaultProps
 
 export default DragHandle

--- a/src/components/Sortable/List.js
+++ b/src/components/Sortable/List.js
@@ -24,7 +24,6 @@ const List = SortableContainer((props) => {
   )
 
   const itemsMarkup = items ? items.map((item, index) => {
-    const key = `item-${index}`
     const {
       index: itemIndex,
       ...itemRest
@@ -32,7 +31,6 @@ const List = SortableContainer((props) => {
 
     return React.cloneElement(item, {
       index,
-      key,
       useDragHandle,
       hideDragHandles,
       ...itemRest

--- a/src/components/Sortable/index.js
+++ b/src/components/Sortable/index.js
@@ -6,8 +6,15 @@ import DragHandle from './DragHandle'
 import Item from './Item'
 import List from './List'
 import { listTypes } from './propTypes'
+import { noop } from '../../utilities/other'
 
 export const propTypes = listTypes
+
+const defaultProps = {
+  onSortStart: noop,
+  onSortMove: noop,
+  onSortEnd: noop
+}
 
 class Sortable extends Component {
   constructor () {
@@ -36,7 +43,7 @@ class Sortable extends Component {
 
     const items = React.Children.map(children, (child, index) => {
       const sortableElement = includes(child.type.displayName, 'sortableElement')
-      const key = `item-${index}`
+      const key = child.props.id ? child.props.id : `item-${index}`
 
       if (sortableElement) {
         return React.cloneElement(child, {
@@ -107,6 +114,7 @@ class Sortable extends Component {
 }
 
 Sortable.propTypes = propTypes
+Sortable.defaultProps = defaultProps
 Sortable.DragHandle = DragHandle
 Sortable.Item = Item
 Sortable.List = List

--- a/src/components/Sortable/tests/Sortable.test.js
+++ b/src/components/Sortable/tests/Sortable.test.js
@@ -42,6 +42,35 @@ describe('Children', () => {
     expect(o.type.displayName).toBe('sortableElement')
     expect(o.key).toBeTruthy()
   })
+
+  test('Provides children with unique keys, if id prop is not defined', () => {
+    const wrapper = shallow(
+      <Sortable>
+        <div>Ron</div>
+        <div>Champ</div>
+        <div>Brick</div>
+      </Sortable>
+    )
+    const o = wrapper.state().items[0]
+    const p = wrapper.state().items[1]
+
+    expect(o.key).not.toBe(p.key)
+  })
+
+  test('Use ID from child as key, if defined', () => {
+    const wrapper = shallow(
+      <Sortable>
+        <div id='ron'>Ron</div>
+        <div id='champ'>Champ</div>
+        <div>Brick</div>
+      </Sortable>
+    )
+    const o = wrapper.state().items[0]
+    const p = wrapper.state().items[1]
+
+    expect(o.key).toContain('ron')
+    expect(p.key).toContain('champ')
+  })
 })
 
 describe('DragHandles', () => {

--- a/stories/SidebarCollapsibleCard.js
+++ b/stories/SidebarCollapsibleCard.js
@@ -34,8 +34,9 @@ storiesOf('SidebarCollapsibleCard', module)
       useDragHandle
       hideDragHandles
       style={{padding: 10, background: '#f1f3f5'}}
+      pressDelay={100}
     >
-      <SidebarCollapsibleCard title='Zoolander 2'>
+      <SidebarCollapsibleCard title='Zoolander 2' id='001'>
         <dl>
           <dt>Character</dt>
           <dd>Jacobim Mugatu</dd>
@@ -43,7 +44,7 @@ storiesOf('SidebarCollapsibleCard', module)
           <dd>2016</dd>
         </dl>
       </SidebarCollapsibleCard>
-      <SidebarCollapsibleCard title='The Lego Movie'>
+      <SidebarCollapsibleCard title='The Lego Movie' id='002'>
         <dl>
           <dt>Character</dt>
           <dd>Lord Business</dd>
@@ -51,7 +52,7 @@ storiesOf('SidebarCollapsibleCard', module)
           <dd>2014</dd>
         </dl>
       </SidebarCollapsibleCard>
-      <SidebarCollapsibleCard title='Step Brothers'>
+      <SidebarCollapsibleCard title='Step Brothers' id='003'>
         <dl>
           <dt>Character</dt>
           <dd>Brennan Huff</dd>


### PR DESCRIPTION
## SidebarCollapsibleCard: Improve Sortable interactions

![screen recording 2017-10-16 at 02 36 pm](https://user-images.githubusercontent.com/2322354/31630731-8002c582-b285-11e7-948e-dd4084009e2f.gif)

This update fixes Sortable's handling of child item keys. Sortable now respects unique keys, and uses ID props if specified.

SidebarCollapsibleCard gains 2 new hooks: onSortStart and onSortEnd that fire when the component is being sorted. The react-sortable-hoc did NOT provide any callback methods for these hooks for the DraggableHandle, only at the Container level. So I had to come up with a creative solution to get this to work.

The two props allow for SidebarCollapsibleCard to be better integrated into Sortable.

Collapsible gains 2 new props: durationOpen and durationClose, that fallback to duration. This allows you to pass in different timings for the animation, allow for a smoother collapse experience with SidebarCollapsibleCard.

Resolves: https://github.com/helpscout/blue/issues/74 https://github.com/helpscout/blue/issues/71