### PR TITLE
Added onClick handler back to the Card component

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -62,6 +62,7 @@ const Card = props => {
     <Link
       block
       className={componentClassName}
+      onClick={onClick}
       href={href}
       to={to}
       {...rest}

--- a/src/components/Card/tests/Card.test.js
+++ b/src/components/Card/tests/Card.test.js
@@ -134,6 +134,36 @@ describe('Link', () => {
     expect(b.length).toBe(1)
     expect(b.node.props.children).toBe('MegaMind')
   })
+
+  test('onBlur fires for a Link', () => {
+    const spy = jest.fn()
+    const wrapper = shallow(
+      <Card href={link} onBlur={spy} />
+    )
+    wrapper.simulate('blur')
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('onClick fires for a Link', () => {
+    const spy = jest.fn()
+    const wrapper = shallow(
+      <Card href={link} onClick={spy} />
+    )
+    wrapper.simulate('click')
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('onFocus fires for a Link', () => {
+    const spy = jest.fn()
+    const wrapper = shallow(
+      <Card href={link} onFocus={spy} />
+    )
+    wrapper.simulate('focus')
+
+    expect(spy).toHaveBeenCalled()
+  })
 })
 
 describe('Click', () => {


### PR DESCRIPTION
After upgrading Blue to the latest version in Beacon, I found out that the `Card` component no longer had an `onClick` handler when they were given an `href` or `to` attribute. I've added it back to fix its behavior.