### PR TITLE
Add Alert component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16421,6 +16421,97 @@
         "source-map": "0.4.4"
       }
     },
+    "seed-alert": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/seed-alert/-/seed-alert-0.2.6.tgz",
+      "integrity": "sha1-WZh1yOBsWlVWKB1dbXFW8DMSn7g=",
+      "dev": true,
+      "requires": {
+        "sass-pathfinder": "0.0.5",
+        "seed-badge": "0.0.2",
+        "seed-button": "0.1.16",
+        "seed-dash": "0.0.1",
+        "seed-publish": "0.0.4",
+        "seed-states": "0.0.4"
+      },
+      "dependencies": {
+        "seed-border": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/seed-border/-/seed-border-0.0.8.tgz",
+          "integrity": "sha1-tP0tPQZkcB87kWZOGS6EX3nIUBw=",
+          "dev": true,
+          "requires": {
+            "sass-pathfinder": "0.0.5",
+            "seed-breakpoints": "0.4.1",
+            "seed-publish": "0.0.2"
+          },
+          "dependencies": {
+            "seed-publish": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/seed-publish/-/seed-publish-0.0.2.tgz",
+              "integrity": "sha1-q/BHzazUzt3SN8NXs6H0Xa/lwwg=",
+              "dev": true
+            }
+          }
+        },
+        "seed-button": {
+          "version": "0.1.16",
+          "resolved": "https://registry.npmjs.org/seed-button/-/seed-button-0.1.16.tgz",
+          "integrity": "sha1-1NWS4cG+xvRFtwXmD74YPGKIAK0=",
+          "dev": true,
+          "requires": {
+            "sass-pathfinder": "0.0.5",
+            "seed-border": "0.0.8",
+            "seed-control": "0.0.4",
+            "seed-dash": "0.0.1",
+            "seed-publish": "0.0.4",
+            "seed-states": "0.0.4"
+          }
+        },
+        "seed-control": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/seed-control/-/seed-control-0.0.4.tgz",
+          "integrity": "sha1-BP++Dqe0G7u+7/Tr5VJpv2jSZpY=",
+          "dev": true,
+          "requires": {
+            "sass-pathfinder": "0.0.5",
+            "seed-dash": "0.0.1"
+          }
+        },
+        "seed-dash": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/seed-dash/-/seed-dash-0.0.1.tgz",
+          "integrity": "sha1-/yHArmMzDsY6ik4+Db9Ka3ooh6I=",
+          "dev": true
+        }
+      }
+    },
+    "seed-badge": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/seed-badge/-/seed-badge-0.0.2.tgz",
+      "integrity": "sha1-UJmyqrIBHylPaVvhOHYNrAjnw0w=",
+      "dev": true,
+      "requires": {
+        "sass-pathfinder": "0.0.5",
+        "seed-dash": "0.0.1",
+        "seed-publish": "0.0.2",
+        "seed-states": "0.0.4"
+      },
+      "dependencies": {
+        "seed-dash": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/seed-dash/-/seed-dash-0.0.1.tgz",
+          "integrity": "sha1-/yHArmMzDsY6ik4+Db9Ka3ooh6I=",
+          "dev": true
+        },
+        "seed-publish": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/seed-publish/-/seed-publish-0.0.2.tgz",
+          "integrity": "sha1-q/BHzazUzt3SN8NXs6H0Xa/lwwg=",
+          "dev": true
+        }
+      }
+    },
     "seed-barista": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/seed-barista/-/seed-barista-1.0.4.tgz",
@@ -16542,6 +16633,23 @@
       "requires": {
         "sass-pathfinder": "0.0.5",
         "seed-config": "0.1.1"
+      }
+    },
+    "seed-color-scheme-helpscout": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/seed-color-scheme-helpscout/-/seed-color-scheme-helpscout-0.0.3.tgz",
+      "integrity": "sha1-gmfvaizHVad1gaimWvJ/tKZzrEA=",
+      "dev": true,
+      "requires": {
+        "seed-color-scheme": "0.0.2"
+      },
+      "dependencies": {
+        "seed-color-scheme": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/seed-color-scheme/-/seed-color-scheme-0.0.2.tgz",
+          "integrity": "sha1-QN4soNtEyzvIRGGzJmQ5ruv/w+c=",
+          "dev": true
+        }
       }
     },
     "seed-config": {
@@ -16680,6 +16788,47 @@
       "resolved": "https://registry.npmjs.org/seed-props/-/seed-props-0.3.1.tgz",
       "integrity": "sha1-QZSb/Sn4DR3T0nYTFyE/EVp8/sE=",
       "dev": true
+    },
+    "seed-publish": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/seed-publish/-/seed-publish-0.0.4.tgz",
+      "integrity": "sha1-2nC1bKo2uEBVjmVpoYstWGfenY4=",
+      "dev": true
+    },
+    "seed-states": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/seed-states/-/seed-states-0.0.4.tgz",
+      "integrity": "sha1-g1lVFUKLX2kLBXYkBBqR3JMKx6E=",
+      "dev": true,
+      "requires": {
+        "sass-pathfinder": "0.0.3",
+        "seed-color-scheme": "0.0.2",
+        "seed-color-scheme-helpscout": "0.0.3",
+        "seed-dash": "0.0.1"
+      },
+      "dependencies": {
+        "sass-pathfinder": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/sass-pathfinder/-/sass-pathfinder-0.0.3.tgz",
+          "integrity": "sha1-fJPBtDprqCP0IEN1kNngTITOft0=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "seed-color-scheme": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/seed-color-scheme/-/seed-color-scheme-0.0.2.tgz",
+          "integrity": "sha1-QN4soNtEyzvIRGGzJmQ5ruv/w+c=",
+          "dev": true
+        },
+        "seed-dash": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/seed-dash/-/seed-dash-0.0.1.tgz",
+          "integrity": "sha1-/yHArmMzDsY6ik4+Db9Ka3ooh6I=",
+          "dev": true
+        }
+      }
     },
     "seed-this": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "rgb-hex": "2.1.0",
     "rimraf": "2.6.2",
     "sass-loader": "6.0.6",
+    "seed-alert": "0.2.6",
     "seed-barista": "1.0.4",
     "seed-button": "0.3.0",
     "seed-card": "0.1.0",

--- a/src/components/Alert/README.md
+++ b/src/components/Alert/README.md
@@ -1,0 +1,36 @@
+# Alert
+
+An Alert component provides contextual feedback messages for user actions with the ability to provide additional actions.
+
+
+## Example
+
+```jsx
+<Alert dismissable icon>
+  Not now Arctic Puffin!
+</Alert>
+```
+
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| actionRight | element | Renders an action-based element on the right side of the content. Typically [Buttons](../Button). |
+| badge | string | Renders a [Badge](../Badge) component. |
+| onDismiss | function | Callback function when this component is dismissed. |
+| className | string | Custom class names to be added to the component. |
+| dismissible | boolean | Allows this component to be dismissed by clicking a [CloseButton](../CloseButton). |
+| icon | boolean | Renders an alert [Icon](../Icon). |
+| noMargin | boolean | Removes margin from the bottom of the component. |
+| status | string | Changes the color of the component to the corresponding status. |
+
+
+### Status
+
+| Value | Description |
+| --- | --- |
+| `error` | Colors the badge red. |
+| `info` | Colors the badge blue. |
+| `success` | Colors the badge green. |
+| `warning` | Colors the badge yellow. |

--- a/src/components/Alert/index.js
+++ b/src/components/Alert/index.js
@@ -1,5 +1,7 @@
 import React, {PureComponent as Component} from 'react'
 import PropTypes from 'prop-types'
+import Badge from '../Badge'
+import Collapsible from '../Collapsible'
 import CloseButton from '../CloseButton'
 import Icon from '../Icon'
 import classNames from '../../utilities/classNames'
@@ -8,8 +10,7 @@ import { statusTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   actionRight: PropTypes.element,
-  badge: PropTypes.element,
-  closeLabel: PropTypes.string,
+  badge: PropTypes.string,
   dismissible: PropTypes.bool,
   icon: PropTypes.bool,
   onDismiss: PropTypes.func,
@@ -26,6 +27,7 @@ export const classNameSpace = 'c-Alert'
 export const cx = {
   main: classNameSpace,
   actionRight: `${classNameSpace}__actionRight`,
+  badge: `${classNameSpace}__badge`,
   block: `${classNameSpace}__block`,
   closeButton: `${classNameSpace}__closeButton`,
   content: `${classNameSpace}__content`,
@@ -70,6 +72,7 @@ class Alert extends Component {
     const componentClassName = classNames(
       cx.main,
       actionRight && 'has-actionRight',
+      badge && 'has-badge',
       dismissible && 'is-dismissible',
       icon && 'has-icon',
       noMargin && 'is-noMargin',
@@ -83,7 +86,11 @@ class Alert extends Component {
       </div>
     ) : null
 
-    const iconMarkup = icon ? (
+    const leftMarkup = badge ? (
+      <div className={cx.badge}>
+        <Badge status={status}>{badge}</Badge>
+      </div>
+    ) : icon ? (
       <div className={cx.icon}>
         <Icon name='alert' size='20' />
       </div>
@@ -102,7 +109,7 @@ class Alert extends Component {
     const componentMarkup = (
       <div className={componentClassName} {...rest} role='alert'>
         <div className={cx.content}>
-          {iconMarkup}
+          {leftMarkup}
           <div className={cx.block}>
             {children}
           </div>
@@ -112,7 +119,11 @@ class Alert extends Component {
       </div>
     )
 
-    return (dismissible && !dismissed) || !dismissed ? componentMarkup : null
+    return dismissible ? (
+      <Collapsible duration={200} isOpen={!dismissed}>
+        {componentMarkup}
+      </Collapsible>
+    ) : componentMarkup
   }
 }
 

--- a/src/components/Alert/index.js
+++ b/src/components/Alert/index.js
@@ -1,0 +1,122 @@
+import React, {PureComponent as Component} from 'react'
+import PropTypes from 'prop-types'
+import CloseButton from '../CloseButton'
+import Icon from '../Icon'
+import classNames from '../../utilities/classNames'
+import { noop } from '../../utilities/other'
+import { statusTypes } from '../../constants/propTypes'
+
+export const propTypes = {
+  actionRight: PropTypes.element,
+  badge: PropTypes.element,
+  closeLabel: PropTypes.string,
+  dismissible: PropTypes.bool,
+  icon: PropTypes.bool,
+  onDismiss: PropTypes.func,
+  noMargin: PropTypes.bool,
+  status: statusTypes
+}
+
+const defaultProps = {
+  onDismiss: noop,
+  status: 'warning'
+}
+
+export const classNameSpace = 'c-Alert'
+export const cx = {
+  main: classNameSpace,
+  actionRight: `${classNameSpace}__actionRight`,
+  block: `${classNameSpace}__block`,
+  closeButton: `${classNameSpace}__closeButton`,
+  content: `${classNameSpace}__content`,
+  icon: `${classNameSpace}__icon`
+}
+
+class Alert extends Component {
+  constructor () {
+    super()
+    this.state = {
+      dismissed: false
+    }
+    this.handleOnDismiss = this.handleOnDismiss.bind(this)
+  }
+
+  handleOnDismiss () {
+    const { onDismiss } = this.props
+    this.setState({
+      dismissed: true
+    })
+    onDismiss()
+  }
+
+  render () {
+    const {
+      actionRight,
+      badge,
+      closeLabel,
+      dismissible,
+      children,
+      className,
+      icon,
+      onDismiss,
+      noMargin,
+      status,
+      ...rest
+    } = this.props
+    const { dismissed } = this.state
+
+    const handleOnDismiss = this.handleOnDismiss
+
+    const componentClassName = classNames(
+      cx.main,
+      actionRight && 'has-actionRight',
+      dismissible && 'is-dismissible',
+      icon && 'has-icon',
+      noMargin && 'is-noMargin',
+      status && `is-${status}`,
+      className
+    )
+
+    const actionRightMarkup = actionRight ? (
+      <div className={cx.actionRight}>
+        {actionRight}
+      </div>
+    ) : null
+
+    const iconMarkup = icon ? (
+      <div className={cx.icon}>
+        <Icon name='alert' size='20' />
+      </div>
+    ) : null
+
+    const closeButtonMarkup = dismissible ? (
+      <div className={cx.closeButton}>
+        <CloseButton
+          onClick={handleOnDismiss}
+          seamless
+          size='sm'
+        />
+      </div>
+    ) : null
+
+    const componentMarkup = (
+      <div className={componentClassName} {...rest} role='alert'>
+        <div className={cx.content}>
+          {iconMarkup}
+          <div className={cx.block}>
+            {children}
+          </div>
+          {actionRightMarkup}
+          {closeButtonMarkup}
+        </div>
+      </div>
+    )
+
+    return (dismissible && !dismissed) || !dismissed ? componentMarkup : null
+  }
+}
+
+Alert.propTypes = propTypes
+Alert.defaultProps = defaultProps
+
+export default Alert

--- a/src/components/Alert/tests/Alert.test.js
+++ b/src/components/Alert/tests/Alert.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import { default as Alert, cx } from '..'
-import { Button, CloseButton, Icon } from '../../'
+import { Badge, Button, CloseButton, Collapsible, Icon } from '../../'
 
 describe('ClassName', () => {
   test('Has default className', () => {
@@ -49,7 +49,6 @@ describe('Dismissing', () => {
     o.simulate('click')
 
     expect(wrapper.state().dismissed).toBe(true)
-    expect(wrapper.html()).toBeFalsy()
   })
 
   test('onDismiss callback can be fired on CloseButton click', () => {
@@ -60,6 +59,31 @@ describe('Dismissing', () => {
     o.simulate('click')
 
     expect(spy).toHaveBeenCalled()
+  })
+
+  test('Does not contain Collasible by default', () => {
+    const wrapper = shallow(<Alert />)
+    const o = wrapper.find(Collapsible)
+
+    expect(o.length).not.toBeTruthy()
+  })
+
+  test('Renders Collasible by default', () => {
+    const wrapper = shallow(<Alert dismissible />)
+    const o = wrapper.find(Collapsible)
+
+    expect(o.length).toBeTruthy()
+    expect(o.node.props.isOpen).toBeTruthy()
+  })
+
+  test('Collapses alert on CloseButton click', () => {
+    const wrapper = mount(<Alert dismissible />)
+    const b = wrapper.find(CloseButton)
+    const o = wrapper.find(Collapsible)
+
+    b.simulate('click')
+
+    expect(o.node.props.isOpen).not.toBeTruthy()
   })
 })
 
@@ -80,6 +104,16 @@ describe('Action right', () => {
     expect(o.length).toBeTruthy()
     expect(wrapper.hasClass('has-actionRight')).toBeTruthy()
   })
+
+  test('onClick from actionRight Button can still fire', () => {
+    const spy = jest.fn()
+    const wrapper = shallow(<Alert actionRight={<Button onClick={spy} />} />)
+    const o = wrapper.find(Button)
+
+    o.simulate('click')
+
+    expect(spy).toHaveBeenCalled()
+  })
 })
 
 describe('Content', () => {
@@ -91,6 +125,26 @@ describe('Content', () => {
     expect(o.length).toBeTruthy()
     expect(d.length).toBeTruthy()
     expect(d.node.props.children).toBe('Buddy')
+  })
+})
+
+describe('Badge', () => {
+  test('Does not render an Badge by default', () => {
+    const wrapper = shallow(<Alert />)
+    const o = wrapper.find(Badge)
+
+    expect(o.length).not.toBeTruthy()
+  })
+
+  test('Renders an alert Badge, if specified', () => {
+    const wrapper = shallow(<Alert badge='Badge' />)
+    const d = wrapper.find(`.${cx.badge}`)
+    const o = wrapper.find(Badge)
+
+    expect(d.length).toBeTruthy()
+    expect(o.length).toBeTruthy()
+    expect(o.node.props.children).toBe('Badge')
+    expect(wrapper.hasClass('has-badge')).toBeTruthy()
   })
 })
 

--- a/src/components/Alert/tests/Alert.test.js
+++ b/src/components/Alert/tests/Alert.test.js
@@ -1,0 +1,135 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { default as Alert, cx } from '..'
+import { Button, CloseButton, Icon } from '../../'
+
+describe('ClassName', () => {
+  test('Has default className', () => {
+    const wrapper = shallow(<Alert />)
+
+    expect(wrapper.hasClass(cx.main)).toBeTruthy()
+  })
+
+  test('Can accept custom className', () => {
+    const wrapper = shallow(<Alert className='buddy' />)
+
+    expect(wrapper.hasClass('buddy')).toBeTruthy()
+  })
+})
+
+describe('Accessibility', () => {
+  test('Has correct aria-role', () => {
+    const wrapper = shallow(<Alert />)
+
+    expect(wrapper.props().role).toBe('alert')
+  })
+})
+
+describe('Dismissing', () => {
+  test('Is not dismissed by default', () => {
+    const wrapper = shallow(<Alert />)
+
+    expect(wrapper.state().dismissed).toBe(false)
+    expect(wrapper.html()).toBeTruthy()
+  })
+
+  test('Renders close button if dismissible', () => {
+    const wrapper = shallow(<Alert dismissible />)
+    const d = wrapper.find(`.${cx.closeButton}`)
+    const o = wrapper.find(CloseButton)
+
+    expect(d.length).toBeTruthy()
+    expect(o.length).toBeTruthy()
+  })
+
+  test('Dismisses alert if CloseButton is clicked', () => {
+    const wrapper = shallow(<Alert dismissible />)
+    const o = wrapper.find(CloseButton)
+
+    o.simulate('click')
+
+    expect(wrapper.state().dismissed).toBe(true)
+    expect(wrapper.html()).toBeFalsy()
+  })
+
+  test('onDismiss callback can be fired on CloseButton click', () => {
+    const spy = jest.fn()
+    const wrapper = shallow(<Alert dismissible onDismiss={spy} />)
+    const o = wrapper.find(CloseButton)
+
+    o.simulate('click')
+
+    expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('Action right', () => {
+  test('Does not render a right action by default', () => {
+    const wrapper = shallow(<Alert />)
+    const d = wrapper.find(`.${cx.actionRight}`)
+
+    expect(d.length).not.toBeTruthy()
+  })
+
+  test('Renders a right action if specified', () => {
+    const wrapper = shallow(<Alert actionRight={<Button />} />)
+    const d = wrapper.find(`.${cx.actionRight}`)
+    const o = d.find(Button)
+
+    expect(d.length).toBeTruthy()
+    expect(o.length).toBeTruthy()
+    expect(wrapper.hasClass('has-actionRight')).toBeTruthy()
+  })
+})
+
+describe('Content', () => {
+  test('Can render child content', () => {
+    const wrapper = shallow(<Alert><div className='buddy'>Buddy</div></Alert>)
+    const o = wrapper.find(`.${cx.block}`)
+    const d = o.find('.buddy')
+
+    expect(o.length).toBeTruthy()
+    expect(d.length).toBeTruthy()
+    expect(d.node.props.children).toBe('Buddy')
+  })
+})
+
+describe('Icon', () => {
+  test('Does not render an Icon by default', () => {
+    const wrapper = shallow(<Alert />)
+    const o = wrapper.find(Icon)
+
+    expect(o.length).not.toBeTruthy()
+  })
+
+  test('Renders an alert icon, if specified', () => {
+    const wrapper = shallow(<Alert icon />)
+    const d = wrapper.find(`.${cx.icon}`)
+    const o = wrapper.find(Icon)
+
+    expect(d.length).toBeTruthy()
+    expect(o.length).toBeTruthy()
+    expect(o.node.props.name).toBe('alert')
+    expect(wrapper.hasClass('has-icon')).toBeTruthy()
+  })
+})
+
+describe('Status', () => {
+  const status = ['error', 'info', 'success', 'warning']
+
+  status.forEach(status => {
+    test(`Renders ${status} styles`, () => {
+      const wrapper = shallow(<Alert status={status} />)
+
+      expect(wrapper.hasClass(`is-${status}`)).toBeTruthy()
+    })
+  })
+})
+
+describe('Styles', () => {
+  test('Applies "noMargin" styles, if specified', () => {
+    const wrapper = shallow(<Alert noMargin />)
+
+    expect(wrapper.hasClass('is-noMargin')).toBeTruthy()
+  })
+})

--- a/src/components/CloseButton/README.md
+++ b/src/components/CloseButton/README.md
@@ -15,7 +15,9 @@ A CloseButton component provides the closing action typically used in UI like Mo
 | Prop | Type | Description |
 | --- | --- | --- |
 | onBlur | function | Callback when button is blurred. |
+| onClick | function | Callback when button is clicked. |
 | onChange | function | Callback when button value is changed. |
 | onFocus | function | Callback when button is focused. |
 | className | string | Custom class names to be added to the component. |
+| seamless | boolean | Applies a seamless style to the component. |
 | title | string | Custom title for the button. |

--- a/src/components/CloseButton/index.js
+++ b/src/components/CloseButton/index.js
@@ -3,12 +3,15 @@ import PropTypes from 'prop-types'
 import Icon from '../Icon'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
+import { sizeTypes } from './propTypes'
 
 export const propTypes = {
   className: PropTypes.string,
   onBlur: PropTypes.func,
   onClick: PropTypes.func,
   onFocus: PropTypes.func,
+  seamless: PropTypes.bool,
+  size: sizeTypes,
   title: PropTypes.string
 }
 
@@ -22,12 +25,16 @@ const defaultProps = {
 const CloseButton = props => {
   const {
     className,
+    seamless,
+    size,
     title,
     ...rest
   } = props
 
   const componentClassName = classNames(
     'c-CloseButton',
+    seamless && 'is-seamless',
+    size && `is-${size}`,
     className
   )
 
@@ -37,7 +44,7 @@ const CloseButton = props => {
         center
         className='c-CloseButton__icon'
         ignoreClick
-        muted
+        muted={!seamless}
         name='cross-medium'
         title='Close'
       />

--- a/src/components/CloseButton/propTypes.js
+++ b/src/components/CloseButton/propTypes.js
@@ -1,0 +1,8 @@
+import PropTypes from 'prop-types'
+
+export const sizeTypes = PropTypes.oneOf([
+  'md',
+  'sm',
+  'xs',
+  ''
+])

--- a/src/components/CloseButton/tests/CloseButton.test.js
+++ b/src/components/CloseButton/tests/CloseButton.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount, shallow } from 'enzyme'
+import { shallow } from 'enzyme'
 import CloseButton from '..'
 
 describe('ClassName', () => {
@@ -40,7 +40,7 @@ describe('Accessibility', () => {
 describe('Events', () => {
   test('Can trigger onBlur callback', () => {
     const spy = jest.fn()
-    const wrapper = mount(<CloseButton onBlur={spy} />)
+    const wrapper = shallow(<CloseButton onBlur={spy} />)
 
     wrapper.simulate('blur')
 
@@ -49,7 +49,7 @@ describe('Events', () => {
 
   test('Can trigger onClick callback', () => {
     const spy = jest.fn()
-    const wrapper = mount(<CloseButton onClick={spy} />)
+    const wrapper = shallow(<CloseButton onClick={spy} />)
 
     wrapper.simulate('click')
 
@@ -58,10 +58,24 @@ describe('Events', () => {
 
   test('Can trigger onFocus callback', () => {
     const spy = jest.fn()
-    const wrapper = mount(<CloseButton onFocus={spy} />)
+    const wrapper = shallow(<CloseButton onFocus={spy} />)
 
     wrapper.simulate('focus')
 
     expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('Styles', () => {
+  test('Applies "seamless" styles, if specified', () => {
+    const wrapper = shallow(<CloseButton seamless />)
+
+    expect(wrapper.hasClass('is-seamless')).toBeTruthy()
+  })
+
+  test('Applies size styles, if specified', () => {
+    const wrapper = shallow(<CloseButton size='sm' />)
+
+    expect(wrapper.hasClass('is-sm')).toBeTruthy()
   })
 })

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
+export { default as Alert } from './Alert'
 export { default as Animate } from './Animate'
 export { default as AnimateGroup } from './AnimateGroup'
 export { default as Avatar } from './Avatar'

--- a/src/styles/components/Alert.scss
+++ b/src/styles/components/Alert.scss
@@ -25,6 +25,13 @@ $seed-alert-namespace: "c-Alert";
     }
   }
 
+  &__badge {
+    padding: 4px 0;
+    + * {
+      margin-left: 8px;
+    }
+  }
+
   // Adjust margin for icons
   &__icon {
     padding: 3px 0;

--- a/src/styles/components/Alert.scss
+++ b/src/styles/components/Alert.scss
@@ -1,0 +1,77 @@
+$seed-alert-namespace: "c-Alert";
+@import "pack/seed-alert/_index";
+
+.#{$seed-alert-namespace} {
+  @import "../resets/base";
+  padding: 8px 16px;
+  text-align: left;
+
+  // Modifiers
+  &.is-noMargin {
+    margin-bottom: 0;
+  }
+
+  &__content {
+    align-items: flex-start;
+    display: flex;
+
+    // Base elements
+    > * {
+      max-width: 100%;
+      min-width: 0;
+      + * {
+        margin-left: 12px;
+      }
+    }
+  }
+
+  // Adjust margin for icons
+  &__icon {
+    padding: 3px 0;
+    + * {
+      margin-left: 8px;
+    }
+  }
+
+  // .c-alert__block
+  // This element contains the content of the alert (usually text).
+  // This element uses a base line-height to allow for adaptability with the dynamic
+  // range of child content, and it ensures that both the child content aligns
+  // correctly with the block's sibling content.
+  //
+  // The block also has a min-height of 28px, which matches the height of it's
+  // potential sibling elements (icons, badges, buttons).
+  &__block {
+    line-height: 28px;
+    max-width: 100%;
+    min-height: 28px;
+    min-width: 0;
+
+    .c-Heading,
+    .c-Text,
+    .c-Link,
+    h1, h2, h3, h4, h5, h6,
+    p,
+    ol, ul {
+      color: inherit;
+    }
+
+    ul {
+      margin-bottom: 8px;
+
+      li:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    > p {
+      margin: 5px 0;
+    }
+  }
+
+  &__closeButton {
+    margin-left: auto;
+    margin-right: -4px;
+    padding-left: 8px;
+  }
+}

--- a/src/styles/components/CloseButton.scss
+++ b/src/styles/components/CloseButton.scss
@@ -1,3 +1,4 @@
+@import "pack/seed-dash/_index";
 @import "pack/seed-family/_index";
 @import "pack/seed-this/_index";
 
@@ -6,7 +7,22 @@
   @import "../resets/button";
 
   $block: this();
+  $padding: 2px 6px;
   $size: 32px;
+  $sizes: (
+    md: (
+      size: $size,
+      padding: $padding
+    ),
+    sm: (
+      size: 28px,
+      padding: 2px 3px
+    ),
+    xs: (
+      size: 24px,
+      padding: 2px 1px
+    )
+  );
 
   background-color: white;
   border: none;
@@ -14,6 +30,8 @@
   cursor: pointer;
   display: block;
   height: $size;
+  padding: $padding;
+  position: relative;
   width: $size;
 
   &__icon {
@@ -21,12 +39,56 @@
     position: relative;
     right: -1px; // Fix alignment
     transition: opacity 0.1s ease;
+    z-index: 1;
 
     @include parent("#{$block}:hover") {
       opacity: 0.8;
     }
     @include parent("#{$block}:focus") {
       opacity: 0.8;
+    }
+  }
+
+  &:before {
+    background-color: currentColor;
+    border-radius: 50%;
+    content: "";
+    display: none;
+    height: 100%;
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    transform: translateZ(0);
+    transition: opacity 0.2s ease;
+    width: 100%;
+  }
+  &:hover:before {
+    opacity: 0.1;
+  }
+  &:active:before {
+    opacity: 0.3;
+  }
+  &:focus:before {
+    opacity: 0.1;
+  }
+
+  // Modifiers
+  &.is-seamless {
+    background-color: transparent;
+    color: currentColor;
+    &:before {
+      display: block;
+    }
+  }
+
+  // Sizes
+  @each $size, $values in $sizes {
+    &.is-#{$size} {
+      $sz: _get($values, size);
+      height: $sz;
+      padding: _get($values, padding);
+      width: $sz;
     }
   }
 }

--- a/src/styles/components/__index.scss
+++ b/src/styles/components/__index.scss
@@ -1,3 +1,4 @@
+@import "./Alert";
 @import "./Animate/_index";
 @import "./Avatar";
 @import "./AvatarStack";

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Animate,
   AnimateGroup,
   Avatar,
@@ -42,6 +43,7 @@ import {
 } from '..'
 
 const components = [
+  Alert,
   Animate,
   AnimateGroup,
   Avatar,

--- a/stories/Alert.js
+++ b/stories/Alert.js
@@ -46,6 +46,12 @@ stories.add('dismissible', () => (
   </div>
 ))
 
+stories.add('badge', () => (
+  <div>
+    <Alert badge='Wow'>Badge Buddy!</Alert>
+  </div>
+))
+
 stories.add('icon', () => (
   <div>
     <Alert icon>Icon Buddy!</Alert>

--- a/stories/Alert.js
+++ b/stories/Alert.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { Alert, Button, Heading, Link, Text } from '../src/index.js'
+
+const stories = storiesOf('Alert', module)
+
+stories.add('default', () => (
+  <Alert>Buddy!</Alert>
+))
+
+stories.add('content', () => (
+  <Alert>
+    <Heading size='h1'>H1 Heading</Heading>
+    <Heading size='h2'>H2 Heading</Heading>
+    <Heading size='h3'>H3 Heading</Heading>
+    <Heading size='h4'>H4 Heading</Heading>
+    <Heading size='h5'>H5 Heading</Heading>
+    <Heading size='h6'>H6 Heading</Heading>
+    <p>
+      <Text>Paragraph. <Link>Link</Link>.</Text>
+    </p>
+    <ul>
+      <li>List item</li>
+      <li>List item</li>
+      <li>List item</li>
+    </ul>
+  </Alert>
+))
+
+stories.add('actionRight', () => (
+  <div>
+    <Alert
+      actionRight={<Button size='sm'>Action!</Button>}
+      icon
+    >
+      Action Right Buddy with Icon!
+    </Alert>
+  </div>
+))
+
+stories.add('dismissible', () => (
+  <div>
+    <Alert dismissible>
+      Buddy! This is dismissible.
+    </Alert>
+  </div>
+))
+
+stories.add('icon', () => (
+  <div>
+    <Alert icon>Icon Buddy!</Alert>
+  </div>
+))
+
+stories.add('status', () => (
+  <div>
+    <Alert status='info'>Info Buddy!</Alert>
+    <Alert status='error'>Error Buddy!</Alert>
+    <Alert status='success'>Success Buddy!</Alert>
+    <Alert status='warning'>Warning Buddy!</Alert>
+  </div>
+))

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,6 +1,7 @@
 import '../src/styles/blue.scss'
 import '../src/styles/blue.hs-app.scss'
 
+import './Alert'
 import './Animate'
 import './Avatar'
 import './AvatarStack'


### PR DESCRIPTION
## Add Alert component

![screen recording 2017-10-18 at 06 03 pm](https://user-images.githubusercontent.com/2322354/31745567-4e102d00-b431-11e7-87c4-eb15c63ff392.gif)

This update adds a new Alert component, with the styles come from [seed-alert](http://developer.helpscout.net/seed/packs/seed-alert/).

### Example

```jsx
<Alert dismissable icon>
  Not now Arctic Puffin!
</Alert>
```

Additionally, the `CloseButton` component was enhanced with a new `seamless` style and new `size` props to allow it to be used within Alert for dismissal.

This one is for you @ryan-mulrooney ❤️ 

Resolves: https://github.com/helpscout/blue/issues/87