### PR TITLE
KeypressListener: Work with iframes

### DIFF
--- a/src/components/KeypressListener/index.js
+++ b/src/components/KeypressListener/index.js
@@ -1,10 +1,12 @@
-// See:
+// Modified version of:
 // https://github.com/Shopify/polaris/blob/master/src/components/KeypressListener/KeypressListener.tsx
 
-import { Component } from 'react'
+import React, { PureComponent as Component } from 'react'
+import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
-import { noop } from '../../utilities/other'
 import { addEventListener, removeEventListener } from '@shopify/javascript-utilities/events'
+import { getClosestDocument } from '../../utilities/node'
+import { noop } from '../../utilities/other'
 
 export const propTypes = {
   keyCode: PropTypes.number,
@@ -25,16 +27,27 @@ class KeypressListener extends Component {
   constructor () {
     super()
     this.handleKeyEvent = this.handleKeyEvent.bind(this)
+    this.node = null
+    this.scope = null
   }
 
   componentDidMount () {
     const { scope } = this.props
-    addEventListener(scope, this.props.type, this.handleKeyEvent)
+    this.node = ReactDOM.findDOMNode(this)
+    this.scope = scope === document ? getClosestDocument(this.node) : scope
+
+    addEventListener(this.scope, this.props.type, this.handleKeyEvent)
   }
 
   componentWillUnmount () {
-    const { scope } = this.props
-    removeEventListener(scope, this.props.type, this.handleKeyEvent)
+    removeEventListener(this.scope, this.props.type, this.handleKeyEvent)
+
+    this.node = null
+    this.scope = null
+  }
+
+  shouldComponentUpdate () {
+    return false
   }
 
   handleKeyEvent (event) {
@@ -74,7 +87,7 @@ class KeypressListener extends Component {
   }
 
   render () {
-    return null
+    return (<div />)
   }
 }
 

--- a/src/components/KeypressListener/tests/KeypressListener.test.js
+++ b/src/components/KeypressListener/tests/KeypressListener.test.js
@@ -197,3 +197,20 @@ describe('Only, without modifier keys', () => {
     wrapper.unmount()
   })
 })
+
+describe('Scope', () => {
+  test('Sets document as scope by default', () => {
+    const wrapper = mount(<KeypressListener />)
+    const o = wrapper.instance()
+
+    expect(o.scope === document).toBeTruthy()
+  })
+
+  test('Can set a specific node scope', () => {
+    const div = document.createElement('div')
+    const wrapper = mount(<KeypressListener scope={div} />)
+    const o = wrapper.instance()
+
+    expect(o.scope === div).toBeTruthy()
+  })
+})

--- a/src/utilities/node.js
+++ b/src/utilities/node.js
@@ -146,3 +146,7 @@ export const isNodeVisible = (options) => {
 
   return parseInt(top, 10) <= parseInt(viewportBottom, 10) && parseInt(bottom, 10) >= parseInt(viewportTop, 10)
 }
+
+export const getClosestDocument = (node) => {
+  return node && isNodeElement(node) ? node.ownerDocument : document
+}

--- a/src/utilities/tests/node/getClosestDocument.test.js
+++ b/src/utilities/tests/node/getClosestDocument.test.js
@@ -1,0 +1,33 @@
+import {
+  getClosestDocument
+} from '../../node'
+
+afterEach(() => {
+  global.document.innerHTML = ''
+})
+
+test('Returns global document, by default', () => {
+  expect(getClosestDocument() === document).toBeTruthy()
+})
+
+test('Returns global document, if argument is not a node', () => {
+  expect(getClosestDocument('div') === document).toBeTruthy()
+})
+
+test('Returns global document, node parent is global document', () => {
+  const o = document.createElement('div')
+  document.body.appendChild(o)
+
+  expect(getClosestDocument(o) === document).toBeTruthy()
+})
+
+test('Returns closest document of iframe node', () => {
+  const iframe = document.createElement('iframe')
+  document.body.appendChild(iframe)
+  iframe.contentDocument.write('<div></div>')
+
+  const o = iframe.contentDocument.querySelector('div')
+  const iframeDocument = iframe.contentDocument
+
+  expect(getClosestDocument(o) === iframeDocument).toBeTruthy()
+})


### PR DESCRIPTION
## KeypressListener: Work with iframes

This update adds a new node util, that retrieves the closest `document`, given
a DOM node. This allows for KeypressListener to be used within an `iframe`,
and bind events to the iframe `document`, vs the global window `document`.

The scope is automatically set in the KeypressListener component. Various
other Blue components that use these bindings like Portal, Modal, or Dropdown,
do not need to be updated.