### PR TITLE
Input: Multiline - Fix ghost overflow

### DIFF
--- a/src/styles/components/Input/InputResizer.scss
+++ b/src/styles/components/Input/InputResizer.scss
@@ -3,6 +3,7 @@
   bottom: 0;
   height: 0;
   left: 0;
+  overflow: hidden;
   position: absolute;
   right: 0;
   visibility: hidden;


### PR DESCRIPTION
## Input: Multiline - Fix ghost overflow

![screen recording 2017-10-27 at 12 19 pm](https://user-images.githubusercontent.com/2322354/32114440-8d87204c-bb11-11e7-91aa-f202f3d67ff3.gif)

This update adds `overflow:hidden` to the wrapping component of the input
ghosts. This ensures that the ghost components (that are involved in Input
multiline calculation) don't affect the layout.

Tested in Storybook. This change does not prevent the Input component from
re-calculating the height.

Resolves: https://github.com/helpscout/blue/issues/104