### PR TITLE
Dropdown: Simplify positioning

### DIFF
--- a/src/components/Drop/Positioner.js
+++ b/src/components/Drop/Positioner.js
@@ -5,7 +5,7 @@ import EventListener from '../EventListener'
 import classNames from '../../utilities/classNames'
 import { applyStylesToNode, isNodeElement } from '../../utilities/node'
 import {
-  getOptimalViewportPosition,
+  getViewportPosition,
   getDirections
 } from '../../utilities/nodePosition'
 import { noop } from '../../utilities/other'
@@ -82,7 +82,7 @@ class Positioner extends Component {
     // the getOptimalViewportPosition method is tested.
     // However, I'm unable to test it with this component due to the difficulty
     // of setting up Enzyme to recognize the triggerNode
-    return getOptimalViewportPosition({
+    return getViewportPosition({
       triggerNode: this.triggerNode,
       contentNode: this.contentNode,
       offset: offset,

--- a/src/components/Dropdown/Menu.js
+++ b/src/components/Dropdown/Menu.js
@@ -218,9 +218,11 @@ class Menu extends Component {
     if (focusItem) {
       const node = focusItem.node
       node.focus()
-      /* instabul ignore next */
+      /* istanbul ignore next */
       // Cannot be tested in JSDOM, due to lack of scrollHeight DOM API
       if (isNodeScrollable(this.scrollableNode)) {
+        /* istanbul ignore next */
+        // Scrolling does not exist in JSDOM
         node.scrollIntoView()
       }
     }

--- a/src/components/Dropdown/Menu.js
+++ b/src/components/Dropdown/Menu.js
@@ -12,7 +12,10 @@ import Keys from '../../constants/Keys'
 import classNames from '../../utilities/classNames'
 import { incrementFocusIndex } from '../../utilities/focus'
 import { noop } from '../../utilities/other'
-import { applyStylesToNode } from '../../utilities/node'
+import {
+  applyStylesToNode,
+  isNodeScrollable
+} from '../../utilities/node'
 import { getHeightRelativeToViewport } from '../../utilities/nodePosition'
 
 export const propTypes = {
@@ -76,6 +79,7 @@ class Menu extends Component {
     this.node = null
     this.wrapperNode = null
     this.contentNode = null
+    this.scrollableNode = null
     this.listNode = null
     // https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
     this._isMounted = false
@@ -214,7 +218,11 @@ class Menu extends Component {
     if (focusItem) {
       const node = focusItem.node
       node.focus()
-      node.scrollIntoView()
+      /* instabul ignore next */
+      // Cannot be tested in JSDOM, due to lack of scrollHeight DOM API
+      if (isNodeScrollable(this.scrollableNode)) {
+        node.scrollIntoView()
+      }
     }
   }
 
@@ -362,7 +370,9 @@ class Menu extends Component {
                 ref={node => { this.contentNode = node }}
                 style={{height: this.height}}
               >
-                <Scrollable>
+                <Scrollable
+                  scrollableRef={node => { this.scrollableNode = node }}
+                >
                   <div
                     className='c-DropdownMenu__list'
                     ref={node => { this.listNode = node }}

--- a/src/utilities/node.js
+++ b/src/utilities/node.js
@@ -147,6 +147,26 @@ export const isNodeVisible = (options) => {
   return parseInt(top, 10) <= parseInt(viewportBottom, 10) && parseInt(bottom, 10) >= parseInt(viewportTop, 10)
 }
 
+export const getScrollParent = (node) => {
+  /* istanbul ignore next */
+  if (!isNodeElement(node)) {
+    return null
+  }
+  /* istanbul ignore next */
+  // Cannot be tested in JSDOM. scrollHeight and clientHeight do not exist.
+  if (node.scrollHeight > node.clientHeight) {
+    return node
+  } else {
+    return getScrollParent(node.parentNode)
+  }
+}
+
+export const isNodeScrollable = (node) => {
+  /* istanbul ignore next */
+  // Cannot be tested in JSDOM. scrollHeight and clientHeight do not exist.
+  return node && isNodeElement(node) ? node.scrollHeight > node.clientHeight : false
+}
+
 export const getClosestDocument = (node) => {
   return node && isNodeElement(node) ? node.ownerDocument : document
 }

--- a/src/utilities/node.js
+++ b/src/utilities/node.js
@@ -148,7 +148,7 @@ export const isNodeVisible = (options) => {
 }
 
 export const getScrollParent = (node) => {
-  /* istanbul ignore next */
+  /* istanbul ignore else */
   if (!isNodeElement(node)) {
     return null
   }

--- a/src/utilities/tests/node/getScrollParent.test.js
+++ b/src/utilities/tests/node/getScrollParent.test.js
@@ -1,0 +1,10 @@
+import {
+  getScrollParent
+} from '../../node'
+
+test('Returns null for invalid arguments', () => {
+  expect(getScrollParent()).toBe(null)
+  expect(getScrollParent(true)).toBe(null)
+  expect(getScrollParent('div')).toBe(null)
+  expect(getScrollParent({})).toBe(null)
+})

--- a/src/utilities/tests/nodePosition/getDirectionY.test.js
+++ b/src/utilities/tests/nodePosition/getDirectionY.test.js
@@ -9,7 +9,7 @@ test('Returns false for invalid arguments', () => {
 })
 
 test('Returns blank if no matches', () => {
-  expect(getDirectionY('nopeeeeeee')).toBe('down')
+  expect(getDirectionY('nopeeeeeee')).toBe('')
 })
 
 test('Returns down if matches', () => {

--- a/src/utilities/tests/nodePosition/getViewportPosition.test.js
+++ b/src/utilities/tests/nodePosition/getViewportPosition.test.js
@@ -1,0 +1,203 @@
+import {
+  getViewportPosition
+} from '../../nodePosition'
+
+test('Returns false for invalid arguments', () => {
+  expect(getViewportPosition()).toBeFalsy()
+  expect(getViewportPosition(true)).toBeFalsy()
+  expect(getViewportPosition({})).toBeFalsy()
+})
+
+test('Returns false for invalid triggerNode + contentNode', () => {
+  const triggerNode = document.createElement('div')
+  const contentNode = document.createElement('div')
+
+  expect(getViewportPosition({
+    triggerNode: true,
+    contentNode: true
+  })).toBeFalsy()
+
+  expect(getViewportPosition({
+    triggerNode,
+    contentNode: true
+  })).toBeFalsy()
+
+  expect(getViewportPosition({
+    triggerNode: true,
+    contentNode
+  })).toBeFalsy()
+})
+
+test('Returns coordinates object for valid elements', () => {
+  const triggerNode = document.createElement('div')
+  const contentNode = document.createElement('div')
+  document.body.appendChild(triggerNode)
+  document.body.appendChild(contentNode)
+
+  triggerNode.getBoundingClientRect = () => ({
+    width: 100,
+    height: 80,
+    top: 80,
+    left: 8,
+    right: 0,
+    bottom: 0
+  })
+  contentNode.getBoundingClientRect = () => ({
+    width: 200,
+    height: 400,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0
+  })
+  const offset = 8
+  const o = getViewportPosition({ triggerNode, contentNode, offset })
+
+  expect(typeof o).toBe('object')
+  expect(o.top).not.toBe('undefined')
+  expect(o.left).not.toBe('undefined')
+  expect(o.offsetTop).not.toBe('undefined')
+  expect(o.offsetLeft).not.toBe('undefined')
+  expect(o.direction).not.toBe('undefined')
+  expect(o.direction.x).not.toBe('undefined')
+  expect(o.direction.y).not.toBe('undefined')
+})
+
+test('Returns calculated top/left props for valid elements', () => {
+  const triggerNode = document.createElement('div')
+  const contentNode = document.createElement('div')
+  document.body.appendChild(triggerNode)
+  document.body.appendChild(contentNode)
+
+  const triggerNodeClientRect = {
+    width: 100,
+    height: 80,
+    top: 80,
+    left: 8,
+    right: 400,
+    bottom: 0
+  }
+  const contentNodeClientRect = {
+    width: 200,
+    height: 400,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0
+  }
+
+  triggerNode.getBoundingClientRect = () => (triggerNodeClientRect)
+  contentNode.getBoundingClientRect = () => (contentNodeClientRect)
+  const offset = 8
+  const direction = { x: '', y: 'down' }
+  const o = getViewportPosition({ triggerNode, contentNode, offset, direction })
+
+  expect(o.top).toBe(triggerNodeClientRect.top + triggerNodeClientRect.height + offset)
+  expect(o.left).toBe(triggerNodeClientRect.left)
+})
+
+test('Returns offset of zero if no offset is defined', () => {
+  const triggerNode = document.createElement('div')
+  const contentNode = document.createElement('div')
+  document.body.appendChild(triggerNode)
+  document.body.appendChild(contentNode)
+
+  const triggerNodeClientRect = {
+    width: 100,
+    height: 80,
+    top: 0,
+    left: 0,
+    right: 400,
+    bottom: 0
+  }
+  const contentNodeClientRect = {
+    width: 200,
+    height: 400,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0
+  }
+
+  const boundingOffset = 8
+  triggerNode.getBoundingClientRect = () => (triggerNodeClientRect)
+  contentNode.getBoundingClientRect = () => (contentNodeClientRect)
+  const o = getViewportPosition({ triggerNode, contentNode })
+
+  expect(o.offset).toBe(0 + boundingOffset)
+})
+
+describe('Positioning', () => {
+  // Note: JSDOM's window dimensions are 1024x768
+  test('Adjusts from up -> down, if applicable', () => {
+    const triggerNode = document.createElement('div')
+    const contentNode = document.createElement('div')
+    document.body.appendChild(triggerNode)
+    document.body.appendChild(contentNode)
+
+    const triggerNodeClientRect = {
+      width: 100,
+      height: 80,
+      top: 0,
+      left: 8,
+      right: 400,
+      bottom: 0
+    }
+    const contentNodeClientRect = {
+      width: 200,
+      height: 400,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0
+    }
+    triggerNode.getBoundingClientRect = () => (triggerNodeClientRect)
+    contentNode.getBoundingClientRect = () => (contentNodeClientRect)
+
+    const offset = 8
+    const direction = {
+      x: '',
+      y: 'up'
+    }
+
+    const o = getViewportPosition({ triggerNode, contentNode, offset, direction })
+
+    expect(o.direction.y).toBe('down')
+  })
+
+  test('Adjusts from down -> up, if applicable', () => {
+    const triggerNode = document.createElement('div')
+    const contentNode = document.createElement('div')
+    document.body.appendChild(triggerNode)
+    document.body.appendChild(contentNode)
+
+    const triggerNodeClientRect = {
+      width: 100,
+      height: 80,
+      top: 700,
+      left: 8,
+      right: 400,
+      bottom: 0
+    }
+    const contentNodeClientRect = {
+      width: 200,
+      height: 400,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0
+    }
+    triggerNode.getBoundingClientRect = () => (triggerNodeClientRect)
+    contentNode.getBoundingClientRect = () => (contentNodeClientRect)
+
+    const offset = 8
+    const direction = {
+      x: '',
+      y: 'down'
+    }
+
+    const o = getViewportPosition({ triggerNode, contentNode, offset, direction })
+
+    expect(o.direction.y).toBe('up')
+  })
+})

--- a/stories/Dropdown.js
+++ b/stories/Dropdown.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Dropdown, Flexy, Link } from '../src/index.js'
+import { Dropdown, Flexy, Hr, Link } from '../src/index.js'
 
 const logAction = (i) => () => {
   console.log(`Action ${i}`)
@@ -64,7 +64,7 @@ stories.add('Default', () => (
         </Dropdown>
       </Flexy.Item>
       <Flexy.Item>
-        <Dropdown direction='left up'>
+        <Dropdown>
           <Dropdown.Trigger>
             Another
           </Dropdown.Trigger>
@@ -124,5 +124,53 @@ stories.add('Trigger', () => (
         {itemsMarkup(10)}
       </Dropdown.Menu>
     </Dropdown>
+  </div>
+))
+
+stories.add('directions', () => (
+  <div style={{padding: 100}}>
+    <Dropdown direction='down left'>
+      <Dropdown.Trigger>
+        Down (Left)
+      </Dropdown.Trigger>
+      <Dropdown.Menu>
+        {itemsMarkup(3)}
+      </Dropdown.Menu>
+    </Dropdown>
+
+    <Hr />
+
+    <Dropdown direction='down right'>
+      <Dropdown.Trigger>
+        Down (Right)
+      </Dropdown.Trigger>
+      <Dropdown.Menu>
+        {itemsMarkup(3)}
+      </Dropdown.Menu>
+    </Dropdown>
+
+    <Hr />
+
+    <Dropdown direction='up left'>
+      <Dropdown.Trigger>
+        Up (Left)
+      </Dropdown.Trigger>
+      <Dropdown.Menu>
+        {itemsMarkup(3)}
+      </Dropdown.Menu>
+    </Dropdown>
+
+    <Hr />
+
+    <Dropdown direction='up right'>
+      <Dropdown.Trigger>
+        Up (Right)
+      </Dropdown.Trigger>
+      <Dropdown.Menu>
+        {itemsMarkup(3)}
+      </Dropdown.Menu>
+    </Dropdown>
+
+    <Hr />
   </div>
 ))


### PR DESCRIPTION
## Dropdown: Simplify positioning

![screen recording 2017-10-27 at 03 14 pm](https://user-images.githubusercontent.com/2322354/32121518-e6326440-bb2a-11e7-87fb-61e513898403.gif)

This update simplifies the positioning calculations used by the Dropdown
component (more accurately, the Drop.Positioner component).

The adjusted positions are similar to the ones available in other
Dropdown libraries, like Bootstrap.

This is a temporary "downgrade", until I can implement the [12/16-point
positioning system](https://github.com/helpscout/blue/issues/103), that we can leverage for Tooltips and Popovers.

For now, the Drop.Positioner calculations only benefit Dropdown.

Note: Up/down recalcuation is still available. However, left/right
recalculations have been removed.

### Bug Fixes

The DropdownMenu has also been enhanced to only `scrollIntoView` if the
Scrollable component has a scrollbar. This is to resolve that function
forcing the window to scroll.