### PR TITLE
Drop: Fix className and style props for ComposedComponent

### DIFF
--- a/src/components/Drop/index.js
+++ b/src/components/Drop/index.js
@@ -71,10 +71,12 @@ export const DropComponent = (/* istanbul ignore next */ options = defaultOption
             zIndex={zIndex}
           >
             <ComposedComponent
+              className={className}
               closePortal={closePortal}
               isOpen={portalIsOpen}
               onClose={onClose}
               onOpen={onOpen}
+              style={style}
               {...rest}
             />
           </Positioner>

--- a/src/components/Drop/tests/Drop.test.js
+++ b/src/components/Drop/tests/Drop.test.js
@@ -1,13 +1,25 @@
 import React from 'react'
 import { mount, shallow } from 'enzyme'
 import Drop from '..'
+import classNames from '../../../utilities/classNames'
 
 const ContentComponent = props => {
+  const { className, style } = props
+  const componentClassName = classNames(
+    'content',
+    className
+  )
   const handleClick = () => {
     console.log('wee')
   }
   return (
-    <div className='content' onClick={handleClick}>Content</div>
+    <div
+      className={componentClassName}
+      onClick={handleClick}
+      style={style}
+    >
+      Content
+    </div>
   )
 }
 const trigger = (
@@ -25,6 +37,26 @@ test('Can create a component as a HOC', () => {
 
   expect(o).toBeTruthy()
   expect(o.innerHTML).toContain('Content')
+
+  wrapper.unmount()
+})
+
+test('Can pass className to composed component', () => {
+  const TestComponent = Drop()(ContentComponent)
+  const wrapper = mount(<TestComponent className='ron' isOpen />)
+  const o = document.querySelector('.content')
+
+  expect(o.classList.contains('ron')).toBeTruthy()
+
+  wrapper.unmount()
+})
+
+test('Can styles to composed component', () => {
+  const TestComponent = Drop()(ContentComponent)
+  const wrapper = mount(<TestComponent style={{background: 'red'}} isOpen />)
+  const o = document.querySelector('.content')
+
+  expect(o.style.background).toBe('red')
 
   wrapper.unmount()
 })

--- a/src/components/Dropdown/tests/Menu.test.js
+++ b/src/components/Dropdown/tests/Menu.test.js
@@ -16,6 +16,22 @@ afterEach(() => {
   document.body.innerHTML = ''
 })
 
+describe('Classname', () => {
+  test('Has default className', () => {
+    const wrapper = shallow(<MenuComponent />)
+    const o = wrapper.find('.c-DropdownMenu')
+
+    expect(o.length).toBeTruthy()
+  })
+
+  test('Can accept custom classNames', () => {
+    const wrapper = shallow(<MenuComponent className='ron' />)
+    const o = wrapper.find('.c-DropdownMenu')
+
+    expect(o.hasClass('ron')).toBeTruthy()
+  })
+})
+
 describe('Nodes', () => {
   test('Has a reference to DOM nodes', () => {
     const wrapper = mount(<MenuComponent />)


### PR DESCRIPTION
## Drop: Fix className and style props for ComposedComponent

This update fixes the Drop HOC to correctly pass `className` and `style` props
to the ComposedComponent.