### PR TITLE
Add Helix + simple integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@helpscout/helix": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@helpscout/helix/-/helix-0.0.8.tgz",
+      "integrity": "sha512-1/1vAYH5cec+xnNBMy3fwlzekAeBUXqSMMyg2Tsa5ZH8khABjIHh2L+1N/cb0HsFgC0jEDo4L6KEvIFR/dpeww==",
+      "dev": true,
+      "requires": {
+        "faker": "4.1.0",
+        "lodash": "4.17.4"
+      }
+    },
     "@hypnosphi/fuse.js": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/@hypnosphi/fuse.js/-/fuse.js-3.0.9.tgz",
@@ -6142,6 +6152,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+      "dev": true
+    },
+    "faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
       "dev": true
     },
     "fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-transition-group": "2.2.0"
   },
   "devDependencies": {
+    "@helpscout/helix": "0.0.8",
     "@storybook/addon-options": "^3.2.4",
     "@storybook/cli": "^3.2.9",
     "@storybook/react": "^3.2.4",

--- a/src/tests/libraries/helix/createSpec.test.js
+++ b/src/tests/libraries/helix/createSpec.test.js
@@ -1,0 +1,31 @@
+import { createSpec, faker } from '@helpscout/helix'
+
+test('Can create and generate a spec', () => {
+  const Spec = createSpec({
+    id: faker.random.number(),
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName()
+  })
+
+  const fixture = Spec.generate()
+
+  expect(typeof fixture.id).toBe('number')
+  expect(typeof fixture.firstName).toBe('string')
+  expect(typeof fixture.lastName).toBe('string')
+})
+
+test('Can seed fixture results', () => {
+  const Spec = createSpec({
+    id: faker.random.number(),
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName()
+  })
+
+  const one = Spec.seed(1).generate()
+  const two = Spec.seed(2).generate()
+  const three = Spec.seed(1).generate()
+
+  expect(one.id).not.toBe(two.id)
+  expect(two.id).not.toBe(three.id)
+  expect(three.id).toBe(one.id)
+})

--- a/src/tests/libraries/helix/faker.test.js
+++ b/src/tests/libraries/helix/faker.test.js
@@ -1,0 +1,42 @@
+import { createSpec, faker } from '@helpscout/helix'
+
+test('Can generate simple computed values', () => {
+  const Computed = createSpec({
+    id: faker.random.number(),
+    name: faker.fake('{{name.firstName}} {{name.lastName}}')
+  })
+
+  const name = Computed.seed(1).generate().name.split(' ')
+
+  expect(name.length).toBe(2)
+  expect(typeof name[0]).toBe('string')
+  expect(typeof name[1]).toBe('string')
+})
+
+test('Can generate functional computed values', () => {
+  const Computed = createSpec({
+    id: faker.random.number(),
+    name: () => faker.fake('{{name.firstName}} {{name.lastName}}')
+  })
+
+  const name = Computed.seed(1).generate().name.split(' ')
+
+  expect(name.length).toBe(2)
+  expect(typeof name[0]).toBe('string')
+  expect(typeof name[1]).toBe('string')
+})
+
+test('Can generate complex computed values', () => {
+  const props = { name: faker.name.firstName() }
+  const Computed = createSpec({
+    id: faker.random.number(),
+    name: faker.computed(props)(values => {
+      return `${values.name}-123`
+    })
+  })
+
+  const name = Computed.seed(1).generate().name
+
+  expect(typeof name).toBe('string')
+  expect(name).toContain('-123')
+})

--- a/src/tests/libraries/helix/withReactComponents.test.js
+++ b/src/tests/libraries/helix/withReactComponents.test.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { createSpec, faker } from '@helpscout/helix'
+import { Card, Text } from '../../../'
+
+test('Renders fixture data into Blue component', () => {
+  const fixture = createSpec({
+    id: faker.random.uuid(),
+    name: faker.fake('{{name.firstName}} {{name.lastName}}'),
+    text: faker.lorem.sentence()
+  }).generate()
+
+  const wrapper = shallow(
+    <Card id={fixture.id}>
+      <Text className='name' muted>{fixture.name} said…</Text><br />
+      <Text className='message'>"{fixture.text}"</Text>
+    </Card>
+  )
+
+  const name = wrapper.find('.name')
+  const message = wrapper.find('.message')
+
+  expect(wrapper.props().id).toBe(fixture.id)
+  expect(name.props().children).toContain(fixture.name)
+  expect(message.props().children).toContain(fixture.text)
+})


### PR DESCRIPTION
## Add Helix + simple integration tests

This update adds [Helix](https://github.com/helpscout/helix), our fixture generating library.
Simple integration tests with Helix has also been added.

Resolves: https://github.com/helpscout/blue/issues/110