### PR TITLE
Pressing ESC should not close all Portal components

### DIFF
--- a/src/components/Portal/index.js
+++ b/src/components/Portal/index.js
@@ -38,6 +38,7 @@ class Portal extends React.Component {
     this.isClosing = false
     this.mountPortal = this.mountPortal.bind(this)
     this.unmountPortal = this.unmountPortal.bind(this)
+    this._portalList = []
   }
 
   componentDidMount () {
@@ -109,6 +110,8 @@ class Portal extends React.Component {
     // Render to specified target, instead of document
     this.mountSelector.appendChild(this.node)
     this.renderPortalContent(props)
+
+    this._portalList.push(this.node)
 
     if (onOpen) onOpen(this)
 

--- a/src/components/Portal/index.js
+++ b/src/components/Portal/index.js
@@ -38,7 +38,6 @@ class Portal extends React.Component {
     this.isClosing = false
     this.mountPortal = this.mountPortal.bind(this)
     this.unmountPortal = this.unmountPortal.bind(this)
-    this._portalList = []
   }
 
   componentDidMount () {
@@ -110,8 +109,6 @@ class Portal extends React.Component {
     // Render to specified target, instead of document
     this.mountSelector.appendChild(this.node)
     this.renderPortalContent(props)
-
-    this._portalList.push(this.node)
 
     if (onOpen) onOpen(this)
 

--- a/src/components/PortalWrapper/index.js
+++ b/src/components/PortalWrapper/index.js
@@ -6,10 +6,13 @@ import KeypressListener from '../KeypressListener'
 import { default as Portal, propTypes as portalTypes } from '../Portal'
 import Keys from '../../constants/Keys'
 import { createUniqueIDFactory } from '../../utilities/id'
+import { setupManager } from '../../utilities/globalManager'
 
 const defaultOptions = {
   id: 'PortalWrapper'
 }
+
+const managerNamespace = 'BluePortalWrapperManager'
 
 const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
   const propTypes = portalTypes
@@ -24,6 +27,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
   class PortalWrapper extends Component {
     constructor (props) {
       super()
+
       this.state = Object.assign({}, props, options, {
         id: uniqueID(),
         isMounted: props.isOpen
@@ -31,10 +35,17 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
       this.closePortal = this.closePortal.bind(this)
       this.openPortal = this.openPortal.bind(this)
       this.handleOnClose = this.handleOnClose.bind(this)
-      this.bodyOverflowStyle = null
+      // Welcome aboard, Mr. Manager!
+      this._MrManager = setupManager(managerNamespace)
+      // Wow, I'm Mr. Manager!
+      // Well, manager… we we just say manager.
     }
 
     componentDidMount () {
+      const { id, isMounted } = this.state
+      if (isMounted) {
+        this._MrManager.add(id)
+      }
       if (this.props.path) {
         this.openPortal()
       }
@@ -49,17 +60,23 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
 
     /* istanbul ignore next */
     openPortal () {
+      const { id } = this.state
       this.setState({
         isOpen: true,
         isMounted: true
       })
+      this._MrManager.add(id)
     }
 
     closePortal () {
-      this.setState({
-        isOpen: false,
-        isMounted: false
-      })
+      const { id } = this.state
+      if (this._MrManager.last() === id) {
+        this.setState({
+          isOpen: false,
+          isMounted: false
+        })
+        this._MrManager.remove(id)
+      }
     }
 
     sequenceClosePortal (onClose) {

--- a/src/components/PortalWrapper/tests/PortalWrapper.test.js
+++ b/src/components/PortalWrapper/tests/PortalWrapper.test.js
@@ -62,3 +62,35 @@ describe('ID', () => {
     expect(c.id).toContain('Brick')
   })
 })
+
+describe('Manager', () => {
+  test('Can close last Manage item ', () => {
+    const TestComponent = PortalWrapper()(TestButton)
+    const wrapper = mount(
+      <div>
+        <TestComponent isOpen />
+        <TestComponent isOpen />
+      </div>
+    )
+    const c = document.body.childNodes[0]
+    const o = wrapper.find(TestComponent).last()
+
+    o.node.closePortal()
+    expect(o.node.state.isOpen).toBe(false)
+  })
+
+  test('Cannot close Component that is not last in Manage list', () => {
+    const TestComponent = PortalWrapper()(TestButton)
+    const wrapper = mount(
+      <div>
+        <TestComponent isOpen />
+        <TestComponent isOpen />
+      </div>
+    )
+    const c = document.body.childNodes[0]
+    const o = wrapper.find(TestComponent).first()
+
+    o.node.closePortal()
+    expect(o.node.state.isOpen).toBe(true)
+  })
+})

--- a/src/components/PortalWrapper/tests/PortalWrapper.test.js
+++ b/src/components/PortalWrapper/tests/PortalWrapper.test.js
@@ -72,7 +72,6 @@ describe('Manager', () => {
         <TestComponent isOpen />
       </div>
     )
-    const c = document.body.childNodes[0]
     const o = wrapper.find(TestComponent).last()
 
     o.node.closePortal()
@@ -87,7 +86,6 @@ describe('Manager', () => {
         <TestComponent isOpen />
       </div>
     )
-    const c = document.body.childNodes[0]
     const o = wrapper.find(TestComponent).first()
 
     o.node.closePortal()

--- a/src/utilities/globalManager.js
+++ b/src/utilities/globalManager.js
@@ -1,0 +1,40 @@
+import { createUniqueIDFactory } from './id'
+
+export const setupManager = (namespace = '') => {
+  const ns = (typeof namespace !== 'string' || !namespace.length)
+  ? createUniqueIDFactory('BlueGlobalManager')() : namespace
+
+  window[ns] = window[ns] || []
+
+  // Welcome aboard, Mr. Manager!
+  // Wow, I'm Mr. Manager!
+  // Well, manager… we we just say manager.
+  return {
+    data: window[ns],
+    add: add(window[ns]),
+    remove: remove(window[ns]),
+    first: first(window[ns]),
+    last: last(window[ns])
+  }
+}
+
+export const add = manager => item => {
+  manager.push(item)
+  return manager
+}
+
+export const remove = manager => item => {
+  const index = manager.indexOf(item)
+  if (index >= 0) {
+    manager.splice(index, 1)
+  }
+  return manager
+}
+
+export const first = manager => () => {
+  return manager[0]
+}
+
+export const last = manager => () => {
+  return manager[manager.length - 1]
+}

--- a/src/utilities/tests/globalManager.test.js
+++ b/src/utilities/tests/globalManager.test.js
@@ -1,0 +1,83 @@
+import { setupManager } from '../globalManager'
+
+const defaultNameSpace = 'BlueGlobalManager'
+
+afterEach(() => {
+  window.Buddy = undefined
+})
+
+describe('Namespace', () => {
+  test('Adds a namespace by default', () => {
+    setupManager()
+    expect(window[`${defaultNameSpace}1`]).toBeTruthy()
+  })
+
+  test('Can define a namespace', () => {
+    expect(window.Buddy).not.toBeTruthy()
+    setupManager('Buddy')
+    expect(window.Buddy).toBeTruthy()
+  })
+
+  test('Does not override existing global object', () => {
+    window.Buddy = { elf: true }
+    setupManager('Buddy')
+
+    expect(window.Buddy.elf).toBe(true)
+  })
+})
+
+describe('Add', () => {
+  test('Adds item to manager data', () => {
+    const manager = setupManager('Buddy')
+    manager.add('sugar')
+    manager.add('syrup')
+
+    expect(window.Buddy.length).toBe(2)
+    expect(window.Buddy.indexOf('syrup')).toBe(1)
+  })
+})
+
+describe('Remove', () => {
+  test('Removes item from manager data', () => {
+    const manager = setupManager('Buddy')
+    manager.add('sugar')
+    manager.add('syrup')
+    manager.remove('syrup')
+    expect(window.Buddy.indexOf('syrup')).toBe(-1)
+    manager.remove('fake')
+    expect(window.Buddy.indexOf('sugar')).toBe(0)
+    manager.remove('sugar')
+    expect(window.Buddy.indexOf('sugar')).toBe(-1)
+  })
+})
+
+describe('First', () => {
+  test('Returns first item', () => {
+    const manager = setupManager('Buddy')
+    manager.add('sugar')
+    manager.add('syrup')
+
+    expect(manager.first()).toBe('sugar')
+  })
+})
+
+describe('Last', () => {
+  test('Returns last item', () => {
+    const manager = setupManager('Buddy')
+    manager.add('sugar')
+    manager.add('syrup')
+
+    expect(manager.last()).toBe('syrup')
+  })
+})
+
+describe('Data', () => {
+  test('Returns managed data', () => {
+    const manager = setupManager('Buddy')
+    manager.add('sugar')
+    manager.add('syrup')
+
+    expect(manager.data.length).toBe(2)
+    expect(manager.data.indexOf('syrup')).toBe(1)
+  })
+})


### PR DESCRIPTION
## Pressing ESC should not close all Portal components

![screen recording 2017-11-27 at 12 52 pm](https://user-images.githubusercontent.com/2322354/33291248-2f808638-d393-11e7-96f9-58729961f480.gif)

This update adds a new "Manager" to the PortalWrapper component,
created with the new `globalManager` utility. This manager ensures
that pressing Escape ONLY closes the most recently Portal'ed component.

This is done by the manager tracking the IDs (which are unique) of
all the PortalWrapper created components.

This has been tested with Modals as well as Dropdowns.

Resolves: https://github.com/helpscout/blue/issues/97