### PR TITLE
PortalWrapper: Fix integration with Route usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,43 +31,117 @@
         "lodash-decorators": "4.3.5"
       }
     },
-    "@storybook/addon-options": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-options/-/addon-options-3.2.6.tgz",
-      "integrity": "sha512-G3rB7sp7yB3UAnZMj0j8wKw1wPsDpi8shxPAHFnBeeSrXfRWyDlh52P6PfysGj7drPDnx5TIlZdetebRTL5EsA==",
+    "@storybook/addon-actions": {
+      "version": "3.2.16",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.2.16.tgz",
+      "integrity": "sha512-TXR/H5lDCtPCmc+/nidvVBiTlGsPHxeJ/LMPuGxq/yF7EvzrfXw+CuEuaPNp5qknSioOLm9GngbozNg8HfBgKg==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "3.2.6"
+        "@storybook/addons": "3.2.16",
+        "deep-equal": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "prop-types": "15.6.0",
+        "react-inspector": "2.2.1",
+        "uuid": "3.1.0"
       },
       "dependencies": {
-        "@storybook/addons": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.2.6.tgz",
-          "integrity": "sha512-i/sHbvEeMnnnLiPeXmE/b0OaVH5IM4U8CsdTh44RGjQVCnKstPpEhjD+hzPlhKFQnAtk9+vUxphvCWBgy6VouA==",
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.11.0"
+          }
+        },
+        "react-inspector": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.2.1.tgz",
+          "integrity": "sha512-aXrxJTfriJtZtv/+A9cFIOpfbt711yCD1Ht3fSn3JyuDaAt1+eLtb01R5d/8gGpyquOVWn/d+eM1VPqFXS7UZA==",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "is-dom": "1.0.9"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
           "dev": true
         }
       }
     },
-    "@storybook/cli": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-3.2.9.tgz",
-      "integrity": "sha1-XkAoBCG79jwlYGQ0HQW6rmlLEBA=",
+    "@storybook/addon-links": {
+      "version": "3.2.16",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.2.16.tgz",
+      "integrity": "sha512-JFs2p7EGRFpwUkg7xV7Vi3h/zBr4UjmprF9YYHR2L5TQFbztlKJPBhiATRSQtgFyNNAo7zNkSf439Rkrb9k7yQ==",
       "dev": true,
       "requires": {
-        "@storybook/codemod": "3.2.6",
-        "chalk": "2.1.0",
+        "@storybook/addons": "3.2.16"
+      }
+    },
+    "@storybook/addon-options": {
+      "version": "3.2.16",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-options/-/addon-options-3.2.16.tgz",
+      "integrity": "sha512-kg5ln/VGEi/yLpVcgK8z99JbAoEZGeJzExcke0ueHI4+xpx7yvZ0t4OhuOkbQpwC0V+bYZSbeWeAATw/igPwxg==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "3.2.16"
+      }
+    },
+    "@storybook/addons": {
+      "version": "3.2.16",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.2.16.tgz",
+      "integrity": "sha512-Dxs0XceqqUSG+vao5uCZdphmCAGlpnwDLV0abjYpPH0eKb2QN5Rs/Vrl0MzuOYGghPv8Y1QfhdB6DFh7AuIoTQ==",
+      "dev": true
+    },
+    "@storybook/channel-postmessage": {
+      "version": "3.2.16",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.2.16.tgz",
+      "integrity": "sha512-8D3UeZfb4TarkEp0xMCUxX5rW/m2YghYmlnFDcMCgPhN9R2pRySjxxbCjK+ry0q2hUII4R9Bbck63AUqwcQDow==",
+      "dev": true,
+      "requires": {
+        "@storybook/channels": "3.2.16",
+        "global": "4.3.2",
+        "json-stringify-safe": "5.0.1"
+      }
+    },
+    "@storybook/channels": {
+      "version": "3.2.16",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.2.16.tgz",
+      "integrity": "sha512-zjaDE/0yvlLfOcpzeTIWi1K7d873UykUmGLwFSO2hUIM7hlc+QxCeE0MH+OrQYUWC8gcU8pg+IWAk/6qzWAZsA==",
+      "dev": true
+    },
+    "@storybook/cli": {
+      "version": "3.2.16",
+      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-3.2.16.tgz",
+      "integrity": "sha512-9kfTGGTEQaSBPRWTAdQQ1jq0pwebnrIpwKWecvAV73astJ5AevrjvFxdAdIGim93qBC5JChbZNdpgL7GN8m5HA==",
+      "dev": true,
+      "requires": {
+        "@storybook/codemod": "3.2.16",
+        "chalk": "2.3.0",
         "child-process-promise": "2.2.1",
-        "commander": "2.9.0",
+        "commander": "2.12.2",
         "cross-spawn": "5.1.0",
         "jscodeshift": "0.3.32",
         "json5": "0.5.1",
         "latest-version": "3.1.0",
         "merge-dirs": "0.2.1",
-        "opencollective": "1.0.3",
         "shelljs": "0.7.8",
-        "update-notifier": "2.2.0"
+        "update-notifier": "2.3.0"
       },
       "dependencies": {
+        "@storybook/codemod": {
+          "version": "3.2.16",
+          "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-3.2.16.tgz",
+          "integrity": "sha512-Jzt/kjGPmUUrSobzhjcaamDyB+t4JgL7le4Sxt9jtcG0He7Ki99Ed8wVeTFVme1CgOkakIC0Yw9+1xlwfRTn7g==",
+          "dev": true,
+          "requires": {
+            "jscodeshift": "0.3.32"
+          }
+        },
         "ansi-align": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -93,14 +167,14 @@
           }
         },
         "boxen": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.1.tgz",
-          "integrity": "sha1-DxHn/jRO25OXl3/BPt5/ZNlWSB0=",
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz",
+          "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
           "dev": true,
           "requires": {
             "ansi-align": "2.0.0",
             "camelcase": "4.1.0",
-            "chalk": "2.1.0",
+            "chalk": "2.3.0",
             "cli-boxes": "1.0.0",
             "string-width": "2.1.1",
             "term-size": "1.2.0",
@@ -114,15 +188,21 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
         },
         "configstore": {
           "version": "3.1.1",
@@ -230,9 +310,9 @@
           }
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -251,61 +331,20 @@
           "dev": true
         },
         "update-notifier": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
-          "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+          "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
           "dev": true,
           "requires": {
-            "boxen": "1.2.1",
-            "chalk": "1.1.3",
+            "boxen": "1.2.2",
+            "chalk": "2.3.0",
             "configstore": "3.1.1",
             "import-lazy": "2.1.0",
+            "is-installed-globally": "0.1.0",
             "is-npm": "1.0.0",
             "latest-version": "3.1.0",
             "semver-diff": "2.1.0",
             "xdg-basedir": "3.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-              "dev": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
           }
         },
         "write-file-atomic": {
@@ -327,195 +366,127 @@
         }
       }
     },
-    "@storybook/codemod": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-3.2.6.tgz",
-      "integrity": "sha512-6BngQ3TP8w30Tzv+UBXQxb64/1INoQ1t58bMPrKtAzD2LYWtaWw1dypep1mhfSSYcliL/4hMAfsKujbotAdiNQ==",
+    "@storybook/mantra-core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@storybook/mantra-core/-/mantra-core-1.7.2.tgz",
+      "integrity": "sha512-GD4OYJ8GsayVhIg306sfgcKDk9j8YfuSKIAWvdB/g7IDlw0pDgueONALVEEE2XWJtCwcsUyDtCYzXFgCBWLEjA==",
       "dev": true,
       "requires": {
-        "jscodeshift": "0.3.32"
-      }
-    },
-    "@storybook/components": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.2.7.tgz",
-      "integrity": "sha1-fUxyIYUSYOQja7s++CpklLI+Xsk=",
-      "dev": true,
-      "requires": {
-        "glamor": "2.20.40",
-        "glamorous": "4.9.5",
-        "prop-types": "15.6.0"
-      },
-      "dependencies": {
-        "brcast": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
-          "integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg==",
-          "dev": true
-        },
-        "glamor": {
-          "version": "2.20.40",
-          "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
-          "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
-          "dev": true,
-          "requires": {
-            "fbjs": "0.8.12",
-            "inline-style-prefixer": "3.0.6",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0",
-            "through": "2.3.8"
-          }
-        },
-        "glamorous": {
-          "version": "4.9.5",
-          "resolved": "https://registry.npmjs.org/glamorous/-/glamorous-4.9.5.tgz",
-          "integrity": "sha512-yz9D8M8Yfic0LJ37J1GELXztfu5M2SYsu146wzku8Vq/V6N1SSSJWmBtaHB8emEpql9jhFwfh3Fc1lDKllp2Yg==",
-          "dev": true,
-          "requires": {
-            "brcast": "3.0.1",
-            "fast-memoize": "2.2.7",
-            "html-tag-names": "1.1.2",
-            "is-function": "1.0.1",
-            "is-plain-object": "2.0.4",
-            "react-html-attributes": "1.4.0",
-            "svg-tag-names": "1.1.1"
-          }
-        }
+        "@storybook/react-komposer": "2.0.3",
+        "@storybook/react-simple-di": "1.2.1",
+        "babel-runtime": "6.23.0"
       }
     },
     "@storybook/react": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.2.8.tgz",
-      "integrity": "sha1-fUPvRQVZt887PswXzFTVoJ1epAI=",
+      "version": "3.2.16",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.2.16.tgz",
+      "integrity": "sha512-gMS+KrI5u0OTnHYhyLkMLknCQRCyDL3QULXKCYtkUcZ6l2MKvOVSMwwG1VUPWssWtLBvN4Fdx9A+9BxDWLZhpw==",
       "dev": true,
       "requires": {
-        "@storybook/addon-actions": "3.2.6",
-        "@storybook/addon-links": "3.2.6",
-        "@storybook/addons": "3.2.6",
-        "@storybook/channel-postmessage": "3.2.0",
-        "@storybook/ui": "3.2.7",
-        "airbnb-js-shims": "1.2.0",
-        "autoprefixer": "7.1.1",
-        "babel-core": "6.25.0",
-        "babel-loader": "7.0.0",
-        "babel-plugin-react-docgen": "1.7.0",
-        "babel-preset-env": "1.6.0",
+        "@storybook/addon-actions": "3.2.16",
+        "@storybook/addon-links": "3.2.16",
+        "@storybook/addons": "3.2.16",
+        "@storybook/channel-postmessage": "3.2.16",
+        "@storybook/ui": "3.2.16",
+        "airbnb-js-shims": "1.3.0",
+        "autoprefixer": "7.1.6",
+        "babel-core": "6.26.0",
+        "babel-loader": "7.1.2",
+        "babel-plugin-react-docgen": "1.8.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "babel-plugin-transform-runtime": "6.23.0",
+        "babel-preset-env": "1.6.1",
         "babel-preset-minify": "0.2.0",
         "babel-preset-react": "6.24.1",
-        "babel-preset-react-app": "3.0.1",
+        "babel-preset-react-app": "3.1.0",
         "babel-preset-stage-0": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.26.0",
         "case-sensitive-paths-webpack-plugin": "2.1.1",
-        "chalk": "2.1.0",
-        "commander": "2.9.0",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
         "common-tags": "1.4.0",
         "configstore": "3.1.1",
-        "css-loader": "0.28.4",
-        "express": "4.15.3",
-        "file-loader": "0.11.2",
+        "core-js": "2.5.1",
+        "css-loader": "0.28.7",
+        "express": "4.16.2",
+        "file-loader": "1.1.5",
         "find-cache-dir": "1.0.0",
         "glamor": "2.20.40",
-        "glamorous": "4.9.5",
+        "glamorous": "4.11.0",
         "global": "4.3.2",
-        "json-loader": "0.5.4",
+        "json-loader": "0.5.7",
         "json-stringify-safe": "5.0.1",
         "json5": "0.5.1",
         "lodash.flattendeep": "4.4.0",
         "lodash.pick": "4.4.0",
-        "postcss-flexbugs-fixes": "3.0.0",
-        "postcss-loader": "2.0.6",
+        "postcss-flexbugs-fixes": "3.2.0",
+        "postcss-loader": "2.0.9",
         "prop-types": "15.6.0",
-        "qs": "6.4.0",
-        "react-modal": "2.3.2",
+        "qs": "6.5.1",
         "redux": "3.7.2",
-        "request": "2.81.0",
-        "serve-favicon": "2.4.3",
+        "request": "2.83.0",
+        "serve-favicon": "2.4.5",
         "shelljs": "0.7.8",
-        "style-loader": "0.17.0",
-        "url-loader": "0.5.9",
+        "style-loader": "0.18.2",
+        "url-loader": "0.6.2",
         "util-deprecate": "1.0.2",
         "uuid": "3.1.0",
-        "webpack": "2.6.1",
-        "webpack-dev-middleware": "1.11.0",
-        "webpack-hot-middleware": "2.18.2"
+        "webpack": "3.8.1",
+        "webpack-dev-middleware": "1.12.2",
+        "webpack-hot-middleware": "2.21.0"
       },
       "dependencies": {
-        "@storybook/addon-actions": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.2.6.tgz",
-          "integrity": "sha512-YuWOyC/sLvD2kicVem7JVAaFmnWmOXZI9OMWJHMjnH3znb6UjDpMQz5espDna/fF7rT9KEw9J+uwsM1rAxim1g==",
+        "accepts": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+          "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
           "dev": true,
           "requires": {
-            "@storybook/addons": "3.2.6",
-            "deep-equal": "1.0.1",
-            "json-stringify-safe": "5.0.1",
-            "prop-types": "15.6.0",
-            "react-inspector": "2.1.1",
-            "uuid": "3.1.0"
+            "mime-types": "2.1.17",
+            "negotiator": "0.6.1"
           }
         },
-        "@storybook/addon-links": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.2.6.tgz",
-          "integrity": "sha512-6Vl5S+pTVJDKyGymn8v6IQwUkhO2PbHk14y0rmvQ93ivIWeoonA0H0TdDWSgLiuyMpqxxKu3f0tiZfLVnuSSpg==",
+        "airbnb-js-shims": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-1.3.0.tgz",
+          "integrity": "sha512-Y/9jgf3uEdNyeWPUV1N49FowM/qMIiKSTkRUpYT4jpHkSADfTiRVwI8Mm6o4CIxhnBK1uMf4RIYNYKwwILMCAQ==",
           "dev": true,
           "requires": {
-            "@storybook/addons": "3.2.6"
+            "array-includes": "3.0.3",
+            "es5-shim": "4.5.9",
+            "es6-shim": "0.35.3",
+            "function.prototype.name": "1.0.3",
+            "object.entries": "1.0.4",
+            "object.getownpropertydescriptors": "2.0.3",
+            "object.values": "1.0.4",
+            "promise.prototype.finally": "3.1.0",
+            "string.prototype.padend": "3.0.0",
+            "string.prototype.padstart": "3.0.0"
           }
         },
-        "@storybook/addons": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.2.6.tgz",
-          "integrity": "sha512-i/sHbvEeMnnnLiPeXmE/b0OaVH5IM4U8CsdTh44RGjQVCnKstPpEhjD+hzPlhKFQnAtk9+vUxphvCWBgy6VouA==",
+        "ajv": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.0.tgz",
+          "integrity": "sha1-6yhAdG6dxIvV4GOjbj/UAMXqtak=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
           "dev": true
         },
-        "@storybook/channel-postmessage": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.2.0.tgz",
-          "integrity": "sha1-YS/1MSC/JmZgy5MousmtZxIoovc=",
-          "dev": true,
-          "requires": {
-            "@storybook/channels": "3.2.0",
-            "global": "4.3.2",
-            "json-stringify-safe": "5.0.1"
-          }
-        },
-        "@storybook/channels": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.2.0.tgz",
-          "integrity": "sha1-11OVIS23a0njM19QzOW8djzwtcY=",
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
-        },
-        "@storybook/ui": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.2.7.tgz",
-          "integrity": "sha1-wH3VUj4sg9n4rFp5gsMFzFnzTng=",
-          "dev": true,
-          "requires": {
-            "@hypnosphi/fuse.js": "3.0.9",
-            "@storybook/components": "3.2.7",
-            "@storybook/react-fuzzy": "0.4.0",
-            "babel-runtime": "6.23.0",
-            "deep-equal": "1.0.1",
-            "events": "1.1.1",
-            "global": "4.3.2",
-            "json-stringify-safe": "5.0.1",
-            "keycode": "2.1.9",
-            "lodash.debounce": "4.0.8",
-            "lodash.pick": "4.4.0",
-            "lodash.sortby": "4.7.0",
-            "mantra-core": "1.7.0",
-            "podda": "1.2.2",
-            "prop-types": "15.6.0",
-            "qs": "6.4.0",
-            "react-icons": "2.2.5",
-            "react-inspector": "2.1.1",
-            "react-komposer": "2.0.0",
-            "react-modal": "2.3.2",
-            "react-split-pane": "0.1.65",
-            "react-treebeard": "2.0.3",
-            "redux": "3.7.2"
-          }
         },
         "ansi-styles": {
           "version": "3.2.0",
@@ -526,71 +497,316 @@
             "color-convert": "1.9.0"
           }
         },
-        "babel-plugin-react-docgen": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.7.0.tgz",
-          "integrity": "sha512-0Pw0sdu3W+NfVS048dqMetujQH6gXxCgd2tQGmUmgP/iNNlSbd7aDFj0e8xDmuZQRMy6UNC29zhMpnJJ0xc5BQ==",
+        "array-flatten": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+          "dev": true
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        },
+        "autoprefixer": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.6.tgz",
+          "integrity": "sha512-C9yv/UF3X+eJTi/zvfxuyfxmLibYrntpF3qoJYrMeQwgUJOZrZvpJiMG2FMQ3qnhWtF/be4pYONBBw95ZGe3vA==",
           "dev": true,
           "requires": {
-            "babel-types": "6.25.0",
+            "browserslist": "2.9.1",
+            "caniuse-lite": "1.0.30000775",
+            "normalize-range": "0.1.2",
+            "num2fraction": "1.2.2",
+            "postcss": "6.0.14",
+            "postcss-value-parser": "3.3.0"
+          }
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "babel-core": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+          "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.0",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.0",
+            "debug": "2.6.8",
+            "json5": "0.5.1",
             "lodash": "4.17.4",
-            "react-docgen": "2.16.0"
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.7",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
           }
         },
-        "babel-preset-env": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
-          "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
+        "babel-generator": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+          "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
           "dev": true,
           "requires": {
-            "babel-plugin-check-es2015-constants": "6.22.0",
-            "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-            "babel-plugin-transform-async-to-generator": "6.24.1",
-            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-            "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-            "babel-plugin-transform-es2015-block-scoping": "6.24.1",
-            "babel-plugin-transform-es2015-classes": "6.24.1",
-            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-            "babel-plugin-transform-es2015-destructuring": "6.23.0",
-            "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-            "babel-plugin-transform-es2015-for-of": "6.23.0",
-            "babel-plugin-transform-es2015-function-name": "6.24.1",
-            "babel-plugin-transform-es2015-literals": "6.22.0",
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-            "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-            "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-            "babel-plugin-transform-es2015-object-super": "6.24.1",
-            "babel-plugin-transform-es2015-parameters": "6.24.1",
-            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-            "babel-plugin-transform-es2015-spread": "6.22.0",
-            "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-            "babel-plugin-transform-es2015-template-literals": "6.22.0",
-            "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-            "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-            "babel-plugin-transform-exponentiation-operator": "6.24.1",
-            "babel-plugin-transform-regenerator": "6.24.1",
-            "browserslist": "2.2.0",
-            "invariant": "2.2.2",
-            "semver": "5.3.0"
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
           }
         },
-        "brcast": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
-          "integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg==",
+        "babel-loader": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.2.tgz",
+          "integrity": "sha512-jRwlFbINAeyDStqK6Dd5YuY0k5YuzQUvlz2ZamuXrXmxav3pNqe9vfJ402+2G+OmlJSXxCOpB6Uz0INM7RQe2A==",
+          "dev": true,
+          "requires": {
+            "find-cache-dir": "1.0.0",
+            "loader-utils": "1.1.0",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "babel-plugin-dynamic-import-node": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.1.0.tgz",
+          "integrity": "sha512-tTfZbM9Ecwj3GK50mnPrUpinTwA4xXmDiQGCk/aBYbvl1+X8YqldK86wZ1owVJ4u3mrKbRlXMma80J18qwiaTQ==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-syntax-dynamic-import": "6.18.0",
+            "babel-template": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-object-rest-spread": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+          "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+          "dev": true,
+          "requires": {
+            "babel-plugin-syntax-object-rest-spread": "6.13.0",
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+          "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+          "dev": true,
+          "requires": {
+            "regenerator-transform": "0.10.1"
+          }
+        },
+        "babel-preset-react-app": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-3.1.0.tgz",
+          "integrity": "sha512-jEAeVozxLzftLl0iDZ0d5jrmfbo3yogON/eI4AsEDIs8p6WW+t9mDRUsj5l12bqPOLSiVOElCQ3QyGjMcyBiwA==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-dynamic-import-node": "1.1.0",
+            "babel-plugin-syntax-dynamic-import": "6.18.0",
+            "babel-plugin-transform-class-properties": "6.24.1",
+            "babel-plugin-transform-object-rest-spread": "6.26.0",
+            "babel-plugin-transform-react-constant-elements": "6.23.0",
+            "babel-plugin-transform-react-jsx": "6.24.1",
+            "babel-plugin-transform-react-jsx-self": "6.22.0",
+            "babel-plugin-transform-react-jsx-source": "6.22.0",
+            "babel-plugin-transform-regenerator": "6.26.0",
+            "babel-plugin-transform-runtime": "6.23.0",
+            "babel-preset-env": "1.6.1",
+            "babel-preset-react": "6.24.1"
+          }
+        },
+        "babel-register": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+          "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+          "dev": true,
+          "requires": {
+            "babel-core": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "core-js": "2.5.1",
+            "home-or-tmp": "2.0.0",
+            "lodash": "4.17.4",
+            "mkdirp": "0.5.1",
+            "source-map-support": "0.4.15"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.1",
+            "regenerator-runtime": "0.11.0"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.8",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
+        },
+        "boom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "browserslist": {
+          "version": "2.9.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.1.tgz",
+          "integrity": "sha512-3n3nPdbUqn3nWmsy4PeSQthz2ja1ndpoXta+dwFFNhveGjMg6FXpWYe12vsTpNoXJbzx3j7GZXdtoVIdvh3JbA==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000775",
+            "electron-to-chromium": "1.3.27"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000775",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000775.tgz",
+          "integrity": "sha1-dNJ/7dxH88hM+8sTDDCSo168LeI=",
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
         },
         "configstore": {
           "version": "3.1.1",
@@ -606,6 +822,139 @@
             "xdg-basedir": "3.0.0"
           }
         },
+        "content-type": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.2.14"
+          }
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "dev": true,
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "dev": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            }
+          }
+        },
+        "css-loader": {
+          "version": "0.28.7",
+          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.7.tgz",
+          "integrity": "sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "css-selector-tokenizer": "0.7.0",
+            "cssnano": "3.10.0",
+            "icss-utils": "2.1.0",
+            "loader-utils": "1.1.0",
+            "lodash.camelcase": "4.3.0",
+            "object-assign": "4.1.1",
+            "postcss": "5.2.18",
+            "postcss-modules-extract-imports": "1.1.0",
+            "postcss-modules-local-by-default": "1.2.0",
+            "postcss-modules-scope": "1.1.0",
+            "postcss-modules-values": "1.3.0",
+            "postcss-value-parser": "3.3.0",
+            "source-list-map": "2.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                  "dev": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+              "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+              "dev": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "js-base64": "2.1.9",
+                "source-map": "0.5.7",
+                "supports-color": "3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
+            }
+          }
+        },
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+          "dev": true
+        },
         "dot-prop": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -613,6 +962,130 @@
           "dev": true,
           "requires": {
             "is-obj": "1.0.1"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.27",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
+          "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
+          "dev": true
+        },
+        "enhanced-resolve": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+          "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "memory-fs": "0.4.1",
+            "object-assign": "4.1.1",
+            "tapable": "0.2.7"
+          }
+        },
+        "etag": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "express": {
+          "version": "4.16.2",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+          "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+          "dev": true,
+          "requires": {
+            "accepts": "1.3.4",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.18.2",
+            "content-disposition": "0.5.2",
+            "content-type": "1.0.4",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "finalhandler": "1.1.0",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "1.1.2",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "2.0.2",
+            "qs": "6.5.1",
+            "range-parser": "1.2.0",
+            "safe-buffer": "5.1.1",
+            "send": "0.16.1",
+            "serve-static": "1.13.1",
+            "setprototypeof": "1.1.0",
+            "statuses": "1.3.1",
+            "type-is": "1.6.15",
+            "utils-merge": "1.0.1",
+            "vary": "1.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "file-loader": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.5.tgz",
+          "integrity": "sha512-RzGHDatcVNpGISTvCpfUfOGpYuSR7HSsSg87ki+wF6rw1Hm0RALPTiAdsxAq1UwLf0RRhbe22/eHK6nhXspiOQ==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "1.1.0",
+            "schema-utils": "0.3.0"
+          }
+        },
+        "finalhandler": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+          "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
           }
         },
         "find-cache-dir": {
@@ -635,38 +1108,198 @@
             "locate-path": "2.0.0"
           }
         },
-        "glamor": {
-          "version": "2.20.40",
-          "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
-          "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
+        "form-data": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
           "dev": true,
           "requires": {
-            "fbjs": "0.8.12",
-            "inline-style-prefixer": "3.0.6",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0",
-            "through": "2.3.8"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
           }
         },
-        "glamorous": {
-          "version": "4.9.5",
-          "resolved": "https://registry.npmjs.org/glamorous/-/glamorous-4.9.5.tgz",
-          "integrity": "sha512-yz9D8M8Yfic0LJ37J1GELXztfu5M2SYsu146wzku8Vq/V6N1SSSJWmBtaHB8emEpql9jhFwfh3Fc1lDKllp2Yg==",
+        "forwarded": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+          "dev": true
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+          "dev": true
+        },
+        "function.prototype.name": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
+          "integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
           "dev": true,
           "requires": {
-            "brcast": "3.0.1",
-            "fast-memoize": "2.2.7",
-            "html-tag-names": "1.1.2",
-            "is-function": "1.0.1",
-            "is-plain-object": "2.0.4",
-            "react-html-attributes": "1.4.0",
-            "svg-tag-names": "1.1.1"
+            "define-properties": "1.1.2",
+            "function-bind": "1.1.0",
+            "is-callable": "1.1.3"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "dev": true,
+          "requires": {
+            "ajv": "5.5.0",
+            "har-schema": "2.0.0"
           }
         },
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "dev": true,
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.0",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "dev": true,
+          "requires": {
+            "depd": "1.1.1",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": "1.3.1"
+          },
+          "dependencies": {
+            "setprototypeof": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+              "dev": true
+            }
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.1"
+          }
+        },
+        "ipaddr.js": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+          "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "json-loader": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+          "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "parseurl": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+          "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
           "dev": true
         },
         "pkg-dir": {
@@ -678,34 +1311,360 @@
             "find-up": "2.1.0"
           }
         },
-        "react-modal": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-2.3.2.tgz",
-          "integrity": "sha512-m+urZGPk+RfUrGj0b8uraZ2dQQo/AABZ+s6aZeZxEpbhMwWZ4WhVr03iYbWTvSatSnC+5x9c2k6qm95N1ybohg==",
+        "postcss": {
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
-            "exenv": "1.2.0",
-            "prop-types": "15.6.0",
-            "react-dom-factories": "1.0.0"
+            "chalk": "2.3.0",
+            "source-map": "0.6.1",
+            "supports-color": "4.5.0"
           }
         },
-        "style-loader": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.17.0.tgz",
-          "integrity": "sha1-6CVLzNt690vVgnTjYQe01atN8xA=",
+        "postcss-flexbugs-fixes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-3.2.0.tgz",
+          "integrity": "sha512-0AuD9HG1Ey3/3nqPWu9yqf7rL0KCPu5VgjDsjf5mzEcuo9H/z8nco/fljKgjsOUrZypa95MI0kS4xBZeBzz2lw==",
           "dev": true,
           "requires": {
-            "loader-utils": "1.1.0"
+            "postcss": "6.0.14"
           }
+        },
+        "postcss-loader": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.9.tgz",
+          "integrity": "sha512-sgoXPtmgVT3aBAhU47Kig8oPF+mbXl8Unjvtz1Qj1q2D2EvSVJW2mKJNzxv5y/LvA9xWwuvdysvhc7Zn80UWWw==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "1.1.0",
+            "postcss": "6.0.14",
+            "postcss-load-config": "1.2.0",
+            "schema-utils": "0.3.0"
+          }
+        },
+        "proxy-addr": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+          "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+          "dev": true,
+          "requires": {
+            "forwarded": "0.1.2",
+            "ipaddr.js": "1.5.2"
+          }
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
+        },
+        "regenerator-transform": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+          "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "private": "0.1.7"
+          }
+        },
+        "request": {
+          "version": "2.83.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.1",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        },
+        "send": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+          "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.3.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "serve-favicon": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.5.tgz",
+          "integrity": "sha512-s7F8h2NrslMkG50KxvlGdj+ApSwaLex0vexuJ9iFf3GLTIp1ph/l1qZvRe9T9TJEYZgmq72ZwJ2VYiAEtChknw==",
+          "dev": true,
+          "requires": {
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
+            "ms": "2.0.0",
+            "parseurl": "1.3.2",
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "serve-static": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+          "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+          "dev": true,
+          "requires": {
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.2",
+            "send": "0.16.1"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "source-list-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "dev": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "url-loader": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
+          "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "1.1.0",
+            "mime": "1.4.1",
+            "schema-utils": "0.3.0"
+          }
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+          "dev": true
+        },
+        "vary": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+          "dev": true
+        },
+        "webpack": {
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
+          "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.1.1",
+            "acorn-dynamic-import": "2.0.2",
+            "ajv": "5.5.0",
+            "ajv-keywords": "2.1.1",
+            "async": "2.5.0",
+            "enhanced-resolve": "3.4.1",
+            "escope": "3.6.0",
+            "interpret": "1.0.3",
+            "json-loader": "0.5.7",
+            "json5": "0.5.1",
+            "loader-runner": "2.3.0",
+            "loader-utils": "1.1.0",
+            "memory-fs": "0.4.1",
+            "mkdirp": "0.5.1",
+            "node-libs-browser": "2.0.0",
+            "source-map": "0.5.7",
+            "supports-color": "4.5.0",
+            "tapable": "0.2.7",
+            "uglifyjs-webpack-plugin": "0.4.6",
+            "watchpack": "1.4.0",
+            "webpack-sources": "1.1.0",
+            "yargs": "8.0.2"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
+        },
+        "webpack-dev-middleware": {
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
+          "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+          "dev": true,
+          "requires": {
+            "memory-fs": "0.4.1",
+            "mime": "1.6.0",
+            "path-is-absolute": "1.0.1",
+            "range-parser": "1.2.0",
+            "time-stamp": "2.0.0"
+          },
+          "dependencies": {
+            "mime": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+              "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+              "dev": true
+            }
+          }
+        },
+        "webpack-hot-middleware": {
+          "version": "2.21.0",
+          "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.21.0.tgz",
+          "integrity": "sha512-P6xiOLy10QlSVSO7GanU9PLxN6zLLQ7RG16MPTvmFwf2KUG7jMp6m+fmdgsR7xoaVVLA7OlX3YO6JjoZEKjCuA==",
+          "dev": true,
+          "requires": {
+            "ansi-html": "0.0.7",
+            "html-entities": "1.2.1",
+            "querystring": "0.2.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "webpack-sources": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+          "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "2.0.0",
+            "source-map": "0.6.1"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
         },
         "write-file-atomic": {
           "version": "2.3.0",
@@ -723,19 +1682,69 @@
           "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
           "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "dev": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          }
         }
       }
     },
-    "@storybook/react-fuzzy": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@storybook/react-fuzzy/-/react-fuzzy-0.4.0.tgz",
-      "integrity": "sha1-KWHoofbBr8zpfp6aFNHf6dkGEIc=",
+    "@storybook/react-komposer": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@storybook/react-komposer/-/react-komposer-2.0.3.tgz",
+      "integrity": "sha512-DjL/XwZLNx79Rc1y0dyjxme64eUSJeJvajCN587sVDsVZIgsPlDWwmaohOCkPhR8HNGrY89qoeFZZxFslT203w==",
+      "dev": true,
+      "requires": {
+        "@storybook/react-stubber": "1.0.1",
+        "babel-runtime": "6.23.0",
+        "hoist-non-react-statics": "1.2.0",
+        "lodash.pick": "4.4.0",
+        "shallowequal": "0.2.2"
+      }
+    },
+    "@storybook/react-simple-di": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@storybook/react-simple-di/-/react-simple-di-1.2.1.tgz",
+      "integrity": "sha512-Sj3JU1KpnTIyBWBp+uAZT3PlZ2IVYrxvOOXgpT92Injcmg2KV2ry1GkZen6XuVZqUfU0vz/sK08aP45boErFnw==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.23.0",
-        "classnames": "2.2.5",
-        "fuse.js": "3.0.5",
-        "prop-types": "15.6.0"
+        "hoist-non-react-statics": "1.2.0"
+      }
+    },
+    "@storybook/react-stubber": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@storybook/react-stubber/-/react-stubber-1.0.1.tgz",
+      "integrity": "sha512-k+CHH+vA8bQfCmzBTtJsPkITFgD+C/w19KuByZ9WeEvNUFtnDaCqfP+Vp3/OR+3IAfAXYYOWolqPLxNPcEqEjw==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
       }
     },
     "@storybook/storybook-deployer": {
@@ -918,6 +1927,134 @@
         }
       }
     },
+    "@storybook/ui": {
+      "version": "3.2.16",
+      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.2.16.tgz",
+      "integrity": "sha512-K6DwvT2Oo4GrJkT0ij8EW1GsjX7Sw9U6hDp2II5tnKsV7egnIKgJ6y5xGOZLHNvDDkeo5KS+Ii3GjrUbnZ1QzQ==",
+      "dev": true,
+      "requires": {
+        "@hypnosphi/fuse.js": "3.0.9",
+        "@storybook/components": "3.2.16",
+        "@storybook/mantra-core": "1.7.2",
+        "@storybook/react-fuzzy": "0.4.3",
+        "@storybook/react-komposer": "2.0.3",
+        "babel-runtime": "6.26.0",
+        "deep-equal": "1.0.1",
+        "events": "1.1.1",
+        "global": "4.3.2",
+        "json-stringify-safe": "5.0.1",
+        "keycode": "2.1.9",
+        "lodash.debounce": "4.0.8",
+        "lodash.pick": "4.4.0",
+        "lodash.sortby": "4.7.0",
+        "podda": "1.2.2",
+        "prop-types": "15.6.0",
+        "qs": "6.5.1",
+        "react-icons": "2.2.7",
+        "react-inspector": "2.2.1",
+        "react-modal": "3.1.5",
+        "react-split-pane": "0.1.71",
+        "react-treebeard": "2.0.3",
+        "redux": "3.7.2"
+      },
+      "dependencies": {
+        "@storybook/components": {
+          "version": "3.2.16",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.2.16.tgz",
+          "integrity": "sha512-+bxwsvwa7TPqwxG6ap2hjjrwSg1g8e2ZGijPQDEGpvNfEnLfbZRyQKXRhfCyeAN3DL8F8Bx95AJuWaYKr0pqpA==",
+          "dev": true,
+          "requires": {
+            "glamor": "2.20.40",
+            "glamorous": "4.11.0",
+            "prop-types": "15.6.0"
+          }
+        },
+        "@storybook/react-fuzzy": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/@storybook/react-fuzzy/-/react-fuzzy-0.4.3.tgz",
+          "integrity": "sha512-TaFbDiEc/34eiAFyOjyvrh5tOqoKscyVH2BHJB15cQ8RepccX3LKIBqSNr7IUi1jmMB5aWjeefvJywPQf13ByQ==",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "classnames": "2.2.5",
+            "fuse.js": "3.0.5",
+            "prop-types": "15.6.0"
+          }
+        },
+        "@types/react": {
+          "version": "16.0.25",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.25.tgz",
+          "integrity": "sha512-K79zMwWRzQ2db+nPoKpi3gA/KmLo6ZQgT4iO2QPEUdBO7as0PcgrmU9KHYzIO3V6lbD7gRjOM0/nUch6xBfOvQ==",
+          "dev": true
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.11.0"
+          }
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        },
+        "react-icon-base": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/react-icon-base/-/react-icon-base-2.1.0.tgz",
+          "integrity": "sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=",
+          "dev": true
+        },
+        "react-icons": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-2.2.7.tgz",
+          "integrity": "sha512-0n4lcGqzJFcIQLoQytLdJCE0DKSA9dkwEZRYoGrIDJZFvIT6Hbajx5mv9geqhqFiNjUgtxg8kPyDfjlhymbGFg==",
+          "dev": true,
+          "requires": {
+            "react-icon-base": "2.1.0"
+          }
+        },
+        "react-inspector": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.2.1.tgz",
+          "integrity": "sha512-aXrxJTfriJtZtv/+A9cFIOpfbt711yCD1Ht3fSn3JyuDaAt1+eLtb01R5d/8gGpyquOVWn/d+eM1VPqFXS7UZA==",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "is-dom": "1.0.9"
+          }
+        },
+        "react-split-pane": {
+          "version": "0.1.71",
+          "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.71.tgz",
+          "integrity": "sha512-c7aK5ffRyeOySSWVeoSEsQHBUrNtzXTB9TFNUnZv/2EM7HEnN1Rfsgxag/bpDcl5GuaY5IuMvq7XySc6nyokog==",
+          "dev": true,
+          "requires": {
+            "@types/inline-style-prefixer": "3.0.1",
+            "@types/react": "16.0.25",
+            "inline-style-prefixer": "3.0.6",
+            "prop-types": "15.6.0",
+            "react-style-proptype": "3.0.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
+        }
+      }
+    },
+    "@types/inline-style-prefixer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/inline-style-prefixer/-/inline-style-prefixer-3.0.1.tgz",
+      "integrity": "sha512-+kbOcYW1/noncDwRryRoB9tH87IYcMfdBGvw98iocK39LtTA2DFL7agmk4UHW/GxjzVfwrxfjlLrqrgA7MCtmg==",
+      "dev": true
+    },
     "@types/lodash": {
       "version": "4.14.71",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.71.tgz",
@@ -1040,23 +2177,6 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
-    },
-    "airbnb-js-shims": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-1.2.0.tgz",
-      "integrity": "sha512-V70beD2QKqv8Yy9vpX+dWuZQV5Q2BESJuWyGh2HCcdYAALTWUP9ai+hTWGGc9RvxTdbW6iWbnymBXuN7Eyw8jg==",
-      "dev": true,
-      "requires": {
-        "array-includes": "3.0.3",
-        "es5-shim": "4.5.9",
-        "es6-shim": "0.35.3",
-        "function.prototype.name": "1.0.2",
-        "object.entries": "1.0.4",
-        "object.getownpropertydescriptors": "2.0.3",
-        "object.values": "1.0.4",
-        "string.prototype.padend": "3.0.0",
-        "string.prototype.padstart": "3.0.0"
-      }
     },
     "ajv": {
       "version": "4.11.8",
@@ -2113,6 +3233,17 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
       "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw=",
       "dev": true
+    },
+    "babel-plugin-react-docgen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.8.1.tgz",
+      "integrity": "sha512-11Yxwk8/iEULr+n5DG0BxXD6j/9htpiiR0/hLfi/gtEAK/d6NCNkyKFrC8loQcyMvF3hehPo30SKXG/itSX+hw==",
+      "dev": true,
+      "requires": {
+        "babel-types": "6.25.0",
+        "lodash": "4.17.4",
+        "react-docgen": "2.16.0"
+      }
     },
     "babel-plugin-remove-console": {
       "version": "1.0.1",
@@ -3301,6 +4432,12 @@
         "preserve": "0.2.0",
         "repeat-element": "1.1.2"
       }
+    },
+    "brcast": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
+      "integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg==",
+      "dev": true
     },
     "breakable": {
       "version": "1.0.0",
@@ -6580,6 +7717,12 @@
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
       "dev": true
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -7933,6 +9076,34 @@
         "git-up": "2.0.9"
       }
     },
+    "glamor": {
+      "version": "2.20.40",
+      "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
+      "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.12",
+        "inline-style-prefixer": "3.0.6",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0",
+        "through": "2.3.8"
+      }
+    },
+    "glamorous": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/glamorous/-/glamorous-4.11.0.tgz",
+      "integrity": "sha512-qWRmq5HZ6kGnp09/z3I0L5ZWZF8PX9W90ED8Ndm3ccfaamWRcEURYilk3zA1M1VW1xJlV28+aD2XlwbQF5YlSw==",
+      "dev": true,
+      "requires": {
+        "brcast": "3.0.1",
+        "fast-memoize": "2.2.7",
+        "html-tag-names": "1.1.2",
+        "is-function": "1.0.1",
+        "is-plain-object": "2.0.4",
+        "react-html-attributes": "1.4.0",
+        "svg-tag-names": "1.1.1"
+      }
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -7982,6 +9153,15 @@
           "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
           "dev": true
         }
+      }
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "1.3.4"
       }
     },
     "globals": {
@@ -8242,6 +9422,12 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
+    },
+    "hoist-non-react-statics": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+      "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
       "dev": true
     },
     "home-or-tmp": {
@@ -8962,6 +10148,16 @@
       "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
+      }
+    },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.0"
       }
     },
     "is-integer": {
@@ -10910,40 +12106,6 @@
         "tmpl": "1.0.4"
       }
     },
-    "mantra-core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/mantra-core/-/mantra-core-1.7.0.tgz",
-      "integrity": "sha1-qMg+jO6D72pzgxMVGf6AMa1UY4Y=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "react-komposer": "1.13.1",
-        "react-simple-di": "1.2.0"
-      },
-      "dependencies": {
-        "react-komposer": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/react-komposer/-/react-komposer-1.13.1.tgz",
-          "integrity": "sha1-S4rEvMcTI710E9yrlcgxGX9Q7tA=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.23.0",
-            "hoist-non-react-statics": "1.2.0",
-            "invariant": "2.2.2",
-            "mobx": "2.7.0",
-            "shallowequal": "0.2.2"
-          },
-          "dependencies": {
-            "hoist-non-react-statics": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-              "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
-              "dev": true
-            }
-          }
-        }
-      }
-    },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -11211,12 +12373,6 @@
           "dev": true
         }
       }
-    },
-    "mobx": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-2.7.0.tgz",
-      "integrity": "sha1-zz2C0YwMp/RY2PKiQIF7PcflSgE=",
-      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -13749,148 +14905,6 @@
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
-    "opencollective": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
-      "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
-      "dev": true,
-      "requires": {
-        "babel-polyfill": "6.23.0",
-        "chalk": "1.1.3",
-        "inquirer": "3.0.6",
-        "minimist": "1.2.0",
-        "node-fetch": "1.6.3",
-        "opn": "4.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "2.0.0"
-          }
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5"
-          }
-        },
-        "inquirer": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
-          "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "1.4.0",
-            "chalk": "1.1.3",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.1.0",
-            "external-editor": "2.0.4",
-            "figures": "2.0.0",
-            "lodash": "4.17.4",
-            "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx": "4.1.0",
-            "string-width": "2.1.1",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-          "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
-          "dev": true,
-          "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
-          }
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "1.1.0"
-          }
-        },
-        "opn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-          "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "run-async": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-          "dev": true,
-          "requires": {
-            "is-promise": "2.1.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
-        }
-      }
-    },
     "opn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
@@ -15774,6 +16788,38 @@
       "integrity": "sha1-2chtPcTcLfkBboiUbe/Wm0m0EWI=",
       "dev": true
     },
+    "promise.prototype.finally": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz",
+      "integrity": "sha512-7p/K2f6dI+dM8yjRQEGrTQs5hTQixUAdOGpMEA3+pVxpX5oHKRSKAXyLw9Q9HUWDTdwtoo39dSHGQtN90HcEwQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+          "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "1.1.1",
+            "function-bind": "1.1.1",
+            "has": "1.0.1",
+            "is-callable": "1.1.3",
+            "is-regex": "1.0.4"
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
+        }
+      }
+    },
     "prop-types": {
       "version": "15.6.0",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
@@ -16275,12 +17321,6 @@
         "prop-types": "15.6.0"
       }
     },
-    "react-dom-factories": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom-factories/-/react-dom-factories-1.0.0.tgz",
-      "integrity": "sha1-9DwF5QUbME8zJRYY1byFmynka20=",
-      "dev": true
-    },
     "react-error-overlay": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-1.0.9.tgz",
@@ -16318,64 +17358,14 @@
         "html-element-attributes": "1.3.0"
       }
     },
-    "react-icon-base": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/react-icon-base/-/react-icon-base-2.0.7.tgz",
-      "integrity": "sha1-C9GHNr1s55ym1pzoOHoH+41M7/4=",
+    "react-modal": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.5.tgz",
+      "integrity": "sha512-EjM32L9JPVibJJgu22QySo9d+tl0POaRTmuM7LmsVkx0U+G9tl4LGLrs2DLNOQp0Oko/5nEF/Rwp/h2noucMAw==",
       "dev": true,
       "requires": {
-        "prop-types": "15.5.8"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.5.8",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.8.tgz",
-          "integrity": "sha1-a3suFBCDvjjIWVqlH8VXdccZk5Q=",
-          "dev": true,
-          "requires": {
-            "fbjs": "0.8.12"
-          }
-        }
-      }
-    },
-    "react-icons": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-2.2.5.tgz",
-      "integrity": "sha1-+UJQHCGkzARWziu+5QMsk/YFHc8=",
-      "dev": true,
-      "requires": {
-        "react-icon-base": "2.0.7"
-      }
-    },
-    "react-inspector": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.1.1.tgz",
-      "integrity": "sha512-AeZcBjq8NiknEmrck9LfFLbnwJPNQiPTh8wAEUopZPU6t1zWbGZj10WYq1jNPZNuh0MzkxyGB6HHmNPYogp2mQ==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "is-dom": "1.0.9"
-      }
-    },
-    "react-komposer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-komposer/-/react-komposer-2.0.0.tgz",
-      "integrity": "sha1-uWRzgBSptK7klKg8C1uDPWYHKpA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "hoist-non-react-statics": "1.2.0",
-        "lodash.pick": "4.4.0",
-        "react-stubber": "1.0.0",
-        "shallowequal": "0.2.2"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
-          "dev": true
-        }
+        "exenv": "1.2.0",
+        "prop-types": "15.6.0"
       }
     },
     "react-page-object": {
@@ -16418,24 +17408,6 @@
         "warning": "3.0.0"
       }
     },
-    "react-simple-di": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-simple-di/-/react-simple-di-1.2.0.tgz",
-      "integrity": "sha1-3eDlv2ifOR7yqwLJBDshP+I5xtA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "hoist-non-react-statics": "1.2.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
-          "dev": true
-        }
-      }
-    },
     "react-sortable-hoc": {
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-0.6.7.tgz",
@@ -16445,26 +17417,6 @@
         "invariant": "2.2.2",
         "lodash": "4.17.4",
         "prop-types": "15.6.0"
-      }
-    },
-    "react-split-pane": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.65.tgz",
-      "integrity": "sha1-N8C16lyWCCfn82IdChFLD4yciRg=",
-      "dev": true,
-      "requires": {
-        "inline-style-prefixer": "3.0.6",
-        "prop-types": "15.6.0",
-        "react-style-proptype": "3.0.0"
-      }
-    },
-    "react-stubber": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/react-stubber/-/react-stubber-1.0.0.tgz",
-      "integrity": "sha1-Qe4srHLU1P1wpjiW2pjhNzm4Rig=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
       }
     },
     "react-style-proptype": {
@@ -17083,12 +18035,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
       "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
-      "dev": true
-    },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
       "dev": true
     },
     "rx-lite": {
@@ -17792,27 +18738,6 @@
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-          "dev": true
-        }
-      }
-    },
-    "serve-favicon": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.3.tgz",
-      "integrity": "sha1-WYaxewUCZCtkHCH4GLGszjICXSM=",
-      "dev": true,
-      "requires": {
-        "etag": "1.8.0",
-        "fresh": "0.5.0",
-        "ms": "2.0.0",
-        "parseurl": "1.3.1",
-        "safe-buffer": "5.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
           "dev": true
         }
       }
@@ -19997,6 +20922,49 @@
       "dev": true,
       "optional": true
     },
+    "uglifyjs-webpack-plugin": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+      "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-js": "2.8.29",
+        "webpack-sources": "1.1.0"
+      },
+      "dependencies": {
+        "source-list-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "webpack-sources": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+          "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "2.0.0",
+            "source-map": "0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "ultron": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
@@ -20615,18 +21583,6 @@
             "camelcase": "3.0.0"
           }
         }
-      }
-    },
-    "webpack-hot-middleware": {
-      "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.18.2.tgz",
-      "integrity": "sha512-dB7uOnUWsojZIAC6Nwi5v3tuaQNd2i7p4vF5LsJRyoTOgr2fRYQdMKQxRZIZZaz0cTPBX8rvcWU1A6/n7JTITg==",
-      "dev": true,
-      "requires": {
-        "ansi-html": "0.0.7",
-        "html-entities": "1.2.1",
-        "querystring": "0.2.0",
-        "strip-ansi": "3.0.1"
       }
     },
     "webpack-manifest-plugin": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dist": "babel src --out-dir dist --copy-files",
     "karma": "BABEL_ENV=development NODE_ENV=test karma start config/karma.conf.js",
     "lint": "npm run lint:es && npm run lint:js && npm run lint:css",
-    "lint:js": "standard 'src/**/*.js' 'stories/**/*.js'",
+    "lint:js": "standard 'src/**/*.js' 'stories/**/*.js' 'test/**/*.js'",
     "lint:es": "eslint src/**/*.js --cache && echo \"eslint: No lint errors 🙌!\"",
     "lint:css": "stylelint 'src/styles/**/*.scss'",
     "pretty": "npm run lint:js -- --fix && npm run lint:css -- -- fix",
@@ -56,9 +56,9 @@
   },
   "devDependencies": {
     "@helpscout/helix": "0.0.13",
-    "@storybook/addon-options": "^3.2.4",
-    "@storybook/cli": "^3.2.9",
-    "@storybook/react": "^3.2.4",
+    "@storybook/addon-options": "^3.2.16",
+    "@storybook/cli": "^3.2.16",
+    "@storybook/react": "^3.2.16",
     "@storybook/storybook-deployer": "2.0.0",
     "autoprefixer": "7.1.1",
     "babel-cli": "^6.24.1",
@@ -219,7 +219,10 @@
       "React",
       "react",
       "requestAnimationFrame",
-      "test"
+      "test",
+      "$mount",
+      "mount",
+      "$"
     ]
   },
   "eslintConfig": {

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -17,6 +17,10 @@ const trigger = (
   <a className='trigger'>Trigger</a>
 )
 
+beforeEach(() => {
+  window.BluePortalWrapperGlobalManager = undefined
+})
+
 afterEach(() => {
   document.body.innerHTML = ''
   document.body.style.overflow = null

--- a/src/components/Portal/tests/Portal.test.js
+++ b/src/components/Portal/tests/Portal.test.js
@@ -2,69 +2,71 @@ import React from 'react'
 import { mount } from 'enzyme'
 import Portal from '..'
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000
-const PORTAL_TEST_TIMEOUT = 300
+// jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000
+const PORTAL_TEST_TIMEOUT = 10
 
 const cleanUp = (wrapper) => {
   if (wrapper) wrapper.unmount()
   global.document.body.innerHTML = ''
 }
 
-test('Renders at the body on mount', () => {
-  const preMountNodeCount = document.body.childNodes.length
-  const wrapper = mount(
-    <Portal>
-      <div className='brick'>BRICK</div>
-    </Portal>
-  )
-  const portal = document.body.childNodes[0]
-  const el = portal.getElementsByClassName('brick')[0]
+describe('Renders', () => {
+  test('Renders at the body on mount', () => {
+    const preMountNodeCount = document.body.childNodes.length
+    const wrapper = mount(
+      <Portal>
+        <div className='brick'>BRICK</div>
+      </Portal>
+    )
+    const portal = document.body.childNodes[0]
+    const el = portal.getElementsByClassName('brick')[0]
 
-  expect(document.body.childNodes.length).toBe(preMountNodeCount + 1)
-  expect(el).toBeTruthy()
-  expect(el.innerHTML).toBe('BRICK')
+    expect(document.body.childNodes.length).toBe(preMountNodeCount + 1)
+    expect(el).toBeTruthy()
+    expect(el.innerHTML).toBe('BRICK')
 
-  cleanUp(wrapper)
-})
+    cleanUp(wrapper)
+  })
 
-test('Is removed from the body on unmount', (done) => {
-  const wrapper = mount(
-    <Portal>
-      <div className='brick'>BRICK</div>
-    </Portal>
-  )
+  test('Is removed from the body on unmount', (done) => {
+    const wrapper = mount(
+      <Portal>
+        <div className='brick'>BRICK</div>
+      </Portal>
+    )
 
-  wrapper.unmount()
+    wrapper.unmount()
 
-  setTimeout(() => {
-    expect(document.getElementsByClassName('brick').length).toBe(0)
-    cleanUp()
-    done()
-  }, PORTAL_TEST_TIMEOUT)
-})
+    setTimeout(() => {
+      expect(document.getElementsByClassName('brick').length).toBe(0)
+      cleanUp()
+      done()
+    }, PORTAL_TEST_TIMEOUT)
+  })
 
-test('Can add custom className', () => {
-  const wrapper = mount(
-    <Portal className='champ'>
-      <div className='brick'>BRICK</div>
-    </Portal>
-  )
+  test('Can add custom className', () => {
+    const wrapper = mount(
+      <Portal className='champ'>
+        <div className='brick'>BRICK</div>
+      </Portal>
+    )
 
-  expect(document.getElementsByClassName('champ').length).toBe(1)
+    expect(document.getElementsByClassName('champ').length).toBe(1)
 
-  cleanUp(wrapper)
-})
+    cleanUp(wrapper)
+  })
 
-test('Can add custom ID', () => {
-  const wrapper = mount(
-    <Portal id='champ'>
-      <div className='brick'>BRICK</div>
-    </Portal>
-  )
+  test('Can add custom ID', () => {
+    const wrapper = mount(
+      <Portal id='champ'>
+        <div className='brick'>BRICK</div>
+      </Portal>
+    )
 
-  expect(document.getElementById('champ')).toBeTruthy()
+    expect(document.getElementById('champ')).toBeTruthy()
 
-  cleanUp(wrapper)
+    cleanUp(wrapper)
+  })
 })
 
 describe('renderTo', () => {

--- a/src/components/Portal/tests/Portal.test.js
+++ b/src/components/Portal/tests/Portal.test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme'
 import Portal from '..'
 
 // jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000
-const PORTAL_TEST_TIMEOUT = 10
+const PORTAL_TEST_TIMEOUT = 300
 
 const cleanUp = (wrapper) => {
   if (wrapper) wrapper.unmount()

--- a/src/components/PortalWrapper/Content.js
+++ b/src/components/PortalWrapper/Content.js
@@ -1,0 +1,39 @@
+import { PureComponent as Component } from 'react'
+import PropTypes from 'prop-types'
+import { setupManager } from '../../utilities/globalManager'
+
+const managerNamespace = 'BluePortalWrapperGlobalManager'
+
+export const propTypes = {
+  manager: PropTypes.object,
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+}
+const defaultProps = {
+  manager: setupManager(managerNamespace),
+  id: 1000
+}
+
+class Content extends Component {
+  componentDidMount () {
+    const { id, manager } = this.props
+    manager.add(id)
+  }
+
+  componentWillUnmount () {
+    const { id, manager } = this.props
+    manager.remove(id)
+  }
+
+  render () {
+    const {
+      children
+    } = this.props
+
+    return children || null
+  }
+}
+
+Content.propTypes = propTypes
+Content.defaultProps = defaultProps
+
+export default Content

--- a/src/components/PortalWrapper/tests/Content.test.js
+++ b/src/components/PortalWrapper/tests/Content.test.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { setupManager } from '../../../utilities/globalManager'
+import Content from '../Content'
+
+afterEach(() => {
+  window.MrManager = undefined
+})
+
+describe('Children', () => {
+  test('Can render children', () => {
+    const wrapper = mount(
+      <Content><div className='ron' /></Content>
+    )
+    const o = wrapper.find('div.ron')
+
+    expect(o.length).toBe(1)
+  })
+})
+
+describe('Manager', () => {
+  test('Creates a manager by default', () => {
+    const wrapper = mount(<Content />)
+    const props = wrapper.props()
+
+    expect(props.manager).toBeTruthy()
+    expect(typeof props.manager.add).toBe('function')
+    expect(typeof props.manager.remove).toBe('function')
+  })
+
+  test('Accepts a manager', () => {
+    const manager = setupManager('MrManager')
+    const wrapper = mount(<Content manager={manager} />)
+
+    expect(wrapper.props().manager).toBe(manager)
+  })
+
+  test('Adds ID to manager on mount', () => {
+    const manager = setupManager('MrManager')
+    expect(manager.data.length).toBe(0)
+
+    mount(<Content manager={manager} id={1} />)
+
+    expect(manager.data.length).toBe(1)
+  })
+
+  test('Removes from manager on unmount', () => {
+    const manager = setupManager('MrManager')
+    const wrapper = mount(<Content manager={manager} id={1} />)
+
+    expect(manager.data.length).toBe(1)
+
+    wrapper.unmount()
+
+    expect(manager.data.length).toBe(0)
+  })
+})

--- a/src/utilities/globalManager.js
+++ b/src/utilities/globalManager.js
@@ -14,7 +14,8 @@ export const setupManager = (namespace = '') => {
     add: add(window[ns]),
     remove: remove(window[ns]),
     first: first(window[ns]),
-    last: last(window[ns])
+    last: last(window[ns]),
+    max: max(window[ns])
   }
 }
 
@@ -37,4 +38,8 @@ export const first = manager => () => {
 
 export const last = manager => () => {
   return manager[manager.length - 1]
+}
+
+export const max = manager => () => {
+  return Math.max.apply(Math, manager)
 }

--- a/src/utilities/id.js
+++ b/src/utilities/id.js
@@ -1,10 +1,15 @@
 // Source
 // https://github.com/Shopify/javascript-utilities/blob/master/src/other.ts
 export function createUniqueIDFactory (prefix = '') {
-  let index = 1
+  const index = createUniqueIndexFactory(1)
   return (prefixOverride) => {
     const namespace = prefixOverride || prefix
 
-    return `${namespace}${index++}`
+    return `${namespace}${index()}`
   }
+}
+
+export function createUniqueIndexFactory (start = 1) {
+  let index = typeof start === 'number' ? start : 1
+  return () => index++
 }

--- a/src/utilities/tests/id.test.js
+++ b/src/utilities/tests/id.test.js
@@ -1,4 +1,7 @@
-import { createUniqueIDFactory } from '../id'
+import {
+  createUniqueIDFactory,
+  createUniqueIndexFactory
+} from '../id'
 
 describe('createUniqueIDFactory', () => {
   test('Generates an numerical ID (string), without arguments', () => {
@@ -21,5 +24,48 @@ describe('createUniqueIDFactory', () => {
     uid() // 4
     // Next call should be 5
     expect(uid()).toBe('prefix5')
+  })
+})
+
+describe('createUniqueIndexFactory', () => {
+  test('Defaults to 1 if argument is invalid', () => {
+    const ui = createUniqueIndexFactory('index')
+
+    expect(ui()).toBe(1)
+  })
+
+  test('Generates an numerical ID (number), without arguments', () => {
+    const ui = createUniqueIndexFactory()
+
+    expect(ui()).toBe(1)
+  })
+
+  test('Auto-increments ID num on every call', () => {
+    const ui = createUniqueIndexFactory()
+    ui() // 1
+    ui() // 2
+    ui() // 3
+    ui() // 4
+    ui() // 5
+
+    expect(ui()).toBe(6)
+  })
+
+  test('Generates an index based on a start number', () => {
+    const ui = createUniqueIndexFactory(100)
+
+    expect(ui()).toBe(100)
+  })
+
+  test('Auto-increments ID based on a start number', () => {
+    const ui = createUniqueIndexFactory(100)
+    ui() // 100
+    ui() // 101
+    ui() // 102
+    ui() // 103
+    ui() // 104
+    ui() // 105
+
+    expect(ui()).toBe(106)
   })
 })

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -1,9 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import Perf from 'react-addons-perf'
 import { storiesOf } from '@storybook/react'
 import { Heading, Modal, Link } from '../src/index.js'
 import { MemoryRouter } from 'react-router'
 import { Route } from 'react-router-dom'
+
+window.Perf = Perf
 
 storiesOf('Modal', module)
   .addDecorator(story => (
@@ -170,12 +173,27 @@ storiesOf('Modal', module)
         </ul>
 
         <Modal path='/team' onBeforeOpen={onBeforeOpen}>
-          <h1>Team Modal</h1>
+          <h1>Team Modal: A</h1>
           <p>Modal content</p>
         </Modal>
 
         <Modal path='/team/brick'>
-          <h1>Team Modal: Brick</h1>
+          <h1>Team Modal: B</h1>
+          <p>Modal inner content</p>
+        </Modal>
+
+        <Modal path='/team/brick'>
+          <h1>Team Modal: C</h1>
+          <p>Modal inner content</p>
+        </Modal>
+
+        <Modal path='/team/brick'>
+          <h1>Team Modal: D</h1>
+          <p>Modal inner content</p>
+        </Modal>
+
+        <Modal path='/team/brick'>
+          <h1>Team Modal: E</h1>
           <p>Modal inner content</p>
         </Modal>
 

--- a/test/acceptance/components/Dropdown.spec.js
+++ b/test/acceptance/components/Dropdown.spec.js
@@ -1,9 +1,17 @@
 import React from 'react'
 import { Dropdown, Portal } from '../../../src/index'
+import Keys from '../../../src/constants/Keys'
+
+const simulateKeyPress = (keyCode) => {
+  const event = new Event('keyup')
+  event.keyCode = keyCode
+
+  document.dispatchEvent(event)
+}
 
 describe('Dropdown', () => {
-  it('should position menu correctly on open', (done) => {
-    const wrapper = mount(
+  it('should open menu on trigger click', () => {
+    mount(
       <div>
         <Dropdown>
           <Dropdown.Trigger className='trigger'>Action</Dropdown.Trigger>
@@ -15,7 +23,7 @@ describe('Dropdown', () => {
             <Dropdown.Item>Brick</Dropdown.Item>
           </Dropdown.Menu>
         </Dropdown>
-        <div id='modals' />
+        <Portal.Container />
       </div>
     )
 
@@ -23,8 +31,92 @@ describe('Dropdown', () => {
 
     $('.trigger')[0].click()
 
+    expect($('.menu').length).toBe(1)
+  })
+
+  it('should open menu if specified', () => {
+    mount(
+      <div>
+        <Dropdown isOpen>
+          <Dropdown.Trigger className='trigger'>Action</Dropdown.Trigger>
+          <Dropdown.Menu className='menu'>
+            <Dropdown.Item>Ron</Dropdown.Item>
+            <Dropdown.Item>Champ</Dropdown.Item>
+            <Dropdown.Item>Brian</Dropdown.Item>
+            <Dropdown.Divider />
+            <Dropdown.Item>Brick</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
+        <Portal.Container />
+      </div>
+    )
+    expect($('.menu').length).toBe(1)
+  })
+
+  it('should can open sub-menu on sub-trigger click', () => {
+    mount(
+      <div>
+        <Dropdown isOpen>
+          <Dropdown.Trigger className='trigger'>Action</Dropdown.Trigger>
+          <Dropdown.Menu className='menu'>
+            <Dropdown.Item className='sub'>
+              Ron
+              <Dropdown.Menu className='menu'>
+                <Dropdown.Item>Ron</Dropdown.Item>
+                <Dropdown.Item>Champ</Dropdown.Item>
+                <Dropdown.Item>Brian</Dropdown.Item>
+                <Dropdown.Divider />
+                <Dropdown.Item>Brick</Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown.Item>
+            <Dropdown.Item>Champ</Dropdown.Item>
+            <Dropdown.Item>Brian</Dropdown.Item>
+            <Dropdown.Divider />
+            <Dropdown.Item>Brick</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
+        <Portal.Container />
+      </div>
+    )
+
+    expect($('.menu').length).toBe(1)
+    $('.sub').find('.c-DropdownItem__link')[0].click()
+    expect($('.menu').length).toBe(2)
+  })
+
+  it('should close all menus on ESCAPE press', (done) => {
+    mount(
+      <div>
+        <Dropdown isOpen>
+          <Dropdown.Trigger className='trigger'>Action</Dropdown.Trigger>
+          <Dropdown.Menu className='menu'>
+            <Dropdown.Item className='sub'>
+              Ron
+              <Dropdown.Menu className='menu'>
+                <Dropdown.Item>Ron</Dropdown.Item>
+                <Dropdown.Item>Champ</Dropdown.Item>
+                <Dropdown.Item>Brian</Dropdown.Item>
+                <Dropdown.Divider />
+                <Dropdown.Item>Brick</Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown.Item>
+            <Dropdown.Item>Champ</Dropdown.Item>
+            <Dropdown.Item>Brian</Dropdown.Item>
+            <Dropdown.Divider />
+            <Dropdown.Item>Brick</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
+        <Portal.Container />
+      </div>
+    )
+
+    $('.sub').find('.c-DropdownItem__link')[0].click()
+    expect($('.menu').length).toBe(2)
+
+    simulateKeyPress(Keys.ESCAPE)
+
     setTimeout(() => {
-      expect($('.menu').length).toBe(1)
+      expect($('.menu').length).toBe(0)
       done()
     }, 300)
   })

--- a/test/acceptance/components/Modal.spec.js
+++ b/test/acceptance/components/Modal.spec.js
@@ -1,10 +1,19 @@
 import React from 'react'
+import { MemoryRouter as Router } from 'react-router'
 import { Heading, Link, Modal, Portal } from '../../../src/index'
+import Keys from '../../../src/constants/Keys'
+
+const simulateKeyPress = (keyCode) => {
+  const event = new Event('keyup')
+  event.keyCode = keyCode
+
+  document.dispatchEvent(event)
+}
 
 describe('Modal', () => {
   it('should be able to open/close modal', (done) => {
     const triggerMarkup = (<Link className='trigger'>Click</Link>)
-    const wrapper = mount(
+    mount(
       <div>
         <Modal
           trigger={triggerMarkup}
@@ -30,6 +39,74 @@ describe('Modal', () => {
     setTimeout(() => {
       expect($('.modal').length).toBe(0)
       done()
+    }, 450)
+  })
+
+  it('should be able to open with route', (done) => {
+    mount(
+      <Router initialEntries={['/']}>
+        <div>
+          <Modal className='modal' exact path='/' />
+          <Portal.Container />
+        </div>
+      </Router>
+    )
+
+    expect($('.modal').length).toBe(1)
+    done()
+  })
+
+  it('should be able to open multiple modals on route change', (done) => {
+    const wrapper = mount(
+      <Router initialEntries={['/new/path', '/']} initialIndex={1}>
+        <div>
+          <Modal className='modal' path='/' />
+          <Modal className='modal' path='/new' />
+          <Modal className='modal' path='/new/path' />
+          <Portal.Container />
+        </div>
+      </Router>
+    )
+
+    expect($('.modal').length).toBe(1)
+
+    wrapper.node.history.goBack()
+
+    expect($('.modal').length).toBe(3)
+    done()
+  })
+
+  it('should be able to close individual modals, in order', (done) => {
+    const wrapper = mount(
+      <Router initialEntries={['/new/path', '/']} initialIndex={1}>
+        <div>
+          <Modal className='modal one' path='/' />
+          <Modal className='modal two' path='/new' />
+          <Modal className='modal three' path='/new/path' />
+          <Portal.Container />
+        </div>
+      </Router>
+    )
+
+    wrapper.node.history.goBack()
+
+    simulateKeyPress(Keys.ESCAPE)
+
+    setTimeout(() => {
+      expect($('.modal').length).toBe(2)
+      expect($('.modal.one').length).toBe(1)
+      expect($('.modal.two').length).toBe(1)
+      expect($('.modal.three').length).toBe(0)
+
+      simulateKeyPress(Keys.ESCAPE)
+
+      setTimeout(() => {
+        expect($('.modal').length).toBe(1)
+        expect($('.modal.one').length).toBe(1)
+        expect($('.modal.two').length).toBe(0)
+        expect($('.modal.three').length).toBe(0)
+        done()
+      }, 450)
     }, 450)
   })
 })

--- a/test/acceptance/test-helpers.js
+++ b/test/acceptance/test-helpers.js
@@ -6,20 +6,21 @@ import '../../src/styles/blue.scss'
 import '../../src/styles/blue.hs-app.scss'
 
 // require all the test files in the test folder that end with Spec.js or Spec.jsx
-const testsContext = require.context(".", true, /spec.jsx?$/);
-testsContext.keys().forEach(testsContext);
+const testsContext = require.context('.', true, /spec.jsx?$/)
+testsContext.keys().forEach(testsContext)
 
 const mountNode = document.createElement('div')
 mountNode.id = 'karma-react-root'
 document.body.appendChild(mountNode)
 
 const mountHelper = (component) => {
+  window.BluePortalWrapperGlobalManager = null
+  mountNode.innerHTML = ''
   const wrapper = mount(component, { attachTo: mountNode })
   return wrapper
 }
 
 const $mountHelper = (component) => {
-  mountNode.innerHTML = ''
   const wrapper = mountHelper(component)
   const $wrapper = $(wrapper.getDOMNode())
   return $wrapper


### PR DESCRIPTION
## PortalWrapper: Fix integration with Route usage

![screen recording 2017-11-29 at 03 10 pm](https://user-images.githubusercontent.com/2322354/33401958-193b87e6-d529-11e7-86aa-5519c58da882.gif)

This commit resolves the issue where Route (react-router) mounted
components built with PortalWrapper (specifically Modals) don't
correctly close when the ESCAPE key is pressed.

This is due to `react-router` injecting the Modals in a non-linear
order. To resolve this, I've adjusted how PortalWrapper works with
it's GlobalManager. Instead of using IDs, it will use unique
incrementing index number values. This ensures that the latest
injected component, always has the highest index value. Therefore,
when triggere a close (with the escape key), the GlobalManager will
look for the highest index value and execute the close action it.

Unit tests were enhanced, but more importantly, acceptance tests
were added to test out these interactions, especially with
route changes/ESCAPE interactions.

Note: Storybook was updated to the latest versions in this update.

Resolves: https://github.com/helpscout/blue/issues/127