### PR TITLE
Icon: Add ability to have a (right) side caret

### DIFF
--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -21,3 +21,4 @@ An Icon component renders an SVG icon.
 | onClick | `function` | Callback function when component is clicked. |
 | size | `number`/`string` | Adjusts the size of the component. |
 | title | `string` | Provides a name for the component. |
+| withCaret | `bool` | Renders a caret icon, next to the component's SVG icon. |

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -18,7 +18,8 @@ export const propTypes = {
   onClick: PropTypes.func,
   size: sizeTypes,
   subtle: PropTypes.bool,
-  title: PropTypes.string
+  title: PropTypes.string,
+  withCaret: PropTypes.bool
 }
 
 const defaultProps = {
@@ -28,7 +29,8 @@ const defaultProps = {
   muted: false,
   name: null,
   onClick: noop,
-  size: '20'
+  size: '20',
+  withCaret: false
 }
 
 const Icon = props => {
@@ -45,6 +47,7 @@ const Icon = props => {
     size,
     subtle,
     title,
+    withCaret,
     ...rest
   } = props
 
@@ -58,11 +61,20 @@ const Icon = props => {
     muted && 'is-muted',
     subtle && 'is-subtle',
     size && `is-${size}`,
+    withCaret && 'is-withCaret',
     className
   )
 
   const src = { __html: ICONS[name] }
   const iconTitle = title || name
+
+  const caretMarkup = withCaret ? (
+    <span
+      className='c-Icon__icon is-caret'
+      dangerouslySetInnerHTML={{__html: ICONS['caret-down']}}
+      title='Caret'
+    />
+  ) : null
 
   return (
     <span
@@ -76,6 +88,7 @@ const Icon = props => {
         dangerouslySetInnerHTML={src}
         title={iconTitle}
       />
+      {caretMarkup}
       <VisuallyHidden>{iconTitle}</VisuallyHidden>
     </span>
   )

--- a/src/components/Icon/tests/Icon.test.js
+++ b/src/components/Icon/tests/Icon.test.js
@@ -66,3 +66,22 @@ describe('Styles', () => {
     expect(wrapper.prop('className')).toContain('is-subtle')
   })
 })
+
+describe('withCaret', () => {
+  const caretClassName = '.c-Icon__icon.is-caret'
+
+  test('Does not render caret by default', () => {
+    const wrapper = shallow(<Icon name='emoji' />)
+    const o = wrapper.find(caretClassName)
+
+    expect(o.length).toBe(0)
+  })
+
+  test('Can render caret, if specified', () => {
+    const wrapper = shallow(<Icon name='emoji' withCaret />)
+    const o = wrapper.find(caretClassName)
+
+    expect(wrapper.hasClass('is-withCaret')).toBe(true)
+    expect(o.length).toBe(1)
+  })
+})

--- a/src/styles/components/Icon.scss
+++ b/src/styles/components/Icon.scss
@@ -1,9 +1,11 @@
 @import "pack/seed-dash/_index";
+@import "pack/seed-family/_index";
 
 .c-Icon {
   @import "../configs/color";
   $sizes: (8, 10, 12, 14, 16, 18, 20, 24);
   $shades: faint, muted, subtle;
+  $caretSize: 10px;
   $default-size: 20;
 
   box-sizing: border-box;
@@ -43,6 +45,10 @@
     &.is-#{$size} {
       height: ($size * 1px);
       width: ($size * 1px);
+
+      &.is-withCaret {
+        width: (($size * 1px) + $caretSize);
+      }
     }
   }
 
@@ -63,6 +69,19 @@
     path,
     rect {
       fill: currentColor;
+    }
+
+    @include parent(".is-withCaret > ") {
+      width: calc(100% - #{$caretSize});
+    }
+
+    &.is-caret {
+      $size: $caretSize;
+      height: $size;
+      position: absolute;
+      right: 0;
+      top: calc(50% - #{ceil($size / 2)});
+      width: $size;
     }
   }
 }

--- a/stories/Icon.js
+++ b/stories/Icon.js
@@ -1,76 +1,124 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Icon, Text } from '../src/index.js'
+import { Flexy, Icon, Text } from '../src/index.js'
 
-storiesOf('Icon', module)
-  .add('icons', () => {
-    const icons = [
-      'alert',
-      'arrow-left',
-      'arrow-right',
-      'attachment',
-      'caret-down',
-      'caret-left',
-      'caret-right',
-      'caret-up',
-      'chat-active',
-      'chat',
-      'clock-large',
-      'clock-small',
-      'collapse',
-      'cross-large',
-      'cross-medium',
-      'cross-small',
-      'document',
-      'drag',
-      'emoji',
-      'helpscout-logo',
-      'image-add',
-      'image',
-      'link',
-      'meatball',
-      'search',
-      'star',
-      'tick-large',
-      'tick-small',
-      'video'
-    ].map(i => (
-      <div style={{display: 'inline-block', margin: 12, textAlign: 'center'}}>
-        <Icon name={i} key={i} center />
-        <Text muted size='sm'>{i}</Text>
-        <br />
-      </div>
-    ))
+const stories = storiesOf('Icon', module)
 
-    return (<div>{icons}</div>)
-  })
-  .add('sizes', () => {
-    const icons = [
-      '14', '16', '18', '24'
-    ].map(i => (
-      <div style={{display: 'inline-block', margin: 12, textAlign: 'center'}}>
-        <Icon name='emoji' size={i} key={i} center />
-        <Text muted size='sm'>{i}</Text>
-        <br />
-      </div>
-    ))
+stories.add('icons', () => {
+  const icons = [
+    'alert',
+    'arrow-left',
+    'arrow-right',
+    'attachment',
+    'caret-down',
+    'caret-left',
+    'caret-right',
+    'caret-up',
+    'chat-active',
+    'chat',
+    'clock-large',
+    'clock-small',
+    'collapse',
+    'cross-large',
+    'cross-medium',
+    'cross-small',
+    'document',
+    'drag',
+    'emoji',
+    'helpscout-logo',
+    'image-add',
+    'image',
+    'link',
+    'meatball',
+    'search',
+    'star',
+    'tick-large',
+    'tick-small',
+    'video'
+  ].map(i => (
+    <div style={{display: 'inline-block', margin: 12, textAlign: 'center'}}>
+      <Icon name={i} key={i} center />
+      <Text muted size='sm'>{i}</Text>
+      <br />
+    </div>
+  ))
 
-    return (<div>{icons}</div>)
-  })
-  .add('colors', () => {
-    return (
+  return (<div>{icons}</div>)
+})
+
+stories.add('sizes', () => {
+  const icons = [
+    '14', '16', '18', '24'
+  ].map(i => (
+    <div style={{display: 'inline-block', margin: 12, textAlign: 'center'}}>
+      <Icon name='emoji' size={i} key={i} center />
+      <Text muted size='sm'>{i}</Text>
+      <br />
+    </div>
+  ))
+
+  return (<div>{icons}</div>)
+})
+
+stories.add('colors', () => {
+  return (
+    <div>
       <div>
-        <div>
-          <Icon name='emoji' />
-          <Text muted size='sm'>Regular</Text>
-          <br />
-        </div>
+        <Icon name='emoji' />
+        <Text muted size='sm'>Regular</Text>
         <br />
-        <div>
-          <Icon name='emoji' muted />
-          <Text muted size='sm'>Muted</Text>
-          <br />
-        </div>
       </div>
-    )
-  })
+      <br />
+      <div>
+        <Icon name='emoji' muted />
+        <Text muted size='sm'>Muted</Text>
+        <br />
+      </div>
+    </div>
+  )
+})
+
+stories.add('withCaret', () => {
+  const icons = [
+    '14', '16', '18', '24'
+  ].map(i => (
+    <div style={{display: 'inline-block', margin: 12, textAlign: 'center'}}>
+      <Icon name='emoji' size={i} key={i} center withCaret />
+      <Text muted size='sm'>{i}</Text>
+      <br />
+    </div>
+  ))
+
+  return (
+    <div>
+      <Flexy just='left'>
+        <Flexy.Item>
+          <Icon name='emoji' withCaret />
+        </Flexy.Item>
+        <Flexy.Item>
+          <Text muted size='sm'>With Caret</Text>
+        </Flexy.Item>
+      </Flexy>
+
+      <Flexy just='left'>
+        <Flexy.Item>
+          <Icon name='emoji' withCaret muted />
+        </Flexy.Item>
+        <Flexy.Item>
+          <Text muted size='sm'>Muted + Caret</Text>
+        </Flexy.Item>
+      </Flexy>
+
+      <Flexy just='left' style={{color: 'red'}}>
+        <Flexy.Item>
+          <Icon name='emoji' withCaret />
+        </Flexy.Item>
+        <Flexy.Item>
+          <Text muted size='sm'>Caret + Custom color</Text>
+        </Flexy.Item>
+      </Flexy>
+
+      {icons}
+    </div>
+  )
+})

--- a/test/acceptance/components/Icon.spec.js
+++ b/test/acceptance/components/Icon.spec.js
@@ -1,0 +1,87 @@
+import React from 'react'
+import { Icon } from '../../../src/index'
+
+describe('Icon', () => {
+
+  describe('Color', () => {
+    it('should inherit icon color from parent node', () => {
+      mount(
+        <div style={{color: 'red'}} className='wrapper'>
+          <Icon
+            name='emoji'
+            className='caret'
+            center
+          />
+        </div>
+      )
+      const color = $('.wrapper').css('color')
+      const icon = $('.caret')
+      const svg = icon.find('.c-Icon__icon').first().find('svg path')
+
+      expect(svg.css('fill')).toBe(color)
+    })
+  })
+
+  describe('center', () => {
+    it('should be able to center align Icon', () => {
+      mount(
+        <div>
+          <Icon name='emoji' className='caret' center />
+        </div>
+      )
+      const caret = $('.caret')
+
+      expect(caret.css('margin-left')).not.toBe('0px')
+      expect(caret.css('margin-left')).toBe(caret.css('margin-right'))
+    })
+  })
+
+  describe('withCaret', () => {
+
+    it('should not align caret below icon', () => {
+      mount(
+        <div>
+          <Icon name='emoji' className='default' />
+          <Icon name='emoji' className='caret' withCaret />
+        </div>
+      )
+      const def = $('.default')
+      const caret = $('.caret')
+
+      expect(def.height()).toBe(caret.height())
+      expect(def.width()).toBeLessThan(caret.width())
+    })
+
+    it('should be able to center align Icon withCaret', () => {
+      mount(
+        <div>
+          <Icon name='emoji' className='caret' withCaret center />
+        </div>
+      )
+      const caret = $('.caret')
+
+      expect(caret.css('margin-left')).not.toBe('0px')
+      expect(caret.css('margin-left')).toBe(caret.css('margin-right'))
+    })
+
+    it('should use the same color for both Icon and Caret', () => {
+      mount(
+        <div style={{color: 'red'}} className='wrapper'>
+          <Icon
+            name='emoji'
+            className='caret'
+            withCaret
+            center
+          />
+        </div>
+      )
+      const color = $('.wrapper').css('color')
+      const icon = $('.caret')
+      const svg = icon.find('.c-Icon__icon').first().find('svg path')
+      const caret = icon.find('.c-Icon__icon.is-caret svg path')
+
+      expect(svg.css('fill')).toBe(color)
+      expect(caret.css('fill')).toBe(color)
+    })
+  })
+})

--- a/test/acceptance/components/StatusDot.spec.js
+++ b/test/acceptance/components/StatusDot.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { StatusDot } from '../../../src/index'
 
-describe('Status', () => {
+describe('StatusDot', () => {
   it('should not align adjacent to sibling node by default', () => {
     mount(
       <div>


### PR DESCRIPTION
## Icon: Add ability to have a (right) side caret

![screen shot 2017-11-30 at 6 18 12 pm](https://user-images.githubusercontent.com/2322354/33460832-0447fe5c-d5fe-11e7-9edc-fce3f97c5b5d.jpg)

This update adds a new `withCaret` prop, which renders a small caret
on the right hand side of an Icon component. The caret is automatically
aligned in the center (vertically), regardless of icon size. The caret
does not hinder other prop styles like `center`, and inherits the same
SVG fill color as the regular icon.

To make triple sure of this, I've written some Karma acceptance tests 🎉.

P.S. Acceptance tests are awesome. Boy, I love being able to test
ACTUAL DOM properties.

Partially resolves: https://github.com/helpscout/blue/issues/129