### PR TITLE
Modal: Fix overlapping UI for scrollable content

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,14 +1,17 @@
-import React from 'react'
+import React, {PureComponent as Component} from 'react'
 import PropTypes from 'prop-types'
 import Animate from '../Animate'
 import Card from '../Card'
 import CloseButton from '../CloseButton'
+import EventListener from '../EventListener'
 import Overlay from '../Overlay'
 import PortalWrapper from '../PortalWrapper'
 import Scrollable from '../Scrollable'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 import { propTypes as portalTypes } from '../Portal'
+import { hasContentOverflowY } from '../../utilities/node'
+import getScrollbarWidth from '../../vendors/getScrollbarWidth'
 
 export const propTypes = Object.assign({}, portalTypes, {
   closeIcon: PropTypes.bool,
@@ -49,70 +52,111 @@ const portalOptions = {
   zIndex: modalBaseZIndex
 }
 
-const Modal = props => {
-  const {
-    children,
-    className,
-    closeIcon,
-    closePortal,
-    exact,
-    isOpen,
-    modalAnimationDelay,
-    openPortal,
-    onClose,
-    onScroll,
-    overlayAnimationDelay,
-    path,
-    portalIsOpen,
-    portalIsMounted,
-    scrollFade,
-    scrollableRef,
-    style,
-    timeout,
-    trigger,
-    zIndex,
-    ...rest
-  } = props
+const scrollbarWidth = getScrollbarWidth()
 
-  const componentClassName = classNames(
-    'c-Modal',
-    isOpen && 'is-open',
-    className
-  )
+class Modal extends Component {
+  constructor () {
+    super()
+    this.handleOnResize = this.handleOnResize.bind(this)
+    this.closeNode = null
+    this.scrollableNode = null
+  }
 
-  const closeMarkup = closeIcon ? (
-    <div className='c-Modal__close'>
-      <CloseButton onClick={closePortal} />
-    </div>
-  ) : null
+  componentDidMount () {
+    this.positionCloseNode()
+  }
 
-  const modalStyle = style ? Object.assign({}, style, {
-    zIndex
-  }) : { zIndex }
+  /* istanbul ignore next */
+  handleOnResize () {
+    this.positionCloseNode()
+  }
 
-  return (
-    <div className={componentClassName} role='document' style={modalStyle} {...rest}>
-      <div className='c-Modal__content'>
-        <Animate sequence='fade down' in={portalIsOpen} wait={modalAnimationDelay}>
-          <Card seamless role='dialog'>
-            {closeMarkup}
-            <Scrollable
-              className='c-Modal__scrollable'
-              fade
-              rounded
-              onScroll={onScroll}
-              scrollableRef={scrollableRef}
-            >
-              {children}
-            </Scrollable>
-          </Card>
+  positionCloseNode () {
+    if (!this.closeNode || !this.scrollableNode) return
+
+    const defaultOffset = 8
+    const borderOffset = 2
+    const offset = hasContentOverflowY(this.scrollableNode)
+      ? /* istanbul ignore next */ `${scrollbarWidth + borderOffset}px`
+      : `${defaultOffset}px`
+
+    this.closeNode.style.right = offset
+  }
+
+  render () {
+    const {
+      children,
+      className,
+      closeIcon,
+      closePortal,
+      exact,
+      isOpen,
+      modalAnimationDelay,
+      openPortal,
+      onClose,
+      onScroll,
+      overlayAnimationDelay,
+      path,
+      portalIsOpen,
+      portalIsMounted,
+      scrollFade,
+      scrollableRef,
+      style,
+      timeout,
+      trigger,
+      zIndex,
+      ...rest
+    } = this.props
+
+    const handleOnResize = this.handleOnResize
+
+    const componentClassName = classNames(
+      'c-Modal',
+      isOpen && 'is-open',
+      className
+    )
+
+    const closeMarkup = closeIcon ? (
+      <div
+        className='c-Modal__close'
+        ref={node => { this.closeNode = node }}
+      >
+        <CloseButton onClick={closePortal} />
+      </div>
+    ) : null
+
+    const modalStyle = style ? Object.assign({}, style, {
+      zIndex
+    }) : { zIndex }
+
+    return (
+      <div className={componentClassName} role='document' style={modalStyle} {...rest}>
+        <EventListener event='resize' handler={handleOnResize} />
+        <div className='c-Modal__content'>
+          <Animate className='c-Modal__Card-container' sequence='fade down' in={portalIsOpen} wait={modalAnimationDelay}>
+            <Card seamless role='dialog'>
+              {closeMarkup}
+              <Scrollable
+                className='c-Modal__scrollable'
+                fade
+                rounded
+                onScroll={onScroll}
+                scrollableRef={(node) => {
+                  this.scrollableNode = node
+                  scrollableRef(node)
+                }}
+              >
+                {children}
+              </Scrollable>
+            </Card>
+          </Animate>
+        </div>
+        <Animate sequence='fade' in={portalIsOpen} wait={overlayAnimationDelay}>
+          <Overlay onClick={closePortal} role='presentation' />
         </Animate>
       </div>
-      <Animate sequence='fade' in={portalIsOpen} wait={overlayAnimationDelay}>
-        <Overlay onClick={closePortal} role='presentation' />
-      </Animate>
-    </div>
-  )
+    )
+  }
 }
 
 Modal.propTypes = propTypes

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -2,8 +2,7 @@ import React, {PureComponent as Component} from 'react'
 import { shallow, mount } from 'enzyme'
 import { MemoryRouter as Router } from 'react-router'
 import { default as Modal, ModalComponent } from '..'
-import Portal from '../../Portal'
-import Scrollable from '../../Scrollable'
+import { Portal, Scrollable } from '../../index'
 import Keys from '../../../constants/Keys'
 import wait from '../../../tests/helpers/wait'
 
@@ -83,6 +82,13 @@ describe('CloseIcon', () => {
         wrapper.unmount()
         done()
       })
+  })
+
+  test('Adjusts CloseButton position on mount', () => {
+    const wrapper = mount(<ModalComponent isOpen />)
+    const o = wrapper.find('.c-Modal__close')
+
+    expect(o.html()).toContain('right:')
   })
 })
 

--- a/src/components/Scrollable/index.js
+++ b/src/components/Scrollable/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import ScrollLock from '../ScrollLock'
 import classNames from '../../utilities/classNames'
 import { hasContentOverflowY } from '../../utilities/node'
+import getScrollbarWidth from '../../vendors/getScrollbarWidth'
 import { getFadeTopStyles, getFadeBottomStyles } from '../../utilities/scrollFade'
 import { noop, requestAnimationFrame } from '../../utilities/other'
 
@@ -25,6 +26,8 @@ const defaultProps = {
   isScrollLocked: true
 }
 
+const scrollbarWidth = getScrollbarWidth()
+
 class Scrollable extends Component {
   constructor () {
     super()
@@ -36,6 +39,7 @@ class Scrollable extends Component {
     this.faderNodeBottom = null
     this.containerNode = null
     this.handleOnScroll = this.handleOnScroll.bind(this)
+    this.scrollbarWidth = scrollbarWidth
   }
 
   componentDidMount () {
@@ -60,6 +64,7 @@ class Scrollable extends Component {
       const transformTop = getFadeTopStyles(event, offset)
       requestAnimationFrame(() => {
         this.faderNodeTop.style.transform = transformTop
+        this.applyFadeStyleOffset(this.faderNodeTop)
       })
     }
 
@@ -67,8 +72,16 @@ class Scrollable extends Component {
       const transformBottom = getFadeBottomStyles(event, offset)
       requestAnimationFrame(() => {
         this.faderNodeBottom.style.transform = transformBottom
+        this.applyFadeStyleOffset(this.faderNodeBottom)
       })
     }
+  }
+
+  applyFadeStyleOffset (node) {
+    const offset = (hasContentOverflowY(this.containerNode))
+      ? /* istanbul ignore next */ `${this.scrollbarWidth}px`
+      : 0
+    node.style.right = offset
   }
 
   handleOnScroll (event) {
@@ -91,6 +104,7 @@ class Scrollable extends Component {
       isScrollLocked,
       ...rest
     } = this.props
+
     const { shouldFadeOnMount } = this.state
 
     const handleOnScroll = this.handleOnScroll

--- a/src/styles/components/Modal.scss
+++ b/src/styles/components/Modal.scss
@@ -22,6 +22,10 @@
     z-index: 1;
   }
 
+  &__Card-container {
+    display: flex;
+  }
+
   &__card-block {
     height: 100%;
   }

--- a/src/vendors/getScrollbarWidth.js
+++ b/src/vendors/getScrollbarWidth.js
@@ -1,0 +1,41 @@
+// Based on this solution
+// https://davidwalsh.name/detect-scrollbar-width
+// Slightly modified with caching, for performance
+const getScrollBarWidth = () => {
+  const namespace = 'BlueOSScrollbarWidthDetect'
+
+  if (window[namespace]) {
+    return window[namespace]
+  }
+
+  const inner = document.createElement('p')
+  inner.style.width = '100%'
+  inner.style.height = '200px'
+
+  const outer = document.createElement('div')
+  outer.style.position = 'absolute'
+  outer.style.top = '0px'
+  outer.style.left = '0px'
+  outer.style.visibility = 'hidden'
+  outer.style.width = '200px'
+  outer.style.height = '150px'
+  outer.style.overflow = 'hidden'
+  outer.appendChild(inner)
+
+  document.body.appendChild(outer)
+  const w1 = inner.offsetWidth
+  outer.style.overflow = 'scroll'
+  let w2 = inner.offsetWidth
+
+  if (w1 === w2) {
+    w2 = outer.clientWidth
+  }
+
+  document.body.removeChild(outer)
+
+  window[namespace] = (w1 - w2)
+
+  return window[namespace]
+}
+
+export default getScrollBarWidth


### PR DESCRIPTION
## Modal: Fix overlapping UI for scrollable content

![screen recording 2017-12-04 at 02 52 pm](https://user-images.githubusercontent.com/2322354/33574961-114c770a-d909-11e7-8c57-ad9f4390b6ef.gif)

This update adjusts the width of the Scrollable faders and the position
of the CloseButton for Modal. Previously, these elements had fixed
sizes/offsets, which overlapped with the (native) scrollbar that appears.

To remedy this, a util function was added to calculate the web
scrollbar width, determined by the OS. Calculcations where then added
to inline styles when applicable.

This update also fixes the Modal scroll bug, introduced by the
AnimeJS integration.

Resolves: https://github.com/helpscout/blue/issues/141