### PR TITLE
Modal: Add the ability to render cardless content

### DIFF
--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -34,6 +34,7 @@ A Modal component presents content within a container on top of the application'
 | path | `string` | Renders component based on a [React Router path](https://reacttraining.com/react-router/web/api/Route/path-string). |
 | scrollFade | `bool` | Enables the upper fade-to-white styles. Default `true`. |
 | scrollableRef | `function` | Retrieves the scrollable node. |
+| seamless | `bool` | Renders content with the standard [Card](../Card) UI. |
 | trigger | `element` | The UI the user clicks to trigger the modal. |
 
 

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -15,6 +15,7 @@ import getScrollbarWidth from '../../vendors/getScrollbarWidth'
 
 export const propTypes = Object.assign({}, portalTypes, {
   closeIcon: PropTypes.bool,
+  seamless: PropTypes.bool,
   scrollFade: PropTypes.bool,
   scrollableRef: PropTypes.func,
   modalAnimationDelay: PropTypes.oneOfType([
@@ -31,6 +32,7 @@ export const propTypes = Object.assign({}, portalTypes, {
 
 const defaultProps = {
   closeIcon: true,
+  seamless: false,
   scrollFade: true,
   isOpen: false,
   modalAnimationDelay: {
@@ -99,6 +101,7 @@ class Modal extends Component {
       path,
       portalIsOpen,
       portalIsMounted,
+      seamless,
       scrollFade,
       scrollableRef,
       style,
@@ -129,26 +132,30 @@ class Modal extends Component {
       zIndex
     }) : { zIndex }
 
+    const childrenMarkup = !seamless ? (
+      <Card seamless role='dialog'>
+        {closeMarkup}
+        <Scrollable
+          className='c-Modal__scrollable'
+          fade
+          rounded
+          onScroll={onScroll}
+          scrollableRef={(node) => {
+            this.scrollableNode = node
+            scrollableRef(node)
+          }}
+        >
+          {children}
+        </Scrollable>
+      </Card>
+    ) : children
+
     return (
       <div className={componentClassName} role='document' style={modalStyle} {...rest}>
         <EventListener event='resize' handler={handleOnResize} />
         <div className='c-Modal__content'>
           <Animate className='c-Modal__Card-container' sequence='fade down' in={portalIsOpen} wait={modalAnimationDelay}>
-            <Card seamless role='dialog'>
-              {closeMarkup}
-              <Scrollable
-                className='c-Modal__scrollable'
-                fade
-                rounded
-                onScroll={onScroll}
-                scrollableRef={(node) => {
-                  this.scrollableNode = node
-                  scrollableRef(node)
-                }}
-              >
-                {children}
-              </Scrollable>
-            </Card>
+            {childrenMarkup}
           </Animate>
         </div>
         <Animate sequence='fade' in={portalIsOpen} wait={overlayAnimationDelay}>

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -2,7 +2,7 @@ import React, {PureComponent as Component} from 'react'
 import { shallow, mount } from 'enzyme'
 import { MemoryRouter as Router } from 'react-router'
 import { default as Modal, ModalComponent } from '..'
-import { Portal, Scrollable } from '../../index'
+import { Card, Portal, Scrollable } from '../../index'
 import Keys from '../../../constants/Keys'
 import wait from '../../../tests/helpers/wait'
 
@@ -334,5 +334,31 @@ describe('Integration: Scrollable', () => {
     o.node.props.onScroll()
 
     expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('Seamless', () => {
+  test('Should not be seamless by default', () => {
+    const wrapper = mount(
+      <ModalComponent>
+        <div className='ron'>RON</div>
+      </ModalComponent>
+    )
+    const o = wrapper.find(Card)
+
+    expect(o.length).toBe(1)
+  })
+
+  test('Does not render the Card component, if seamless', () => {
+    const wrapper = mount(
+      <ModalComponent seamless>
+        <div className='ron'>RON</div>
+      </ModalComponent>
+    )
+    const card = wrapper.find(Card)
+    const o = wrapper.find('.ron')
+
+    expect(card.length).toBe(0)
+    expect(o.length).toBe(1)
   })
 })

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -8,201 +8,218 @@ import { Route } from 'react-router-dom'
 
 window.Perf = Perf
 
-storiesOf('Modal', module)
-  .addDecorator(story => (
-    <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>
-  ))
-  .add('default', () => (
-    <Modal trigger={<Link>Open dis modal</Link>}>
-      <div>
-        <Heading>Title</Heading>
+const stories = storiesOf('Modal', module)
+
+stories.addDecorator(story => (
+  <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>
+))
+
+stories.add('default', () => (
+  <Modal trigger={<Link>Open dis modal</Link>}>
+    <div>
+      <Heading>Title</Heading>
+      <p>
+        Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
+      </p>
+      <p>
+        Tenderloin bacon chicken jowl cupim, sausage shank spare ribs kielbasa. Flank corned beef kevin pastrami short ribs pork andouille turkey sirloin strip steak. Shank tri-tip porchetta beef ribs salami. Pork chop tail kielbasa, turkey pork loin filet mignon chicken jowl alcatra hamburger salami cupim.
+      </p>
+      <p>
+        Corned beef pork belly cupim turkey, filet mignon bresaola short ribs sirloin brisket. Fatback turkey strip steak tenderloin pig ham hock salami cow filet mignon ribeye. Brisket drumstick capicola rump. Biltong jowl prosciutto fatback bresaola strip steak pork chop shankle tri-tip shank salami pancetta ham hock. Cupim kielbasa doner salami, meatball capicola filet mignon pastrami.
+      </p>
+      <p>
+        Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
+      </p>
+      <p>
+        Tenderloin bacon chicken jowl cupim, sausage shank spare ribs kielbasa. Flank corned beef kevin pastrami short ribs pork andouille turkey sirloin strip steak. Shank tri-tip porchetta beef ribs salami. Pork chop tail kielbasa, turkey pork loin filet mignon chicken jowl alcatra hamburger salami cupim.
+      </p>
+      <p>
+        Corned beef pork belly cupim turkey, filet mignon bresaola short ribs sirloin brisket. Fatback turkey strip steak tenderloin pig ham hock salami cow filet mignon ribeye. Brisket drumstick capicola rump. Biltong jowl prosciutto fatback bresaola strip steak pork chop shankle tri-tip shank salami pancetta ham hock. Cupim kielbasa doner salami, meatball capicola filet mignon pastrami.
+      </p>
+    </div>
+  </Modal>
+))
+
+stories.add('open', () => (
+  <Modal isOpen trigger={<Link>Clicky</Link>}>
+    <div>
+      <Heading>Title</Heading>
+      <p>
+        Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
+      </p>
+    </div>
+  </Modal>
+))
+
+stories.add('custom close trigger', () => {
+  class Contents extends React.Component {
+    render () {
+      return (
         <p>
-          Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
+          <button onClick={this.context.closePortal}>Close me</button>
         </p>
-        <p>
-          Tenderloin bacon chicken jowl cupim, sausage shank spare ribs kielbasa. Flank corned beef kevin pastrami short ribs pork andouille turkey sirloin strip steak. Shank tri-tip porchetta beef ribs salami. Pork chop tail kielbasa, turkey pork loin filet mignon chicken jowl alcatra hamburger salami cupim.
-        </p>
-        <p>
-          Corned beef pork belly cupim turkey, filet mignon bresaola short ribs sirloin brisket. Fatback turkey strip steak tenderloin pig ham hock salami cow filet mignon ribeye. Brisket drumstick capicola rump. Biltong jowl prosciutto fatback bresaola strip steak pork chop shankle tri-tip shank salami pancetta ham hock. Cupim kielbasa doner salami, meatball capicola filet mignon pastrami.
-        </p>
-        <p>
-          Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-        </p>
-        <p>
-          Tenderloin bacon chicken jowl cupim, sausage shank spare ribs kielbasa. Flank corned beef kevin pastrami short ribs pork andouille turkey sirloin strip steak. Shank tri-tip porchetta beef ribs salami. Pork chop tail kielbasa, turkey pork loin filet mignon chicken jowl alcatra hamburger salami cupim.
-        </p>
-        <p>
-          Corned beef pork belly cupim turkey, filet mignon bresaola short ribs sirloin brisket. Fatback turkey strip steak tenderloin pig ham hock salami cow filet mignon ribeye. Brisket drumstick capicola rump. Biltong jowl prosciutto fatback bresaola strip steak pork chop shankle tri-tip shank salami pancetta ham hock. Cupim kielbasa doner salami, meatball capicola filet mignon pastrami.
-        </p>
-      </div>
+      )
+    }
+  }
+
+  Contents.contextTypes = {
+    closePortal: PropTypes.func
+  }
+
+  return (
+    <Modal trigger={<Link>Open me</Link>}>
+      <Contents />
     </Modal>
-  ))
-  .add('open', () => (
-    <Modal isOpen trigger={<Link>Clicky</Link>}>
-      <div>
-        <Heading>Title</Heading>
-        <p>
-          Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-        </p>
-      </div>
-    </Modal>
-  ))
-  .add('custom close trigger', () => {
-    class Contents extends React.Component {
-      render () {
-        return (
+  )
+})
+
+stories.add('seamless', () => (
+  <Modal trigger={<Link>Clicky</Link>} seamless>
+    <div>
+      <Heading>No Card!</Heading>
+      <p>So much room for activites!</p>
+    </div>
+  </Modal>
+))
+
+stories.add('nested', () => (
+  <Modal trigger={<Link>Clicky</Link>}>
+    <div>
+      <Heading>Title</Heading>
+      <p>
+        Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
+      </p>
+
+      <Modal trigger={<Link>Level 2</Link>}>
+        <div>
+          <Heading>Level 2</Heading>
           <p>
-            <button onClick={this.context.closePortal}>Close me</button>
+            Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
           </p>
-        )
-      }
-    }
+        </div>
 
-    Contents.contextTypes = {
-      closePortal: PropTypes.func
-    }
-
-    return (
-      <Modal trigger={<Link>Open me</Link>}>
-        <Contents />
+        <Modal trigger={<Link>Level 3</Link>}>
+          <div>
+            <Heading>Level 3</Heading>
+            <p>
+              Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
+            </p>
+          </div>
+        </Modal>
       </Modal>
-    )
-  })
-  .add('nested', () => (
-    <Modal trigger={<Link>Clicky</Link>}>
-      <div>
-        <Heading>Title</Heading>
-        <p>
-          Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-        </p>
 
-        <Modal trigger={<Link>Level 2</Link>}>
-          <div>
-            <Heading>Level 2</Heading>
-            <p>
-              Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-            </p>
-          </div>
+    </div>
+  </Modal>
+))
 
-          <Modal trigger={<Link>Level 3</Link>}>
-            <div>
-              <Heading>Level 3</Heading>
-              <p>
-                Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-              </p>
-            </div>
-          </Modal>
-        </Modal>
+stories.add('custom mounting selector', () => {
+  return (
+    <div>
+      <p>Render modal here:</p>
+      <div className='render-modal-here' />
 
-      </div>
-    </Modal>
-  ))
-  .add('custom mounting selector', () => {
-    return (
-      <div>
-        <p>Render modal here:</p>
-        <div className='render-modal-here' />
+      <Modal trigger={<Link>Clicky</Link>} renderTo='.render-modal-here'>
+        <div>
+          <Heading>Title</Heading>
+          <p>
+            Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
+          </p>
+        </div>
+      </Modal>
+    </div>
+  )
+})
 
-        <Modal trigger={<Link>Clicky</Link>} renderTo='.render-modal-here'>
-          <div>
-            <Heading>Title</Heading>
-            <p>
-              Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-            </p>
-          </div>
-        </Modal>
-      </div>
-    )
-  })
-  .add('lifecycle events', () => {
-    const onBeforeOpen = (modalOpen) => {
-      console.log('Before open!')
-      setTimeout(() => {
-        modalOpen()
-      }, 500)
-    }
-    const onBeforeClose = (modalClose) => {
-      console.log('Before close!')
-      setTimeout(() => {
-        modalClose()
-      }, 500)
-    }
-    return (
-      <div>
-        <p>onBeforeOpen: 500 delay</p>
-        <p>onBeforeClose: 500 delay</p>
-        <Modal
-          className='weee'
-          onBeforeOpen={onBeforeOpen}
-          onBeforeClose={onBeforeClose}
-          trigger={<Link>Clicky</Link>}
-        >
-          <div>
-            <Heading>Title</Heading>
-            <p>
-              Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-            </p>
-          </div>
-        </Modal>
-      </div>
-    )
-  })
-  .add('routes', () => {
-    const onBeforeOpen = (open) => {
-      setTimeout(() => {
-        open()
-      }, 500)
-    }
-    return (
-      <div>
-        <h1>Routes</h1>
-        <ul>
-          <li>
-            <Link to='/'>Home</Link>
-          </li>
-          <li>
-            <Link to='/team'>Team</Link>
-          </li>
-          <li>
-            <Link to='/team/brick'>Brick</Link>
-          </li>
-        </ul>
+stories.add('lifecycle events', () => {
+  const onBeforeOpen = (modalOpen) => {
+    console.log('Before open!')
+    setTimeout(() => {
+      modalOpen()
+    }, 500)
+  }
+  const onBeforeClose = (modalClose) => {
+    console.log('Before close!')
+    setTimeout(() => {
+      modalClose()
+    }, 500)
+  }
+  return (
+    <div>
+      <p>onBeforeOpen: 500 delay</p>
+      <p>onBeforeClose: 500 delay</p>
+      <Modal
+        className='weee'
+        onBeforeOpen={onBeforeOpen}
+        onBeforeClose={onBeforeClose}
+        trigger={<Link>Clicky</Link>}
+      >
+        <div>
+          <Heading>Title</Heading>
+          <p>
+            Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
+          </p>
+        </div>
+      </Modal>
+    </div>
+  )
+})
 
-        <Modal path='/team' onBeforeOpen={onBeforeOpen}>
-          <h1>Team Modal: A</h1>
-          <p>Modal content</p>
-        </Modal>
+stories.add('routes', () => {
+  const onBeforeOpen = (open) => {
+    setTimeout(() => {
+      open()
+    }, 500)
+  }
+  return (
+    <div>
+      <h1>Routes</h1>
+      <ul>
+        <li>
+          <Link to='/'>Home</Link>
+        </li>
+        <li>
+          <Link to='/team'>Team</Link>
+        </li>
+        <li>
+          <Link to='/team/brick'>Brick</Link>
+        </li>
+      </ul>
 
-        <Modal path='/team/brick'>
-          <h1>Team Modal: B</h1>
-          <p>Modal inner content</p>
-        </Modal>
+      <Modal path='/team' onBeforeOpen={onBeforeOpen}>
+        <h1>Team Modal: A</h1>
+        <p>Modal content</p>
+      </Modal>
 
-        <Modal path='/team/brick'>
-          <h1>Team Modal: C</h1>
-          <p>Modal inner content</p>
-        </Modal>
+      <Modal path='/team/brick'>
+        <h1>Team Modal: B</h1>
+        <p>Modal inner content</p>
+      </Modal>
 
-        <Modal path='/team/brick'>
-          <h1>Team Modal: D</h1>
-          <p>Modal inner content</p>
-        </Modal>
+      <Modal path='/team/brick'>
+        <h1>Team Modal: C</h1>
+        <p>Modal inner content</p>
+      </Modal>
 
-        <Modal path='/team/brick'>
-          <h1>Team Modal: E</h1>
-          <p>Modal inner content</p>
-        </Modal>
+      <Modal path='/team/brick'>
+        <h1>Team Modal: D</h1>
+        <p>Modal inner content</p>
+      </Modal>
 
-        <Route exact path='/' render={props => (
-          <div>
-            <h1>HOME PAGE</h1>
-          </div>
-        )} />
-        <Route path='/team' render={props => (
-          <div>
-            <h1>TEAM PAGE</h1>
-          </div>
-        )} />
-      </div>
-    )
-  })
+      <Modal path='/team/brick'>
+        <h1>Team Modal: E</h1>
+        <p>Modal inner content</p>
+      </Modal>
+
+      <Route exact path='/' render={props => (
+        <div>
+          <h1>HOME PAGE</h1>
+        </div>
+      )} />
+      <Route path='/team' render={props => (
+        <div>
+          <h1>TEAM PAGE</h1>
+        </div>
+      )} />
+    </div>
+  )
+})


### PR DESCRIPTION
## Modal: Add the ability to render cardless content

![screen recording 2017-12-04 at 04 10 pm](https://user-images.githubusercontent.com/2322354/33576466-eca76892-d90d-11e7-96e7-0d36a51a9c12.gif)

This update adds the ability to render the children content of
Modals without it's standard Card UI-based container. All that's
required is to pass the `seamless` prop, which is set to `false`
by default.

Resolves: https://github.com/helpscout/blue/issues/140