### PR TITLE
Avatar: Allow for StatusDot to render an Icon

### DIFF
--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -25,3 +25,4 @@ An Avatar component displays a user's avatar image, or their initials if an imag
 | size | `string` | Size of the avatar. |
 | title | `string` | Text for the image `alt` and `title` attributes. |
 | status | `string` | Renders a [StatusDot](../StatusDot) with the status type. |
+| statusIcon | `string` | Name of the [Icon](../Icon) to render into the [StatusDot](../StatusDot). |

--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -18,6 +18,7 @@ export const propTypes = {
   name: PropTypes.string.isRequired,
   shape: shapeTypes,
   size: standardSizeTypes,
+  statusIcon: PropTypes.string,
   status: statusTypes
 }
 
@@ -39,6 +40,7 @@ const Avatar = props => {
     size,
     shape,
     status,
+    statusIcon,
     ...rest
   } = props
 
@@ -77,7 +79,7 @@ const Avatar = props => {
 
   const statusMarkup = status ? (
     <div className='c-Avatar__status'>
-      <StatusDot status={status} />
+      <StatusDot status={status} icon={statusIcon} />
     </div>
   ) : null
 

--- a/src/components/Avatar/tests/Avatar.test.js
+++ b/src/components/Avatar/tests/Avatar.test.js
@@ -152,4 +152,11 @@ describe('StatusDot', () => {
     expect(statusMarkup.length).toBe(1)
     expect(o.length).toBe(1)
   })
+
+  test('Renders an icon in StatusDot, if defined', () => {
+    const wrapper = shallow(<Avatar status='online' statusIcon='tick' />)
+    const o = wrapper.find(StatusDot)
+
+    expect(o.props().icon).toBe('tick')
+  })
 })

--- a/stories/Avatar/index.js
+++ b/stories/Avatar/index.js
@@ -78,6 +78,28 @@ stories.add('status', () => (
   </div>
 ))
 
+stories.add('status:icon', () => (
+  <div>
+    <Avatar
+      name={fixture.name}
+      image={fixture.image}
+      status='online'
+      statusIcon='tick'
+      shape='square'
+      size='lg'
+    />
+    <br />
+    <Avatar
+      name={fixture.name}
+      image={fixture.image}
+      status='offline'
+      statusIcon='cross'
+      shape='square'
+      size='lg'
+    />
+  </div>
+))
+
 stories.add('initials', () => (
   <Avatar name={fixture.name} />
 ))


### PR DESCRIPTION
## Avatar: Allow for StatusDot to render an Icon

![screen shot 2017-12-04 at 4 26 30 pm](https://user-images.githubusercontent.com/2322354/33577242-66d048da-d910-11e7-9367-39025f1f4079.jpg)

This update provides Avatar with a new `statusIcon` prop, which renders
a specified Icon within the Avatar's StatusDot component.

Resolves: https://github.com/helpscout/blue/issues/136