### PR TITLE
Animate: Add additional examples

### DIFF
--- a/src/components/Animate/animations/expand.js
+++ b/src/components/Animate/animations/expand.js
@@ -1,0 +1,18 @@
+export default {
+  onMount: {
+    height: 0,
+    overflow: 'hidden'
+  },
+  onEntering: (node) => {
+    const el = node.childNodes[0]
+    return {
+      height: [0, el.offsetHeight]
+    }
+  },
+  onExit: (node) => {
+    const el = node.childNodes[0]
+    return {
+      height: [el.offsetHeight, 0]
+    }
+  }
+}

--- a/src/components/Animate/animations/flip.js
+++ b/src/components/Animate/animations/flip.js
@@ -1,0 +1,11 @@
+export default {
+  onMount: {
+    perspective: 400,
+  },
+  onEntering: {
+    rotateX: [80, 0]
+  },
+  onExiting: {
+    transform: 'perspective(400px)'
+  }
+}

--- a/src/components/Animate/animations/flip.js
+++ b/src/components/Animate/animations/flip.js
@@ -1,6 +1,6 @@
 export default {
   onMount: {
-    perspective: 400,
+    perspective: 400
   },
   onEntering: {
     rotateX: [80, 0]

--- a/src/components/Animate/animations/index.js
+++ b/src/components/Animate/animations/index.js
@@ -1,6 +1,8 @@
 import down from './down'
 import downSmall from './downSmall'
+import expand from './expand'
 import fade from './fade'
+import flip from './flip'
 import left from './left'
 import right from './right'
 import scale from './scale'
@@ -10,7 +12,9 @@ import up from './up'
 export default {
   down,
   downSmall,
+  expand,
   fade,
+  flip,
   left,
   right,
   scale,

--- a/src/components/Animate/animations/right.js
+++ b/src/components/Animate/animations/right.js
@@ -1,10 +1,10 @@
-const amount = -24
+const amount = 24
 
 export default {
   onEntering: {
-    translateX: [0, amount]
+    translateX: [amount, 0]
   },
   onExiting: {
-    translateX: [amount, 0]
+    translateX: [0, amount]
   }
 }

--- a/stories/AnimateGroup/index.js
+++ b/stories/AnimateGroup/index.js
@@ -4,25 +4,6 @@ import { Animate, AnimateGroup, Card } from '../../src/index.js'
 
 const stories = storiesOf('AnimateGroup', module)
 
-const customHeightSequence = {
-  onMount: {
-    height: 0,
-    overflow: 'hidden'
-  },
-  onEntering: (node) => {
-    const el = node.childNodes[0]
-    return {
-      height: [0, el.offsetHeight * 2, el.offsetHeight]
-    }
-  },
-  onExit: (node) => {
-    const el = node.childNodes[0]
-    return {
-      height: [el.offsetHeight, 0]
-    }
-  }
-}
-
 stories.add('default', () => (
   <div>
     <p>Stagger fade in</p>
@@ -46,7 +27,7 @@ stories.add('default', () => (
 stories.add('expand', () => (
   <div>
     <p>Stagger fade in</p>
-    <div style={{ margin: 'auto', width: '80%'}}>
+    <div style={{margin: 'auto', width: '80%'}}>
       <Card>
         <div>Card</div>
       </Card>

--- a/stories/AnimateGroup/index.js
+++ b/stories/AnimateGroup/index.js
@@ -1,8 +1,27 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Animate, AnimateGroup } from '../../src/index.js'
+import { Animate, AnimateGroup, Card } from '../../src/index.js'
 
 const stories = storiesOf('AnimateGroup', module)
+
+const customHeightSequence = {
+  onMount: {
+    height: 0,
+    overflow: 'hidden'
+  },
+  onEntering: (node) => {
+    const el = node.childNodes[0]
+    return {
+      height: [0, el.offsetHeight * 2, el.offsetHeight]
+    }
+  },
+  onExit: (node) => {
+    const el = node.childNodes[0]
+    return {
+      height: [el.offsetHeight, 0]
+    }
+  }
+}
 
 stories.add('default', () => (
   <div>
@@ -21,5 +40,41 @@ stories.add('default', () => (
         <div>Fade in + left</div>
       </Animate>
     </AnimateGroup>
+  </div>
+))
+
+stories.add('expand', () => (
+  <div>
+    <p>Stagger fade in</p>
+    <div style={{ margin: 'auto', width: '80%'}}>
+      <Card>
+        <div>Card</div>
+      </Card>
+      <AnimateGroup stagger staggerDelay={700}>
+        <Animate sequence='expand' duration={700}>
+          <Card>
+            <div>Expand</div>
+          </Card>
+        </Animate>
+        <Animate sequence='expand fade scale' duration={700}>
+          <Card>
+            <div>Expand, Fade, Scale</div>
+          </Card>
+        </Animate>
+        <Animate sequence='expand fade left' duration={700}>
+          <Card>
+            <div>Expand, Fade, Left</div>
+          </Card>
+        </Animate>
+        <Animate sequence='expand fade right' duration={700}>
+          <Card>
+            <div>Expand, Fade, Right</div>
+          </Card>
+        </Animate>
+      </AnimateGroup>
+      <Card>
+        <div>Card</div>
+      </Card>
+    </div>
   </div>
 ))


### PR DESCRIPTION
## Animate: Add additional examples

![screen recording 2017-12-05 at 12 50 pm](https://user-images.githubusercontent.com/2322354/33622411-c045c8e4-d9bb-11e7-8bcd-910860028344.gif)

This adds additional Storybook examples for Animate. It also fixes
the `right` animation sequence, and adds an `expand` sequence.