### PR TITLE
PortalWrapper: Add wrapperClassName

### DIFF
--- a/src/components/Drop/README.md
+++ b/src/components/Drop/README.md
@@ -46,6 +46,7 @@ export default Drop(dropOptions)(MyPopover)
 | Prop | Type | Description |
 | --- | --- | --- |
 | direction | `string` | Determines the preferred "drop" direction. Accepts `left`, `right`, `up`, `down`, or a combination of horizontal/vertical directions. |
+| wrapperClassName | `string` | Custom className to add to the [PortalWrapper](../PortalWrapper) component. |
 
 Drop is composed using [PortalWrapper](../PortalWrapper). Check out [PortalWrapper](../PortalWrapper) for additional HOC option and prop details.
 

--- a/src/components/Drop/index.js
+++ b/src/components/Drop/index.js
@@ -7,11 +7,13 @@ import { propTypes as portalTypes } from '../Portal'
 
 export const propTypes = Object.assign({}, portalTypes, {
   trigger: PropTypes.oneOfType([PropTypes.element, PropTypes.object]),
-  direction: PropTypes.string
+  direction: PropTypes.string,
+  wrapperClassName: PropTypes.string
 })
 
 const defaultProps = {
-  direction: 'down'
+  direction: 'down',
+  wrapperClassName: 'c-DropWrapper'
 }
 
 const popoverWrapperBaseZIndex = 1020
@@ -46,6 +48,7 @@ export const DropComponent = (/* istanbul ignore next */ options = defaultOption
         style,
         timeout,
         trigger,
+        wrapperClassName,
         zIndex: propsZindex,
         ...rest
       } = this.props

--- a/src/components/Drop/tests/Drop.test.js
+++ b/src/components/Drop/tests/Drop.test.js
@@ -31,94 +31,96 @@ afterEach(() => {
   document.body.innerHTML = ''
 })
 
-test('Can create a component as a HOC', (done) => {
-  const TestComponent = Drop()(ContentComponent)
-  const wrapper = mount(<TestComponent isOpen />)
+describe('Composed', () => {
+  test('Can create a component as a HOC', (done) => {
+    const TestComponent = Drop()(ContentComponent)
+    const wrapper = mount(<TestComponent isOpen />)
 
-  wait()
-    .then(() => {
-      const o = document.querySelector('.content')
+    wait()
+      .then(() => {
+        const o = document.querySelector('.content')
 
-      expect(o).toBeTruthy()
-      expect(o.innerHTML).toContain('Content')
-      wrapper.unmount()
-      done()
-    })
-})
+        expect(o).toBeTruthy()
+        expect(o.innerHTML).toContain('Content')
+        wrapper.unmount()
+        done()
+      })
+  })
 
-test('Can pass className to composed component', (done) => {
-  const TestComponent = Drop()(ContentComponent)
-  const wrapper = mount(<TestComponent className='ron' isOpen />)
+  test('Can pass className to composed component', (done) => {
+    const TestComponent = Drop()(ContentComponent)
+    const wrapper = mount(<TestComponent className='ron' isOpen />)
 
-  wait()
-    .then(() => {
-      const o = document.querySelector('.content')
+    wait()
+      .then(() => {
+        const o = document.querySelector('.content')
 
-      expect(o.classList.contains('ron')).toBeTruthy()
-      wrapper.unmount()
-      done()
-    })
-})
+        expect(o.classList.contains('ron')).toBeTruthy()
+        wrapper.unmount()
+        done()
+      })
+  })
 
-test('Should not steal composed component custom className', (done) => {
-  const TestComponent = Drop()(ContentComponent)
-  const wrapper = mount(<TestComponent className='ron' isOpen />)
+  test('Should not steal composed component custom className', (done) => {
+    const TestComponent = Drop()(ContentComponent)
+    const wrapper = mount(<TestComponent className='ron' isOpen />)
 
-  wait()
-    .then(() => {
-      const o = document.querySelector('.c-Drop')
-      const content = document.querySelector('.content')
+    wait()
+      .then(() => {
+        const o = document.querySelector('.c-Drop')
+        const content = document.querySelector('.content')
 
-      expect(o.classList.contains('ron')).not.toBeTruthy()
-      expect(content.classList.contains('ron')).toBeTruthy()
-      wrapper.unmount()
-      done()
-    })
-})
+        expect(o.classList.contains('ron')).not.toBeTruthy()
+        expect(content.classList.contains('ron')).toBeTruthy()
+        wrapper.unmount()
+        done()
+      })
+  })
 
-test('Can styles to composed component', (done) => {
-  const TestComponent = Drop()(ContentComponent)
-  const wrapper = mount(<TestComponent style={{background: 'red'}} isOpen />)
+  test('Can styles to composed component', (done) => {
+    const TestComponent = Drop()(ContentComponent)
+    const wrapper = mount(<TestComponent style={{background: 'red'}} isOpen />)
 
-  wait()
-    .then(() => {
-      const o = document.querySelector('.content')
+    wait()
+      .then(() => {
+        const o = document.querySelector('.content')
 
-      expect(o.style.background).toBe('red')
-      wrapper.unmount()
-      done()
-    })
-})
+        expect(o.style.background).toBe('red')
+        wrapper.unmount()
+        done()
+      })
+  })
 
-test('Adds default ID', (done) => {
-  const TestComponent = Drop()(ContentComponent)
-  const wrapper = mount(<TestComponent isOpen />)
+  test('Adds default ID', (done) => {
+    const TestComponent = Drop()(ContentComponent)
+    const wrapper = mount(<TestComponent isOpen />)
 
-  wait()
-    .then(() => {
-      const o = document.body.childNodes[0]
+    wait()
+      .then(() => {
+        const o = document.body.childNodes[0]
 
-      expect(o.id).toContain('Drop')
-      wrapper.unmount()
-      done()
-    })
-})
+        expect(o.id).toContain('Drop')
+        wrapper.unmount()
+        done()
+      })
+  })
 
-test('Override default ID with options', (done) => {
-  const options = {
-    id: 'Brick'
-  }
-  const TestComponent = Drop(options)(ContentComponent)
-  const wrapper = mount(<TestComponent isOpen />)
+  test('Override default ID with options', (done) => {
+    const options = {
+      id: 'Brick'
+    }
+    const TestComponent = Drop(options)(ContentComponent)
+    const wrapper = mount(<TestComponent isOpen />)
 
-  wait()
-    .then(() => {
-      const o = document.body.childNodes[0]
+    wait()
+      .then(() => {
+        const o = document.body.childNodes[0]
 
-      expect(o.id).toContain('Brick')
-      wrapper.unmount()
-      done()
-    })
+        expect(o.id).toContain('Brick')
+        wrapper.unmount()
+        done()
+      })
+  })
 })
 
 describe('Trigger', () => {
@@ -139,5 +141,30 @@ describe('Trigger', () => {
     const el = wrapper.find('.trigger')
 
     expect(el.prop('onClick')).toBeInstanceOf(Function)
+  })
+})
+
+describe('wrapperClassName', () => {
+  const TestComponent = Drop()(ContentComponent)
+
+  test('Adds default wrapperClassName', (done) => {
+    mount(<TestComponent isOpen />)
+
+    wait(40).then(() => {
+      const o = document.body.childNodes[0]
+      expect(o.className).toContain('c-DropWrapper')
+      done()
+    })
+  })
+
+  test('Can customize wrapperClassName', (done) => {
+    mount(<TestComponent isOpen wrapperClassName='ron' />)
+
+    wait(40).then(() => {
+      const o = document.body.childNodes[0]
+      expect(o.className).toContain('ron')
+      expect(o.className).toContain('c-DropWrapper')
+      done()
+    })
   })
 })

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -36,6 +36,7 @@ A Modal component presents content within a container on top of the application'
 | scrollableRef | `function` | Retrieves the scrollable node. |
 | seamless | `bool` | Renders content with the standard [Card](../Card) UI. |
 | trigger | `element` | The UI the user clicks to trigger the modal. |
+| wrapperClassName | `string` | Custom className to add to the [PortalWrapper](../PortalWrapper) component. |
 
 
 ### Render hooks

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -27,7 +27,8 @@ export const propTypes = Object.assign({}, portalTypes, {
     PropTypes.object
   ]),
   onScroll: PropTypes.func,
-  trigger: PropTypes.element
+  trigger: PropTypes.element,
+  wrapperClassName: PropTypes.string
 })
 
 const defaultProps = {
@@ -44,7 +45,8 @@ const defaultProps = {
     out: 200
   },
   onScroll: noop,
-  scrollableRef: noop
+  scrollableRef: noop,
+  wrapperClassName: 'c-ModalWrapper'
 }
 
 const modalBaseZIndex = 1040
@@ -107,6 +109,7 @@ class Modal extends Component {
       style,
       timeout,
       trigger,
+      wrapperClassName,
       zIndex,
       ...rest
     } = this.props

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -362,3 +362,26 @@ describe('Seamless', () => {
     expect(o.length).toBe(1)
   })
 })
+
+describe('wrapperClassName', () => {
+  test('Adds default wrapperClassName', (done) => {
+    mount(<Modal isOpen trigger={trigger} />)
+
+    wait(40).then(() => {
+      const o = document.body.childNodes[0]
+      expect(o.className).toContain('c-ModalWrapper')
+      done()
+    })
+  })
+
+  test('Can customize wrapperClassName', (done) => {
+    mount(<Modal isOpen trigger={trigger} wrapperClassName='ron' />)
+
+    wait(40).then(() => {
+      const o = document.body.childNodes[0]
+      expect(o.className).toContain('ron')
+      expect(o.className).toContain('c-ModalWrapper')
+      done()
+    })
+  })
+})

--- a/src/components/PortalWrapper/index.js
+++ b/src/components/PortalWrapper/index.js
@@ -9,7 +9,9 @@ import {
   createUniqueIDFactory,
   createUniqueIndexFactory
 } from '../../utilities/id'
+import { getComponentDefaultProp } from '../../utilities/component'
 import { setupManager } from '../../utilities/globalManager'
+import classNames from '../../utilities/classNames'
 import Content from './Content'
 
 const defaultOptions = {
@@ -33,9 +35,14 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
   class PortalWrapper extends Component {
     constructor (props) {
       super()
+      const composedWrapperClassName = getComponentDefaultProp(ComposedComponent, 'wrapperClassName')
       this.state = Object.assign({}, props, extendedOptions, {
         id: uniqueID(),
-        isMounted: props.isOpen
+        isMounted: props.isOpen,
+        wrapperClassName: classNames(
+          props.wrapperClassName,
+          composedWrapperClassName
+        )
       })
       this.closePortal = this.closePortal.bind(this)
       this.openPortal = this.openPortal.bind(this)
@@ -116,10 +123,15 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
         renderTo,
         trigger,
         timeout,
+        wrapperClassName: propsWrapperClassName,
         ...rest
       } = this.props
       // Remapping open/mount state for ComposedComponent
-      const { id, isOpen: portalIsMounted, isMounted: portalIsOpen } = this.state
+      const {
+        id, isOpen: portalIsMounted,
+        isMounted: portalIsOpen,
+        wrapperClassName
+      } = this.state
 
       const openPortal = this.openPortal
       const handleOnClose = this.handleOnClose
@@ -135,6 +147,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
           wait={this.state.timeout}
         >
           <Portal
+            className={wrapperClassName}
             onBeforeClose={handleOnClose}
             onClose={onClose}
             onBeforeOpen={onBeforeOpen}

--- a/src/components/PortalWrapper/tests/PortalWrapper.test.js
+++ b/src/components/PortalWrapper/tests/PortalWrapper.test.js
@@ -124,3 +124,27 @@ describe('Manager', () => {
     expect(o.node.state.isOpen).toBe(true)
   })
 })
+
+describe('wrapperClassName', () => {
+  test('Does not add a wrapperClassName to portal', (done) => {
+    const TestComponent = PortalWrapper(options)(TestButton)
+    mount(<TestComponent isOpen />)
+
+    wait().then(() => {
+      const c = document.body.childNodes[0]
+      expect(c.className).toBeFalsy()
+      done()
+    })
+  })
+
+  test('Can customize wrapperClassName', (done) => {
+    const TestComponent = PortalWrapper(options)(TestButton)
+    mount(<TestComponent isOpen wrapperClassName='blue' />)
+
+    wait().then(() => {
+      const c = document.body.childNodes[0]
+      expect(c.className).toContain('blue')
+      done()
+    })
+  })
+})

--- a/src/utilities/component.js
+++ b/src/utilities/component.js
@@ -1,0 +1,11 @@
+export const getComponentDefaultProp = (component, prop, fallback = undefined) => {
+  if (
+    typeof component !== 'object' &&
+    typeof component !== 'function'
+  ) return fallback
+  if (typeof prop !== 'string') return fallback
+
+  return component.defaultProps && component.defaultProps[prop] !== undefined
+    ? component.defaultProps[prop]
+    : fallback
+}

--- a/src/utilities/tests/component/getComponentDefaultProp.test.js
+++ b/src/utilities/tests/component/getComponentDefaultProp.test.js
@@ -1,0 +1,36 @@
+import { getComponentDefaultProp } from '../../component'
+
+test('Returns fallback (undefined) if invalid arguments', () => {
+  expect(getComponentDefaultProp()).toBe(undefined)
+  expect(getComponentDefaultProp(true)).toBe(undefined)
+  expect(getComponentDefaultProp(false)).toBe(undefined)
+  expect(getComponentDefaultProp('component')).toBe(undefined)
+  expect(getComponentDefaultProp(['component'])).toBe(undefined)
+  expect(getComponentDefaultProp({a: 1})).toBe(undefined)
+})
+
+test('Returns fallback (undefined) if defaultProp does not exist', () => {
+  expect(getComponentDefaultProp({a: 1}, 'a')).toBe(undefined)
+  expect(getComponentDefaultProp({props: 1}, 'a')).toBe(undefined)
+})
+
+test('Returns defaultProp if exists', () => {
+  const o = {
+    defaultProps: {
+      a: 1
+    }
+  }
+  expect(getComponentDefaultProp(o, 'a')).toBe(1)
+})
+
+test('Can customize fallback', () => {
+  const o = {
+    defaultProps: {
+      a: 1
+    }
+  }
+  const fallback = 'fallback'
+
+  expect(getComponentDefaultProp(o, 'nope', fallback)).toBe(fallback)
+  expect(getComponentDefaultProp(true, 'nope', fallback)).toBe(fallback)
+})

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,5 +1,5 @@
 import '../src/styles/blue.scss'
-import '../src/styles/blue.hs-app.scss'
+// import '../src/styles/blue.hs-app.scss'
 
 import './Alert'
 import './AnimateGroup'


### PR DESCRIPTION
## PortalWrapper: Add wrapperClassName

This update adds a new `wrapperClassName` prop for the composed
components generated by PortalWrapper. This allows you to add
custom class names to the surrounding Portal'ed `div`, providing
extra CSS flexibility (if needed).

This is an enhancement, and no component API changes are required
on the user's end.

Tests + documentation has been added for this update :rocket: