### PR TITLE
Modal: Add Header/Body/Footer sub-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11049,7 +11049,7 @@
           "dependencies": {
             "babylon": {
               "version": "5.8.38",
-              "resolved": "http://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
               "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
               "dev": true
             },
@@ -17308,7 +17308,7 @@
       "dependencies": {
         "babylon": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
           "dev": true
         }
@@ -21602,7 +21602,7 @@
       "dependencies": {
         "fs-extra": {
           "version": "0.30.0",
-          "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {

--- a/src/components/Modal/Body.js
+++ b/src/components/Modal/Body.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import classNames from '../../utilities/classNames'
+
+const Body = props => {
+  const {
+    className,
+    children,
+    ...rest
+  } = props
+
+  const componentClassName = classNames(
+    'c-ModalBody',
+    className
+  )
+
+  return (
+    <div className={componentClassName} {...rest}>
+      {children}
+    </div>
+  )
+}
+
+Body.displayName = 'ModalBody'
+
+export default Body

--- a/src/components/Modal/Footer.js
+++ b/src/components/Modal/Footer.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Toolbar from '../Toolbar'
+import { sizeTypes as toolbarSizeTypes } from '../Toolbar/propTypes'
+import classNames from '../../utilities/classNames'
+
+export const propTypes = {
+  seamless: PropTypes.bool,
+  shadow: PropTypes.bool,
+  size: toolbarSizeTypes
+}
+
+const defaultProps = {
+  seamless: false,
+  shadow: false,
+  size: 'lg'
+}
+
+const Footer = props => {
+  const {
+    className,
+    children,
+    placement,
+    ...rest
+  } = props
+
+  const componentClassName = classNames(
+    'c-ModalFooter',
+    className
+  )
+
+  return (
+    <Toolbar
+      className={componentClassName}
+      placement='bottom'
+      {...rest}
+    >
+      {children}
+    </Toolbar>
+  )
+}
+
+Footer.propTypes = propTypes
+Footer.defaultProps = defaultProps
+Footer.displayName = 'ModalFooter'
+
+export default Footer

--- a/src/components/Modal/Header.js
+++ b/src/components/Modal/Header.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Toolbar from '../Toolbar'
+import { sizeTypes as toolbarSizeTypes } from '../Toolbar/propTypes'
+import classNames from '../../utilities/classNames'
+
+export const propTypes = {
+  seamless: PropTypes.bool,
+  shadow: PropTypes.bool,
+  size: toolbarSizeTypes
+}
+
+const defaultProps = {
+  seamless: false,
+  shadow: false,
+  size: 'lg'
+}
+
+const Header = props => {
+  const {
+    className,
+    children,
+    placement,
+    ...rest
+  } = props
+
+  const componentClassName = classNames(
+    'c-ModalHeader',
+    className
+  )
+
+  return (
+    <Toolbar
+      className={componentClassName}
+      placement='top'
+      {...rest}
+    >
+      {children}
+    </Toolbar>
+  )
+}
+
+Header.propTypes = propTypes
+Header.defaultProps = defaultProps
+Header.displayName = 'ModalHeader'
+
+export default Header

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -3,51 +3,11 @@
 A Modal component presents content within a container on top of the application's main UI. Modals can have multiple instances, in which case they will overlay on top of each other. This component supports [`react-router`](https://github.com/ReactTraining/react-router).
 
 
-## Example
+## Components
 
-```jsx
-<Modal trigger={<a>Click</a>}>
-  Content
-</Modal>
-```
+The Modal component is comprised of smaller components:
 
-
-### React Router Modal
-
-```jsx
-<Modal path='/news-team/channel4' trigger={<a>Click</a>}>
-  Content
-</Modal>
-```
-
-
-
-## Props
-
-| Prop | Type | Description |
-| --- | --- | --- |
-| className | `string` | Custom class names to be added to the component. |
-| closeIcon | `bool` | Shows/hides the component's close icon UI. |
-| exact | `bool` | Used with `path` and React Router. Renders if path matches _exactly_ |
-| isOpen | `bool` | Shows/hides the component. |
-| onScroll | `function` | Callback function when inner Scrollable is scrolled. |
-| path | `string` | Renders component based on a [React Router path](https://reacttraining.com/react-router/web/api/Route/path-string). |
-| scrollFade | `bool` | Enables the upper fade-to-white styles. Default `true`. |
-| scrollableRef | `function` | Retrieves the scrollable node. |
-| seamless | `bool` | Renders content with the standard [Card](../Card) UI. |
-| trigger | `element` | The UI the user clicks to trigger the modal. |
-| wrapperClassName | `string` | Custom className to add to the [PortalWrapper](../PortalWrapper) component. |
-
-
-### Render hooks
-
-This component has special callback props tied into it's mounting cycle.
-
-| Prop | Type | Description |
-| --- | --- | --- |
-| onBeforeOpen | `function` | Fires when the component is mounted, but not rendered. |
-| onOpen | `function` | Fires as soon as the component has rendered. |
-| onBeforeClose | `function` | Fires when the component is about to unmount. |
-| onClose | `function` | Fires after the component is unmounted. |
-
-See [Portal's documentation](../Portal#render-hooks) for more details.
+* [Modal](./docs/Modal.md)
+* [Header](./docs/Header.md)
+* [Body](./docs/Body.md)
+* [Footer](./docs/Footer.md)

--- a/src/components/Modal/docs/Body.md
+++ b/src/components/Modal/docs/Body.md
@@ -1,0 +1,21 @@
+# Body
+
+A Modal.Body component contains content that appears within a [Modal](./Modal.md). 
+
+
+## Example
+
+```jsx
+<Modal>
+  <Modal.Body>
+    ...
+  </Modal.Body>
+</Modal>
+```
+
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| className | `string` | Custom class names to be added to the component. |

--- a/src/components/Modal/docs/Footer.md
+++ b/src/components/Modal/docs/Footer.md
@@ -1,0 +1,26 @@
+# Footer
+
+A Modal.Footer component contains content that appears at the top of a [Modal](./Modal.md). This component is constructed using [Toolbar](../Toolbar).
+
+
+## Example
+
+```jsx
+<Modal>
+  <Modal.Body>
+    ...
+  </Modal.Body>
+  <Modal.Footer>
+    ...
+  </Modal.Footer>
+</Modal>
+```
+
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| className | `string` | Custom class names to be added to the component. |
+
+For more props, check out [Toolbar](../Toolbar).

--- a/src/components/Modal/docs/Header.md
+++ b/src/components/Modal/docs/Header.md
@@ -1,0 +1,43 @@
+# Header
+
+A Modal.Header component contains content that appears at the top of a [Modal](./Modal.md). This component is constructed using [Toolbar](../Toolbar).
+
+
+## Example
+
+```jsx
+<Modal>
+  <Modal.Header>
+    ...
+  </Modal.Header>
+  <Modal.Body>
+    ...
+  </Modal.Body>
+</Modal>
+```
+
+
+### Right-hand actions
+
+By default, a [CloseButton](../CloseButton) appears at the top right-hand side of a Modal. However, if you wish to render content on the right-hand side of your Modal.Header, it is recommended that you disable the CloseButton by passing in `closeIcon={false}`.
+
+```jsx
+<Modal closeIcon={false}>
+  <Modal.Header>
+    <Toolbar.Item>...</Toolbar.Item>
+    <Toolbar.Item>...</Toolbar.Item>
+  </Modal.Header>
+  <Modal.Body>
+    ...
+  </Modal.Body>
+</Modal>
+```
+
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| className | `string` | Custom class names to be added to the component. |
+
+For more props, check out [Toolbar](../Toolbar).

--- a/src/components/Modal/docs/Modal.md
+++ b/src/components/Modal/docs/Modal.md
@@ -1,0 +1,58 @@
+# Modal
+
+A Modal component presents content within a container on top of the application's main UI. Modals can have multiple instances, in which case they will overlay on top of each other. This component supports [`react-router`](https://github.com/ReactTraining/react-router).
+
+
+## Example
+
+```jsx
+<Modal trigger={<a>Click</a>}>
+  <Modal.Body>
+    Content
+  </Modal.Body>
+</Modal>
+```
+
+
+### React Router Modal
+
+```jsx
+<Modal path='/news-team/channel4' trigger={<a>Click</a>}>
+  <Modal.Body>
+    Content
+  </Modal.Body>
+</Modal>
+```
+
+
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| className | `string` | Custom class names to be added to the component. |
+| closeIcon | `bool` | Shows/hides the component's close icon UI. |
+| exact | `bool` | Used with `path` and React Router. Renders if path matches _exactly_ |
+| isOpen | `bool` | Shows/hides the component. |
+| onScroll | `function` | Callback function when inner Scrollable is scrolled. |
+| path | `string` | Renders component based on a [React Router path](https://reacttraining.com/react-router/web/api/Route/path-string). |
+| scrollFade | `bool` | Enables the upper fade-to-white styles. Default `true`. |
+| scrollableRef | `function` | Retrieves the scrollable node. |
+| seamless | `bool` | Renders content with the standard [Card](../Card) UI. |
+| trigger | `element` | The UI the user clicks to trigger the modal. |
+| wrapperClassName | `string` | Custom className to add to the [PortalWrapper](../PortalWrapper) component. |
+
+
+### Render hooks
+
+This component has special callback props tied into it's mounting cycle.
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| onBeforeOpen | `function` | Fires when the component is mounted, but not rendered. |
+| onOpen | `function` | Fires as soon as the component has rendered. |
+| onBeforeClose | `function` | Fires when the component is about to unmount. |
+| onClose | `function` | Fires after the component is unmounted. |
+
+See [Portal's documentation](../Portal#render-hooks) for more details.
+

--- a/src/components/Modal/tests/Body.test.js
+++ b/src/components/Modal/tests/Body.test.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Body from '../Body'
+
+describe('ClassName', () => {
+  test('Has default className', () => {
+    const wrapper = shallow(<Body />)
+
+    expect(wrapper.hasClass('c-ModalBody')).toBeTruthy()
+  })
+
+  test('Applies custom className if specified', () => {
+    const customClass = 'piano-key-neck-tie'
+    const wrapper = shallow(<Body className={customClass} />)
+
+    expect(wrapper.prop('className')).toContain(customClass)
+  })
+})
+
+describe('Children', () => {
+  test('Renders child content', () => {
+    const wrapper = shallow(<Body><div className='child'>Hello</div></Body>)
+    const el = wrapper.find('div.child')
+
+    expect(el.text()).toContain('Hello')
+  })
+})

--- a/src/components/Modal/tests/Footer.test.js
+++ b/src/components/Modal/tests/Footer.test.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Footer from '../Footer'
+import { Toolbar } from '../../index'
+
+describe('ClassName', () => {
+  test('Has default className', () => {
+    const wrapper = shallow(<Footer />)
+
+    expect(wrapper.hasClass('c-ModalFooter')).toBeTruthy()
+  })
+
+  test('Applies custom className if specified', () => {
+    const customClass = 'piano-key-neck-tie'
+    const wrapper = shallow(<Footer className={customClass} />)
+
+    expect(wrapper.prop('className')).toContain(customClass)
+  })
+})
+
+describe('Children', () => {
+  test('Renders child content', () => {
+    const wrapper = shallow(<Footer><div className='child'>Hello</div></Footer>)
+    const el = wrapper.find('div.child')
+
+    expect(el.text()).toContain('Hello')
+  })
+})
+
+describe('Toolbar', () => {
+  test('Is composed of Toolbar', () => {
+    const wrapper = shallow(<Footer />)
+    const o = wrapper.find(Toolbar)
+
+    expect(o.hasClass('c-ModalFooter')).toBe(true)
+  })
+
+  test('Has correct Toolbar placement', () => {
+    const wrapper = shallow(<Footer />)
+    const o = wrapper.find(Toolbar)
+
+    expect(o.prop('placement')).toBe('bottom')
+  })
+
+  test('Can pass props to Toolbar', () => {
+    const wrapper = shallow(<Footer shadow seamless />)
+    const o = wrapper.find(Toolbar)
+
+    expect(o.prop('seamless')).toBe(true)
+    expect(o.prop('shadow')).toBe(true)
+  })
+})

--- a/src/components/Modal/tests/Header.test.js
+++ b/src/components/Modal/tests/Header.test.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Header from '../Header'
+import { Toolbar } from '../../index'
+
+describe('ClassName', () => {
+  test('Has default className', () => {
+    const wrapper = shallow(<Header />)
+
+    expect(wrapper.hasClass('c-ModalHeader')).toBeTruthy()
+  })
+
+  test('Applies custom className if specified', () => {
+    const customClass = 'piano-key-neck-tie'
+    const wrapper = shallow(<Header className={customClass} />)
+
+    expect(wrapper.prop('className')).toContain(customClass)
+  })
+})
+
+describe('Children', () => {
+  test('Renders child content', () => {
+    const wrapper = shallow(<Header><div className='child'>Hello</div></Header>)
+    const el = wrapper.find('div.child')
+
+    expect(el.text()).toContain('Hello')
+  })
+})
+
+describe('Toolbar', () => {
+  test('Is composed of Toolbar', () => {
+    const wrapper = shallow(<Header />)
+    const o = wrapper.find(Toolbar)
+
+    expect(o.hasClass('c-ModalHeader')).toBe(true)
+  })
+
+  test('Has correct Toolbar placement', () => {
+    const wrapper = shallow(<Header />)
+    const o = wrapper.find(Toolbar)
+
+    expect(o.prop('placement')).toBe('top')
+  })
+
+  test('Can pass props to Toolbar', () => {
+    const wrapper = shallow(<Header shadow seamless />)
+    const o = wrapper.find(Toolbar)
+
+    expect(o.prop('seamless')).toBe(true)
+    expect(o.prop('shadow')).toBe(true)
+  })
+})

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -385,3 +385,131 @@ describe('wrapperClassName', () => {
     })
   })
 })
+
+describe('Header', () => {
+  test('Does not render a Modal.Header by default', () => {
+    const wrapper = shallow(
+      <ModalComponent>
+        <Modal.Body>
+          <div className='ron'>Burgandy</div>
+        </Modal.Body>
+      </ModalComponent>
+    )
+    const o = wrapper.find(Modal.Header)
+
+    expect(o.length).toBe(0)
+  })
+
+  test('Renders the Modal.Header within a Card', () => {
+    const wrapper = shallow(
+      <ModalComponent>
+        <Modal.Header />
+        <div className='ron'>Burgandy</div>
+      </ModalComponent>
+    )
+    const o = wrapper.find(Card).find(Modal.Header)
+    const bodyHeader = wrapper.find(Modal.Body).find(Modal.Header)
+
+    expect(o.length).toBe(1)
+    expect(bodyHeader.length).toBe(0)
+  })
+})
+
+describe('Footer', () => {
+  test('Does not render a Modal.Footer by default', () => {
+    const wrapper = shallow(
+      <ModalComponent>
+        <Modal.Body>
+          <div className='ron'>Burgandy</div>
+        </Modal.Body>
+      </ModalComponent>
+    )
+    const o = wrapper.find(Modal.Footer)
+
+    expect(o.length).toBe(0)
+  })
+
+  test('Renders the Modal.Footer within a Card', () => {
+    const wrapper = shallow(
+      <ModalComponent>
+        <Modal.Footer />
+        <div className='ron'>Burgandy</div>
+      </ModalComponent>
+    )
+    const o = wrapper.find(Card).find(Modal.Footer)
+    const bodyFooter = wrapper.find(Modal.Body).find(Modal.Footer)
+
+    expect(o.length).toBe(1)
+    expect(bodyFooter.length).toBe(0)
+  })
+})
+
+describe('Body', () => {
+  test('Can render a Modal.Body', () => {
+    const wrapper = shallow(
+      <ModalComponent>
+        <Modal.Body>
+          <div className='ron'>Burgandy</div>
+        </Modal.Body>
+      </ModalComponent>
+    )
+    const body = wrapper.find(Modal.Body)
+    const div = body.find('.ron')
+
+    expect(body.length).toBe(1)
+    expect(div.length).toBe(1)
+    expect(div.html()).toContain('Burgandy')
+  })
+
+  test('Renders Modal.Body within Card, by default', () => {
+    const wrapper = shallow(
+      <ModalComponent>
+        <Modal.Body>
+          <div className='ron'>Burgandy</div>
+        </Modal.Body>
+      </ModalComponent>
+    )
+    const card = wrapper.find(Card)
+    const body = card.find(Modal.Body)
+    const div = body.find('.ron')
+
+    expect(card.length).toBe(1)
+    expect(body.length).toBe(1)
+    expect(div.length).toBe(1)
+    expect(div.html()).toContain('Burgandy')
+  })
+
+  test('Renders content within a Scrollable, within Modal.Body, by default', () => {
+    const wrapper = shallow(
+      <ModalComponent>
+        <Modal.Body>
+          <div className='ron'>Burgandy</div>
+        </Modal.Body>
+      </ModalComponent>
+    )
+    const card = wrapper.find(Card)
+    const body = card.find(Modal.Body)
+    const scrollable = body.find(Scrollable)
+    const div = scrollable.find('.ron')
+
+    expect(card.length).toBe(1)
+    expect(body.length).toBe(1)
+    expect(scrollable.length).toBe(1)
+    expect(div.length).toBe(1)
+    expect(div.html()).toContain('Burgandy')
+  })
+
+  test('Renders content within a Modal.Body, even if Modal.Body is not provided', () => {
+    const wrapper = shallow(
+      <ModalComponent>
+        <div className='ron'>Burgandy</div>
+      </ModalComponent>
+    )
+    const body = wrapper.find(Modal.Body)
+    const div = body.find('.ron')
+
+    expect(body.length).toBe(1)
+    expect(div.length).toBe(1)
+    expect(div.html()).toContain('Burgandy')
+  })
+})

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -10,12 +10,14 @@ import classNames from '../../utilities/classNames'
 export const propTypes = {
   placement: placementTypes,
   shadow: PropTypes.bool,
+  seamless: PropTypes.bool,
   size: sizeTypes,
   theme: themeTypes
 }
 
 const defaultProps = {
   placement: 'top',
+  seamless: false,
   shadow: false,
   size: 'sm',
   theme: 'default'
@@ -27,6 +29,7 @@ const Toolbar = props => {
     className,
     placement,
     shadow,
+    seamless,
     size,
     theme,
     ...rest
@@ -35,6 +38,7 @@ const Toolbar = props => {
   const componentClassName = classNames(
     'c-Toolbar',
     placement && `is-placement-${placement}`,
+    seamless && 'is-seamless',
     shadow && 'has-shadow',
     size && `is-size-${size}`,
     theme && `is-theme-${theme}`,

--- a/src/components/Toolbar/docs/Toolbar.md
+++ b/src/components/Toolbar/docs/Toolbar.md
@@ -27,8 +27,9 @@ This component is constructed using the [Flexy](../../Flexy/docs/Flexy.md) compo
 | className | `string` | Custom class names to be added to the component. |
 | gap | `string` | Determines the amount of spacing between Flexy child elements. |
 | just | `string` | Determines the horizontal alignment of Flexy child elements. |
-| shadow | `bool` | Renders a drop-shadow. |
 | placement | `string` | Determines the border placement on the component. |
+| seamless | `bool` | Removes the border from the component. |
+| shadow | `bool` | Renders a drop-shadow. |
 | theme | `string` | Determines the thematic colors of the component. |
 
 

--- a/src/components/Toolbar/tests/Toolbar.test.js
+++ b/src/components/Toolbar/tests/Toolbar.test.js
@@ -91,6 +91,22 @@ describe('Shadow', () => {
   })
 })
 
+describe('seamless', () => {
+  test('Does not have a seamless style by default', () => {
+    const wrapper = shallow(<Toolbar />)
+    const o = wrapper.find('.c-Toolbar')
+
+    expect(o.hasClass('is-seamless')).not.toBe(true)
+  })
+
+  test('Can apply seamless styles', () => {
+    const wrapper = shallow(<Toolbar seamless />)
+    const o = wrapper.find('.c-Toolbar')
+
+    expect(o.hasClass('is-seamless')).toBe(true)
+  })
+})
+
 describe('Theme', () => {
   test('Has a default theme', () => {
     const wrapper = shallow(<Toolbar />)

--- a/src/styles/components/Modal/Modal.scss
+++ b/src/styles/components/Modal/Modal.scss
@@ -1,5 +1,5 @@
 .c-Modal {
-  @import "../resets/base";
+  @import "../../resets/base";
   $offset: 8px;
 
   align-items: center;
@@ -26,6 +26,11 @@
     display: flex;
   }
 
+  &__Card {
+    display: flex;
+    flex-direction: column;
+  }
+
   &__card-block {
     height: 100%;
   }
@@ -41,6 +46,7 @@
     position: absolute;
     right: $offset;
     top: $offset;
+    transform: translateZ(0);
     z-index: 3;
   }
 }

--- a/src/styles/components/Modal/ModalBody.scss
+++ b/src/styles/components/Modal/ModalBody.scss
@@ -1,0 +1,5 @@
+.c-ModalBody {
+  @import "../../resets/base";
+  display: flex;
+  flex: 1;
+}

--- a/src/styles/components/Modal/ModalFooter.scss
+++ b/src/styles/components/Modal/ModalFooter.scss
@@ -1,0 +1,6 @@
+.c-ModalFooter {
+  @import "../../resets/base";
+  $borderRadius: 3px;
+  border-bottom-left-radius: $borderRadius;
+  border-Bottom-right-radius: $borderRadius;
+}

--- a/src/styles/components/Modal/ModalHeader.scss
+++ b/src/styles/components/Modal/ModalHeader.scss
@@ -1,0 +1,6 @@
+.c-ModalHeader {
+  @import "../../resets/base";
+  $borderRadius: 3px;
+  border-top-left-radius: $borderRadius;
+  border-top-right-radius: $borderRadius;
+}

--- a/src/styles/components/Modal/__index.scss
+++ b/src/styles/components/Modal/__index.scss
@@ -1,0 +1,4 @@
+@import "./Modal";
+@import "./ModalBody";
+@import "./ModalFooter";
+@import "./ModalHeader";

--- a/src/styles/components/Toolbar/Toolbar.scss
+++ b/src/styles/components/Toolbar/Toolbar.scss
@@ -42,4 +42,9 @@
     background-color: _color(note, background);
     color: _color(yellow, 800);
   }
+
+  // Seamless
+  &.is-seamless {
+    border: none;
+  }
 }

--- a/src/styles/components/__index.scss
+++ b/src/styles/components/__index.scss
@@ -36,7 +36,7 @@
 @import "./List";
 @import "./LoadingDots";
 @import "./Message/_index";
-@import "./Modal";
+@import "./Modal/_index";
 @import "./Overlay";
 @import "./Overflow";
 @import "./PreviewCard";

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -2,13 +2,19 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Perf from 'react-addons-perf'
 import { storiesOf } from '@storybook/react'
-import { Heading, Modal, Link } from '../src/index.js'
+import { Button, EmojiPicker, Heading, Modal, Link, Toolbar } from '../src/index.js'
 import { MemoryRouter } from 'react-router'
 import { Route } from 'react-router-dom'
+import { createSpec, faker } from '@helpscout/helix'
 
 window.Perf = Perf
 
 const stories = storiesOf('Modal', module)
+
+const ContentSpec = createSpec({
+  content: faker.lorem.paragraph(),
+  id: faker.random.uuid()
+})
 
 stories.addDecorator(story => (
   <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>
@@ -18,24 +24,9 @@ stories.add('default', () => (
   <Modal trigger={<Link>Open dis modal</Link>}>
     <div>
       <Heading>Title</Heading>
-      <p>
-        Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-      </p>
-      <p>
-        Tenderloin bacon chicken jowl cupim, sausage shank spare ribs kielbasa. Flank corned beef kevin pastrami short ribs pork andouille turkey sirloin strip steak. Shank tri-tip porchetta beef ribs salami. Pork chop tail kielbasa, turkey pork loin filet mignon chicken jowl alcatra hamburger salami cupim.
-      </p>
-      <p>
-        Corned beef pork belly cupim turkey, filet mignon bresaola short ribs sirloin brisket. Fatback turkey strip steak tenderloin pig ham hock salami cow filet mignon ribeye. Brisket drumstick capicola rump. Biltong jowl prosciutto fatback bresaola strip steak pork chop shankle tri-tip shank salami pancetta ham hock. Cupim kielbasa doner salami, meatball capicola filet mignon pastrami.
-      </p>
-      <p>
-        Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-      </p>
-      <p>
-        Tenderloin bacon chicken jowl cupim, sausage shank spare ribs kielbasa. Flank corned beef kevin pastrami short ribs pork andouille turkey sirloin strip steak. Shank tri-tip porchetta beef ribs salami. Pork chop tail kielbasa, turkey pork loin filet mignon chicken jowl alcatra hamburger salami cupim.
-      </p>
-      <p>
-        Corned beef pork belly cupim turkey, filet mignon bresaola short ribs sirloin brisket. Fatback turkey strip steak tenderloin pig ham hock salami cow filet mignon ribeye. Brisket drumstick capicola rump. Biltong jowl prosciutto fatback bresaola strip steak pork chop shankle tri-tip shank salami pancetta ham hock. Cupim kielbasa doner salami, meatball capicola filet mignon pastrami.
-      </p>
+      {ContentSpec.generate(8).map(({id, content}) => (
+        <p key={id}>{content}</p>
+      ))}
     </div>
   </Modal>
 ))
@@ -44,10 +35,76 @@ stories.add('open', () => (
   <Modal isOpen trigger={<Link>Clicky</Link>}>
     <div>
       <Heading>Title</Heading>
-      <p>
-        Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-      </p>
+      {ContentSpec.generate(2).map(({id, content}) => (
+        <p key={id}>{content}</p>
+      ))}
     </div>
+  </Modal>
+))
+
+stories.add('header/footer', () => (
+  <Modal isOpen trigger={<Link>Clicky</Link>}>
+    <Modal.Header>
+      Header
+    </Modal.Header>
+    <Modal.Body>
+      <Heading>Title</Heading>
+      {ContentSpec.generate(8).map(({id, content}) => (
+        <p key={id}>{content}</p>
+      ))}
+    </Modal.Body>
+    <Modal.Footer>
+      Footer
+    </Modal.Footer>
+  </Modal>
+))
+
+stories.add('header/footer styles', () => (
+  <Modal isOpen trigger={<Link>Clicky</Link>}>
+    <Modal.Header seamless>
+      Header
+    </Modal.Header>
+    <div>
+      <Heading>Title</Heading>
+      {ContentSpec.generate(8).map(({id, content}) => (
+        <p key={id}>{content}</p>
+      ))}
+    </div>
+    <Modal.Footer shadow>
+      Footer
+    </Modal.Footer>
+  </Modal>
+))
+
+stories.add('header/footer with items', () => (
+  <Modal isOpen trigger={<Link>Clicky</Link>} closeIcon={false}>
+    <Modal.Header>
+      <Toolbar.Item>
+        <Heading size='h4'>Heading</Heading>
+      </Toolbar.Item>
+      <Toolbar.Block />
+      <Toolbar.Item>
+        <Button>Action</Button>
+      </Toolbar.Item>
+    </Modal.Header>
+    <Modal.Body>
+      <Heading size='h4'>Inner Heading</Heading>
+      {ContentSpec.generate(8).map(({id, content}) => (
+        <p key={id}>{content}</p>
+      ))}
+    </Modal.Body>
+    <Modal.Footer>
+      <Toolbar.Item>
+        <Button>Another Action</Button>
+      </Toolbar.Item>
+      <Toolbar.Block />
+      <Toolbar.Item>
+        <Button plain>Action</Button>
+      </Toolbar.Item>
+      <Toolbar.Item>
+        <Button primary>Primary</Button>
+      </Toolbar.Item>
+    </Modal.Footer>
   </Modal>
 ))
 
@@ -74,11 +131,8 @@ stories.add('custom close trigger', () => {
 })
 
 stories.add('seamless', () => (
-  <Modal trigger={<Link>Clicky</Link>} seamless>
-    <div>
-      <Heading>No Card!</Heading>
-      <p>So much room for activites!</p>
-    </div>
+  <Modal trigger={<Link>Clicky</Link>} seamless isOpen>
+    <EmojiPicker />
   </Modal>
 ))
 
@@ -86,24 +140,24 @@ stories.add('nested', () => (
   <Modal trigger={<Link>Clicky</Link>}>
     <div>
       <Heading>Title</Heading>
-      <p>
-        Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-      </p>
+      {ContentSpec.generate(2).map(({id, content}) => (
+        <p key={id}>{content}</p>
+      ))}
 
       <Modal trigger={<Link>Level 2</Link>}>
         <div>
           <Heading>Level 2</Heading>
-          <p>
-            Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-          </p>
+          {ContentSpec.generate(2).map(({id, content}) => (
+            <p key={id}>{content}</p>
+          ))}
         </div>
 
         <Modal trigger={<Link>Level 3</Link>}>
           <div>
             <Heading>Level 3</Heading>
-            <p>
-              Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-            </p>
+            {ContentSpec.generate(2).map(({id, content}) => (
+              <p key={id}>{content}</p>
+            ))}
           </div>
         </Modal>
       </Modal>
@@ -121,9 +175,9 @@ stories.add('custom mounting selector', () => {
       <Modal trigger={<Link>Clicky</Link>} renderTo='.render-modal-here'>
         <div>
           <Heading>Title</Heading>
-          <p>
-            Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-          </p>
+          {ContentSpec.generate(2).map(({id, content}) => (
+            <p key={id}>{content}</p>
+          ))}
         </div>
       </Modal>
     </div>
@@ -155,9 +209,9 @@ stories.add('lifecycle events', () => {
       >
         <div>
           <Heading>Title</Heading>
-          <p>
-            Bacon ipsum dolor amet filet mignon swine biltong ball tip ribeye. Bresaola strip steak t-bone andouille biltong. Short loin picanha shankle bresaola pastrami brisket turducken, kevin rump landjaeger kielbasa. Alcatra tongue shoulder leberkas.
-          </p>
+          {ContentSpec.generate(2).map(({id, content}) => (
+            <p key={id}>{content}</p>
+          ))}
         </div>
       </Modal>
     </div>


### PR DESCRIPTION
## Modal: Add Header/Body/Footer sub-components

![screen recording 2017-12-11 at 12 04 pm](https://user-images.githubusercontent.com/2322354/33843485-85d25ef2-de6b-11e7-871b-2775e219334d.gif)

This update adds a new sub-components to Modal: Header, Body, and Footer.
This Header and Footer sub-components are constructed with Toolbar,
and allow you to easily add items (typically action items) to a
Modal dialog.

**Example**
```jsx
<Modal>
  <Modal.Header>
    ...
  </Modal.Header>
  <Modal.Body>
    ...
  </Modal.Body>
  <Modal.Footer>
    ...
  </Modal.Footer>
</Modal>
```

The Modal component has been adjusted to accommodate the new
required markup structure. It is recommended that content is added
into Modal using a `Modal.Body` wrapper. However, if one is not
provided, the Modal component will automatically wrap the content for
you. This is so that the responsive behaviour of the Modal
(powered by CSS flexbox) is preserved.

The docs have been updated to encourage use of Modal.Body.

Resolves: https://github.com/helpscout/blue/issues/153