### PR TITLE
Modal: Add Content sub component

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
       "src/**/*.{js,jsx}",
       "!src/tests/helpers/**/*.{js,jsx}",
       "!src/utilities/smoothScroll.{js,jsx}",
+      "!src/utilities/log.{js,jsx}",
       "!src/vendors/**/*.{js,jsx}",
       "!src/components/index.js",
       "!src/components/Animate/animations/**/*.js"

--- a/src/components/InfiniteScroller/tests/InfiniteScroller.test.js
+++ b/src/components/InfiniteScroller/tests/InfiniteScroller.test.js
@@ -2,7 +2,7 @@ import React, {PureComponent as Component} from 'react'
 import { mount } from 'enzyme'
 import InfiniteScroller from '..'
 import LoadingDots from '../../LoadingDots'
-import { ModalComponent } from '../../Modal'
+import { default as Modal, ModalComponent } from '../../Modal'
 import Text from '../../Text'
 
 const scrollEvent = new Event('scroll')
@@ -90,13 +90,15 @@ describe('scrollParent', () => {
         const getScrollParent = this.getScrollParent.bind(this)
         return (
           <ModalComponent>
-            <div className='outer'>
-              <div
-                className='custom-scroller'
-                ref={node => { this.node = node }}
-              />
-              <InfiniteScroller onLoading={spy} getScrollParent={getScrollParent} />
-            </div>
+            <Modal.Body>
+              <div className='outer'>
+                <div
+                  className='custom-scroller'
+                  ref={node => { this.node = node }}
+                />
+                <InfiniteScroller onLoading={spy} getScrollParent={getScrollParent} />
+              </div>
+            </Modal.Body>
           </ModalComponent>
         )
       }
@@ -124,13 +126,15 @@ describe('scrollParent', () => {
         const getScrollParent = this.getScrollParent.bind(this)
         return (
           <ModalComponent>
-            <div className='outer'>
-              <div
-                className='custom-scroller'
-                ref={node => { this.node = node }}
-              />
-              <InfiniteScroller onLoading={spy} getScrollParent={getScrollParent} />
-            </div>
+            <Modal.Body>
+              <div className='outer'>
+                <div
+                  className='custom-scroller'
+                  ref={node => { this.node = node }}
+                />
+                <InfiniteScroller onLoading={spy} getScrollParent={getScrollParent} />
+              </div>
+            </Modal.Body>
           </ModalComponent>
         )
       }
@@ -321,7 +325,9 @@ describe('Integration: Modal', () => {
     const spy = jest.fn()
     const wrapper = mount(
       <ModalComponent>
-        <InfiniteScroller onLoading={spy} />
+        <Modal.Body>
+          <InfiniteScroller onLoading={spy} />
+        </Modal.Body>
       </ModalComponent>
     )
     const o = wrapper.find('.c-Scrollable__content')

--- a/src/components/Message/Media.js
+++ b/src/components/Message/Media.js
@@ -54,10 +54,12 @@ const Media = props => {
   const mediaContainerMarkup = imageUrl ? (
     <div className='c-MessageMedia__media-container'>
       <Modal trigger={mediaMarkup} scrollFade={false}>
-        <div>
-          {mediaMarkup}
-        </div>
-        {captionMarkup}
+        <Modal.Content>
+          <div>
+            {mediaMarkup}
+          </div>
+          {captionMarkup}
+        </Modal.Content>
       </Modal>
     </div>
   ) : null

--- a/src/components/Modal/Body.js
+++ b/src/components/Modal/Body.js
@@ -1,25 +1,61 @@
 import React from 'react'
+import PropTypes from 'prop-types'
+import Scrollable from '../Scrollable'
 import classNames from '../../utilities/classNames'
+import { noop } from '../../utilities/other'
+
+export const propTypes = {
+  onScroll: PropTypes.func,
+  scrollable: PropTypes.bool,
+  scrollableRef: PropTypes.func,
+  scrollFade: PropTypes.bool
+}
+
+const defaultProps = {
+  onScroll: noop,
+  scrollable: true,
+  scrollableRef: noop,
+  scrollFade: true
+}
 
 const Body = props => {
   const {
     className,
     children,
+    onScroll,
+    scrollable,
+    scrollFade,
+    scrollableRef,
     ...rest
   } = props
 
   const componentClassName = classNames(
     'c-ModalBody',
+    scrollable ? 'is-scrollable' : 'is-not-scrollable',
     className
   )
 
+  const childrenContent = scrollable ? (
+    <Scrollable
+      className='c-ModalBody__scrollable'
+      fade={scrollFade}
+      rounded
+      onScroll={onScroll}
+      scrollableRef={scrollableRef}
+    >
+      {children}
+    </Scrollable>
+  ) : children
+
   return (
     <div className={componentClassName} {...rest}>
-      {children}
+      {childrenContent}
     </div>
   )
 }
 
+Body.propTypes = propTypes
+Body.defaultProps = defaultProps
 Body.displayName = 'ModalBody'
 
 export default Body

--- a/src/components/Modal/Content.js
+++ b/src/components/Modal/Content.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Body from './Body'
+import classNames from '../../utilities/classNames'
+import { noop } from '../../utilities/other'
+
+export const propTypes = {
+  scrollableRef: PropTypes.func
+}
+
+const defaultProps = {
+  scrollableRef: noop
+}
+
+const Content = props => {
+  const {
+    className,
+    children,
+    scrollableRef,
+    ...rest
+  } = props
+
+  const componentClassName = classNames(
+    'c-ModalContent',
+    className
+  )
+
+  const childrenMarkup = React.Children.map(children, child => {
+    if (child.type && child.type === Body) {
+      return React.cloneElement(child, {
+        scrollableRef: (node) => {
+          scrollableRef(node)
+          child.props.scrollableRef(node)
+        }
+      })
+    }
+
+    return child
+  })
+
+  return (
+    <div className={componentClassName} {...rest}>
+      {childrenMarkup}
+    </div>
+  )
+}
+
+Content.propTypes = propTypes
+Content.defaultProps = defaultProps
+Content.displayName = 'ModalContent'
+
+export default Content

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -8,6 +8,7 @@ A Modal component presents content within a container on top of the application'
 The Modal component is comprised of smaller components:
 
 * [Modal](./docs/Modal.md)
+* [Content](./docs/Content.md)
 * [Header](./docs/Header.md)
 * [Body](./docs/Body.md)
 * [Footer](./docs/Footer.md)

--- a/src/components/Modal/docs/Body.md
+++ b/src/components/Modal/docs/Body.md
@@ -19,3 +19,6 @@ A Modal.Body component contains content that appears within a [Modal](./Modal.md
 | Prop | Type | Description |
 | --- | --- | --- |
 | className | `string` | Custom class names to be added to the component. |
+| onScroll | `function` | Callback function when inner Scrollable is scrolled. |
+| scrollFade | `bool` | Enables the upper fade-to-white styles. Default `true`. |
+| scrollableRef | `function` | Retrieves the scrollable node. |

--- a/src/components/Modal/docs/Content.md
+++ b/src/components/Modal/docs/Content.md
@@ -1,0 +1,36 @@
+# Content
+
+A Modal.Content component contains content that appears within a [Modal](./Modal.md). It can be used to group other Modal sub-components, such as [Header](./Header.md), [Body](./Body.md), and [Footer](./Footer.md).
+
+
+## Example
+
+```jsx
+<Modal>
+  <Modal.Content>
+    ...
+  </Modal.Content>
+</Modal>
+```
+
+### Grouping sub-components
+
+```jsx
+<Modal>
+  <Modal.Content>
+    <Modal.Header>
+      ...
+    </Modal.Header>
+    <Modal.Body>
+      ...
+    </Modal.Body>
+  </Modal.Content>
+</Modal>
+```
+
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| className | `string` | Custom class names to be added to the component. |

--- a/src/components/Modal/docs/Modal.md
+++ b/src/components/Modal/docs/Modal.md
@@ -34,10 +34,7 @@ A Modal component presents content within a container on top of the application'
 | closeIcon | `bool` | Shows/hides the component's close icon UI. |
 | exact | `bool` | Used with `path` and React Router. Renders if path matches _exactly_ |
 | isOpen | `bool` | Shows/hides the component. |
-| onScroll | `function` | Callback function when inner Scrollable is scrolled. |
 | path | `string` | Renders component based on a [React Router path](https://reacttraining.com/react-router/web/api/Route/path-string). |
-| scrollFade | `bool` | Enables the upper fade-to-white styles. Default `true`. |
-| scrollableRef | `function` | Retrieves the scrollable node. |
 | seamless | `bool` | Renders content with the standard [Card](../Card) UI. |
 | trigger | `element` | The UI the user clicks to trigger the modal. |
 | wrapperClassName | `string` | Custom className to add to the [PortalWrapper](../PortalWrapper) component. |
@@ -55,4 +52,3 @@ This component has special callback props tied into it's mounting cycle.
 | onClose | `function` | Fires after the component is unmounted. |
 
 See [Portal's documentation](../Portal#render-hooks) for more details.
-

--- a/src/components/Modal/tests/Body.test.js
+++ b/src/components/Modal/tests/Body.test.js
@@ -1,6 +1,7 @@
-import React from 'react'
-import { shallow } from 'enzyme'
+import React, {PureComponent as Component} from 'react'
+import { mount, shallow } from 'enzyme'
 import Body from '../Body'
+import { Scrollable } from '../../index'
 
 describe('ClassName', () => {
   test('Has default className', () => {
@@ -23,5 +24,53 @@ describe('Children', () => {
     const el = wrapper.find('div.child')
 
     expect(el.text()).toContain('Hello')
+  })
+})
+
+describe('Scrollable', () => {
+  class MyComponent extends Component {
+    constructor () {
+      super()
+      this.scrollable = null
+    }
+    render () {
+      return (
+        <Body
+          scrollableRef={node => { this.scrollable = node }}
+          {...this.props}
+        />
+      )
+    }
+  }
+
+  test('Applies scrollable styles by default', () => {
+    const wrapper = shallow(<Body />)
+
+    expect(wrapper.hasClass('is-scrollable')).toBeTruthy()
+  })
+
+  test('Removes scrollable styles, if disabled', () => {
+    const wrapper = shallow(<Body scrollable={false} />)
+
+    expect(wrapper.hasClass('is-scrollable')).not.toBeTruthy()
+    expect(wrapper.hasClass('is-not-scrollable')).toBeTruthy()
+  })
+
+  test('Can pass scrollableRef to parent', () => {
+    const wrapper = mount(<MyComponent />)
+    const n = wrapper.find('.c-Scrollable__content').node
+    const o = wrapper.instance()
+
+    expect(o.scrollable).toBe(n)
+  })
+
+  test('Can fire onScroll callback', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<MyComponent onScroll={spy} />)
+    const o = wrapper.find(Scrollable)
+
+    o.node.props.onScroll()
+
+    expect(spy).toHaveBeenCalled()
   })
 })

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -1,4 +1,4 @@
-import React, {PureComponent as Component} from 'react'
+import React from 'react'
 import { shallow, mount } from 'enzyme'
 import { MemoryRouter as Router } from 'react-router'
 import { default as Modal, ModalComponent } from '..'
@@ -85,7 +85,11 @@ describe('CloseIcon', () => {
   })
 
   test('Adjusts CloseButton position on mount', () => {
-    const wrapper = mount(<ModalComponent isOpen />)
+    const wrapper = mount(
+      <ModalComponent isOpen>
+        <Modal.Body />
+      </ModalComponent>
+    )
     const o = wrapper.find('.c-Modal__close')
 
     expect(o.html()).toContain('right:')
@@ -302,41 +306,6 @@ describe('PortalWrapper', () => {
   })
 })
 
-describe('Integration: Scrollable', () => {
-  class MyComponent extends Component {
-    constructor () {
-      super()
-      this.scrollable = null
-    }
-    render () {
-      return (
-        <ModalComponent
-          scrollableRef={node => { this.scrollable = node }}
-          {...this.props}
-        />
-      )
-    }
-  }
-
-  test('Can pass scrollableRef to parent', () => {
-    const wrapper = mount(<MyComponent />)
-    const n = wrapper.find('.c-Scrollable__content').node
-    const o = wrapper.instance()
-
-    expect(o.scrollable).toBe(n)
-  })
-
-  test('Can fire onScroll callback', () => {
-    const spy = jest.fn()
-    const wrapper = mount(<MyComponent onScroll={spy} />)
-    const o = wrapper.find(Scrollable)
-
-    o.node.props.onScroll()
-
-    expect(spy).toHaveBeenCalled()
-  })
-})
-
 describe('Seamless', () => {
   test('Should not be seamless by default', () => {
     const wrapper = mount(
@@ -352,7 +321,9 @@ describe('Seamless', () => {
   test('Does not render the Card component, if seamless', () => {
     const wrapper = mount(
       <ModalComponent seamless>
-        <div className='ron'>RON</div>
+        <Modal.Content>
+          <div className='ron'>RON</div>
+        </Modal.Content>
       </ModalComponent>
     )
     const card = wrapper.find(Card)
@@ -448,7 +419,9 @@ describe('Body', () => {
   test('Can parse plain-text', () => {
     const wrapper = shallow(
       <ModalComponent>
-        Ron
+        <Modal.Body>
+          Ron
+        </Modal.Body>
       </ModalComponent>
     )
     const body = wrapper.find(Modal.Body)
@@ -459,7 +432,9 @@ describe('Body', () => {
 
   test('Can render Modal.Body without childrent content', () => {
     const wrapper = shallow(
-      <ModalComponent />
+      <ModalComponent>
+        <Modal.Body />
+      </ModalComponent>
     )
     const body = wrapper.find(Modal.Body)
 
@@ -468,7 +443,11 @@ describe('Body', () => {
 
   test('Can render Modal.Body without number content', () => {
     const wrapper = shallow(
-      <ModalComponent>1</ModalComponent>
+      <ModalComponent>
+        <Modal.Body>
+          1
+        </Modal.Body>
+      </ModalComponent>
     )
     const body = wrapper.find(Modal.Body)
 
@@ -510,7 +489,7 @@ describe('Body', () => {
   })
 
   test('Renders content within a Scrollable, within Modal.Body, by default', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <ModalComponent>
         <Modal.Body>
           <div className='ron'>Burgandy</div>
@@ -528,18 +507,36 @@ describe('Body', () => {
     expect(div.length).toBe(1)
     expect(div.html()).toContain('Burgandy')
   })
+})
 
-  test('Renders content within a Modal.Body, even if Modal.Body is not provided', () => {
-    const wrapper = shallow(
+describe('Content', () => {
+  test('Does not set the scrollableNode if Modal.Body is absent', () => {
+    const wrapper = mount(
       <ModalComponent>
-        <div className='ron'>Burgandy</div>
+        <Modal.Content>
+          Ron
+        </Modal.Content>
       </ModalComponent>
     )
-    const body = wrapper.find(Modal.Body)
-    const div = body.find('.ron')
 
-    expect(body.length).toBe(1)
-    expect(div.length).toBe(1)
-    expect(div.html()).toContain('Burgandy')
+    const o = wrapper.instance()
+
+    expect(o.scrollableNode).not.toBeTruthy()
+  })
+
+  test('Can set the scrollNode from a Body nested within a Content', () => {
+    const wrapper = mount(
+      <ModalComponent>
+        <Modal.Content>
+          <Modal.Body>
+            Ron
+          </Modal.Body>
+        </Modal.Content>
+      </ModalComponent>
+    )
+
+    const o = wrapper.instance()
+
+    expect(o.scrollableNode).toBeTruthy()
   })
 })

--- a/src/styles/components/Modal/Modal.scss
+++ b/src/styles/components/Modal/Modal.scss
@@ -15,7 +15,7 @@
   right: 0;
   top: 0;
 
-  &__content {
+  &__innerWrapper {
     display: flex;
     justify-content: center;
     max-height: 98%;
@@ -38,12 +38,6 @@
 
   &__card-block {
     height: 100%;
-  }
-
-  &__scrollable {
-    & > .c-Scrollable__content {
-      padding: 20px;
-    }
   }
 
   &__close {

--- a/src/styles/components/Modal/ModalBody.scss
+++ b/src/styles/components/Modal/ModalBody.scss
@@ -3,4 +3,14 @@
   display: flex;
   flex: 1;
   height: 100%;
+
+  &__scrollable {
+    & > .c-Scrollable__content {
+      padding: 20px;
+    }
+  }
+
+  &.is-not-scrollable {
+    padding: 20px;
+  }
 }

--- a/src/styles/components/Modal/ModalContent.scss
+++ b/src/styles/components/Modal/ModalContent.scss
@@ -1,0 +1,7 @@
+.c-ModalContent {
+  @import "../../resets/base";
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  height: 100%;
+}

--- a/src/styles/components/Modal/__index.scss
+++ b/src/styles/components/Modal/__index.scss
@@ -1,4 +1,5 @@
 @import "./Modal";
 @import "./ModalBody";
+@import "./ModalContent";
 @import "./ModalFooter";
 @import "./ModalHeader";

--- a/src/utilities/log.js
+++ b/src/utilities/log.js
@@ -1,0 +1,44 @@
+/**
+ * Higher order functional wrapper for the other log methods
+ *
+ * @param function  $fn         Console.log method
+ * @param string    $message    Message to log
+ *
+ * @returns function
+ */
+
+/* istanbul ignore next */
+const logWrapper = fn => /* istanbul ignore next */ message => {
+  /* istanbul ignore next */
+  if (process.env.NODE_ENV !== 'test') {
+    return fn(message)
+  }
+}
+
+/* istanbul ignore next */
+export const log = /* istanbul ignore next */ message => {
+  /* istanbul ignore next */
+  return logWrapper(console.log, `Blue: ${message}`)
+}
+
+/* istanbul ignore next */
+export const warn = /* istanbul ignore next */ message => {
+  /* istanbul ignore next */
+  return logWrapper(console.warn, `Blue: ${message}`)
+}
+
+/* istanbul ignore next */
+export const error = /* istanbul ignore next */ message => {
+  /* istanbul ignore next */
+  return logWrapper(console.error, `Blue: ${message}`)
+}
+
+/* istanbul ignore next */
+export const Exception = (methodName, message) => {
+  /* istanbul ignore next */
+  if (typeof methodName !== 'string' || typeof message !== 'string') {
+    warn('helix: Exception(): Arguments need to be strings.')
+  }
+  /* istanbul ignore next */
+  this.message = `Blue: ${methodName}(): ${message}`
+}

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -22,23 +22,23 @@ stories.addDecorator(story => (
 
 stories.add('default', () => (
   <Modal trigger={<Link>Open dis modal</Link>}>
-    <div>
+    <Modal.Body>
       <Heading>Title</Heading>
       {ContentSpec.generate(8).map(({id, content}) => (
         <p key={id}>{content}</p>
       ))}
-    </div>
+    </Modal.Body>
   </Modal>
 ))
 
 stories.add('open', () => (
   <Modal isOpen trigger={<Link>Clicky</Link>}>
-    <div>
+    <Modal.Body>
       <Heading>Title</Heading>
       {ContentSpec.generate(2).map(({id, content}) => (
         <p key={id}>{content}</p>
       ))}
-    </div>
+    </Modal.Body>
   </Modal>
 ))
 
@@ -64,12 +64,12 @@ stories.add('header/footer styles', () => (
     <Modal.Header seamless>
       Header
     </Modal.Header>
-    <div>
+    <Modal.Body>
       <Heading>Title</Heading>
       {ContentSpec.generate(8).map(({id, content}) => (
         <p key={id}>{content}</p>
       ))}
-    </div>
+    </Modal.Body>
     <Modal.Footer shadow>
       Footer
     </Modal.Footer>
@@ -78,33 +78,35 @@ stories.add('header/footer styles', () => (
 
 stories.add('header/footer with items', () => (
   <Modal isOpen trigger={<Link>Clicky</Link>} closeIcon={false}>
-    <Modal.Header>
-      <Toolbar.Item>
-        <Heading size='h4'>Heading</Heading>
-      </Toolbar.Item>
-      <Toolbar.Block />
-      <Toolbar.Item>
-        <Button>Action</Button>
-      </Toolbar.Item>
-    </Modal.Header>
-    <Modal.Body>
-      <Heading size='h4'>Inner Heading</Heading>
-      {ContentSpec.generate(8).map(({id, content}) => (
-        <p key={id}>{content}</p>
-      ))}
-    </Modal.Body>
-    <Modal.Footer>
-      <Toolbar.Item>
-        <Button>Another Action</Button>
-      </Toolbar.Item>
-      <Toolbar.Block />
-      <Toolbar.Item>
-        <Button plain>Action</Button>
-      </Toolbar.Item>
-      <Toolbar.Item>
-        <Button primary>Primary</Button>
-      </Toolbar.Item>
-    </Modal.Footer>
+    <Modal.Content>
+      <Modal.Header>
+        <Toolbar.Item>
+          <Heading size='h4'>Heading</Heading>
+        </Toolbar.Item>
+        <Toolbar.Block />
+        <Toolbar.Item>
+          <Button>Action</Button>
+        </Toolbar.Item>
+      </Modal.Header>
+      <Modal.Body>
+        <Heading size='h4'>Inner Heading</Heading>
+        {ContentSpec.generate(8).map(({id, content}) => (
+          <p key={id}>{content}</p>
+        ))}
+      </Modal.Body>
+      <Modal.Footer>
+        <Toolbar.Item>
+          <Button>Another Action</Button>
+        </Toolbar.Item>
+        <Toolbar.Block />
+        <Toolbar.Item>
+          <Button plain>Action</Button>
+        </Toolbar.Item>
+        <Toolbar.Item>
+          <Button primary>Primary</Button>
+        </Toolbar.Item>
+      </Modal.Footer>
+    </Modal.Content>
   </Modal>
 ))
 
@@ -132,37 +134,39 @@ stories.add('custom close trigger', () => {
 
 stories.add('seamless', () => (
   <Modal trigger={<Link>Clicky</Link>} seamless isOpen>
-    <EmojiPicker />
+    <Modal.Content>
+      <EmojiPicker />
+    </Modal.Content>
   </Modal>
 ))
 
 stories.add('nested', () => (
   <Modal trigger={<Link>Clicky</Link>}>
-    <div>
+    <Modal.Body>
       <Heading>Title</Heading>
       {ContentSpec.generate(2).map(({id, content}) => (
         <p key={id}>{content}</p>
       ))}
 
       <Modal trigger={<Link>Level 2</Link>}>
-        <div>
+        <Modal.Body>
           <Heading>Level 2</Heading>
           {ContentSpec.generate(2).map(({id, content}) => (
             <p key={id}>{content}</p>
           ))}
-        </div>
 
-        <Modal trigger={<Link>Level 3</Link>}>
-          <div>
-            <Heading>Level 3</Heading>
-            {ContentSpec.generate(2).map(({id, content}) => (
-              <p key={id}>{content}</p>
-            ))}
-          </div>
-        </Modal>
+          <Modal trigger={<Link>Level 3</Link>}>
+            <Modal.Body>
+              <Heading>Level 3</Heading>
+              {ContentSpec.generate(2).map(({id, content}) => (
+                <p key={id}>{content}</p>
+              ))}
+            </Modal.Body>
+          </Modal>
+        </Modal.Body>
       </Modal>
 
-    </div>
+    </Modal.Body>
   </Modal>
 ))
 
@@ -173,12 +177,12 @@ stories.add('custom mounting selector', () => {
       <div className='render-modal-here' />
 
       <Modal trigger={<Link>Clicky</Link>} renderTo='.render-modal-here'>
-        <div>
+        <Modal.Body>
           <Heading>Title</Heading>
           {ContentSpec.generate(2).map(({id, content}) => (
             <p key={id}>{content}</p>
           ))}
-        </div>
+        </Modal.Body>
       </Modal>
     </div>
   )
@@ -207,12 +211,12 @@ stories.add('lifecycle events', () => {
         onBeforeClose={onBeforeClose}
         trigger={<Link>Clicky</Link>}
       >
-        <div>
+        <Modal.Body>
           <Heading>Title</Heading>
           {ContentSpec.generate(2).map(({id, content}) => (
             <p key={id}>{content}</p>
           ))}
-        </div>
+        </Modal.Body>
       </Modal>
     </div>
   )
@@ -240,28 +244,38 @@ stories.add('routes', () => {
       </ul>
 
       <Modal path='/team' onBeforeOpen={onBeforeOpen}>
-        <h1>Team Modal: A</h1>
-        <p>Modal content</p>
+        <Modal.Body>
+          <h1>Team Modal: A</h1>
+          <p>Modal content</p>
+        </Modal.Body>
       </Modal>
 
       <Modal path='/team/brick'>
-        <h1>Team Modal: B</h1>
-        <p>Modal inner content</p>
+        <Modal.Body>
+          <h1>Team Modal: B</h1>
+          <p>Modal inner content</p>
+        </Modal.Body>
       </Modal>
 
       <Modal path='/team/brick'>
-        <h1>Team Modal: C</h1>
-        <p>Modal inner content</p>
+        <Modal.Body>
+          <h1>Team Modal: C</h1>
+          <p>Modal inner content</p>
+        </Modal.Body>
       </Modal>
 
       <Modal path='/team/brick'>
-        <h1>Team Modal: D</h1>
-        <p>Modal inner content</p>
+        <Modal.Body>
+          <h1>Team Modal: D</h1>
+          <p>Modal inner content</p>
+        </Modal.Body>
       </Modal>
 
       <Modal path='/team/brick'>
-        <h1>Team Modal: E</h1>
-        <p>Modal inner content</p>
+        <Modal.Body>
+          <h1>Team Modal: E</h1>
+          <p>Modal inner content</p>
+        </Modal.Body>
       </Modal>
 
       <Route exact path='/' render={props => (

--- a/test/acceptance/components/Modal.spec.js
+++ b/test/acceptance/components/Modal.spec.js
@@ -28,7 +28,9 @@ describe('Modal', () => {
             modalAnimationDelay={0}
             overlayAnimationDelay={0}
           >
-            <Heading>Modal content</Heading>
+            <Modal.Body>
+              <Heading>Modal content</Heading>
+            </Modal.Body>
           </Modal>
           <div id='modals' />
         </div>
@@ -146,8 +148,10 @@ describe('Modal', () => {
             modalAnimationDelay={0}
             overlayAnimationDelay={0}
           >
-            <Heading>Modal content</Heading>
-            <div className='big' style={{height: 4000}} />
+            <Modal.Body>
+              <Heading>Modal content</Heading>
+              <div className='big' style={{height: 4000}} />
+            </Modal.Body>
           </Modal>
           <div id='modals' />
         </div>
@@ -158,8 +162,8 @@ describe('Modal', () => {
 
       wait(100)
         .then(() => {
-          expect($('.c-Modal__content').height())
-            .toBeGreaterThan($('.c-Modal__scrollable').height())
+          expect($('.c-Modal__innerWrapper').height())
+            .toBeGreaterThan($('.c-ModalBody__scrollable').height())
           done()
         })
     })
@@ -176,8 +180,10 @@ describe('Modal', () => {
             modalAnimationDelay={0}
             overlayAnimationDelay={0}
           >
-            <Heading>Modal content</Heading>
-            <div className='big' style={{height: 4000}} />
+            <Modal.Body>
+              <Heading>Modal content</Heading>
+              <div className='big' style={{height: 4000}} />
+            </Modal.Body>
           </Modal>
           <div id='modals' />
         </div>


### PR DESCRIPTION
## Modal: Add Content sub component

This update adds a new Modal.Content sub-component for Modal.
The idea for the sub-component is to support swapping Modal's `children`
from one set of components to another (e.g. loading conditions).

As if this update, Modal will no longer render anything inside that
isn't a sub-component. This is to enforce the new component
pattern required.

This update makes it slightly more verbose to add Modal content.
However, it enables better and more reliable flexibility in rendering
various types of content.

**Note to consumers of Blue: This update changes the Modal component
API. Please refer to the docs (or see examples below) if you notice
that your Modals are not rendering content.**

**Example**
```jsx
<Modal>
  <Modal.Content>
    ...
  </Modal.Content>
</Modal>
```

This will still work:
```jsx
<Modal>
  <Modal.Header>
    ...
  </Modal.Header>
  <Modal.Body>
    ...
  </Modal.Body>
</Modal>
```

This will no longer work:
```jsx
<Modal>
  Content
</Modal>
```

Resolves: https://github.com/helpscout/blue/issues/157