### PR TITLE
Modal and List: Bug Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18546,27 +18546,21 @@
       }
     },
     "seed-list": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/seed-list/-/seed-list-0.0.16.tgz",
-      "integrity": "sha1-n1rh/qyVN/yoAQkA3S9+DkgNnRs=",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/seed-list/-/seed-list-0.0.17.tgz",
+      "integrity": "sha512-8ajs2tjni14yCKCkyg6jvg2I2IwwONxCExBi2VDSm0zoailRV3bPlXnJNKGBLw8bIJHeVMkk50Qld4Fz/XqUCQ==",
       "dev": true,
       "requires": {
-        "seed-border": "0.0.9",
+        "seed-border": "0.0.10",
         "seed-breakpoints": "0.4.1",
-        "seed-publish": "0.0.4",
-        "seed-spacing": "0.4.3"
+        "seed-publish": "0.2.0"
       },
       "dependencies": {
-        "seed-border": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/seed-border/-/seed-border-0.0.9.tgz",
-          "integrity": "sha1-i53Ee/H7JCwfcT/uanfCpdoq+ZY=",
-          "dev": true,
-          "requires": {
-            "sass-pathfinder": "0.0.5",
-            "seed-breakpoints": "0.4.1",
-            "seed-publish": "0.0.4"
-          }
+        "seed-publish": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/seed-publish/-/seed-publish-0.2.0.tgz",
+          "integrity": "sha1-IAYOsyPWgIuqBDbYRPqEBJ65Rvo=",
+          "dev": true
         }
       }
     },
@@ -18606,24 +18600,6 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/seed-dash/-/seed-dash-0.0.1.tgz",
           "integrity": "sha1-/yHArmMzDsY6ik4+Db9Ka3ooh6I=",
-          "dev": true
-        }
-      }
-    },
-    "seed-spacing": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/seed-spacing/-/seed-spacing-0.4.3.tgz",
-      "integrity": "sha1-iM25wPQMAy+21EZB5jviu00kxzY=",
-      "dev": true,
-      "requires": {
-        "seed-breakpoints": "0.4.1",
-        "seed-publish": "0.0.2"
-      },
-      "dependencies": {
-        "seed-publish": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/seed-publish/-/seed-publish-0.0.2.tgz",
-          "integrity": "sha1-q/BHzazUzt3SN8NXs6H0Xa/lwwg=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "seed-grid": "0.4.0",
     "seed-harvester": "0.1.5",
     "seed-hr": "0.0.3",
-    "seed-list": "0.0.16",
+    "seed-list": "0.0.17",
     "seed-switch": "0.0.4",
     "seed-this": "0.0.5",
     "standard": "10.0.2",

--- a/src/components/AvatarList/index.js
+++ b/src/components/AvatarList/index.js
@@ -42,6 +42,7 @@ const AvatarList = props => {
     'c-List',
     'c-List--inline',
     'c-List--xs',
+    'is-display-flex',
     className
   )
 

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -6,6 +6,10 @@ import Item from './Item'
 export const propTypes = {
   border: PropTypes.oneOf(['line', 'dot', '']),
   className: PropTypes.string,
+  display: PropTypes.oneOf([
+    'block',
+    'flex'
+  ]),
   size: PropTypes.oneOf([
     'xs',
     'sm',
@@ -22,6 +26,7 @@ export const propTypes = {
 }
 
 const defaultProps = {
+  display: 'block',
   role: 'list'
 }
 
@@ -30,6 +35,7 @@ const List = props => {
     border,
     children,
     className,
+    display,
     role,
     size,
     type,
@@ -40,6 +46,7 @@ const List = props => {
     'c-List',
     border === 'dot' && 'c-List--dotted',
     border === 'line' && 'c-List--bordered',
+    display && `is-display-${display}`,
     size && `c-List--${size}`,
     type && `c-List--${type}`,
     className

--- a/src/components/List/docs/List.md
+++ b/src/components/List/docs/List.md
@@ -25,6 +25,7 @@ A List component is a presentational component, and is an enhanced version of th
 | --- | --- | --- |
 | border | `string` | Border style for the items. `dot` or `line`. |
 | className | `string` | Custom class names to be added to the component. |
+| display | `string` | Changes the component's CSS `display`. `block`/`flex`. |
 | role | `string` | Aria-role for the component. Default is `list`. |
 | size | `string` | Size style for the items. `xs`, `sm`, `md`, or `lg`. |
 | type | `string` | List style style for the items. `bullet`, `inline`, or `number`. |

--- a/src/components/List/tests/List.test.js
+++ b/src/components/List/tests/List.test.js
@@ -80,6 +80,21 @@ describe('Number', () => {
   })
 })
 
+describe('Display', () => {
+  test('Is display block by default', () => {
+    const wrapper = shallow(<List />)
+
+    expect(wrapper.hasClass('is-display-block')).toBeTruthy()
+  })
+
+  test('Can be set to display flex', () => {
+    const wrapper = shallow(<List display='flex' />)
+
+    expect(wrapper.hasClass('is-display-block')).not.toBeTruthy()
+    expect(wrapper.hasClass('is-display-flex')).toBeTruthy()
+  })
+})
+
 describe('Size', () => {
   test('Can render size styles, if specified', () => {
     const wrapper = shallow(<List size='md' />)

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -14,7 +14,6 @@ import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 import { propTypes as portalTypes } from '../Portal'
 import { hasContentOverflowY } from '../../utilities/node'
-import { warn } from '../../utilities/log'
 import getScrollbarWidth from '../../vendors/getScrollbarWidth'
 
 export const propTypes = Object.assign({}, portalTypes, {
@@ -63,7 +62,6 @@ class Modal extends Component {
     this.handleOnResize = this.handleOnResize.bind(this)
     this.closeNode = null
     this.scrollableNode = null
-    this._hasHeader = false
   }
 
   componentDidMount () {
@@ -78,8 +76,7 @@ class Modal extends Component {
   positionCloseNode () {
     if (
       !this.closeNode ||
-      !this.scrollableNode ||
-      this._hasHeader
+      !this.scrollableNode
     ) return
 
     const defaultOffset = 8
@@ -138,16 +135,6 @@ class Modal extends Component {
     }) : { zIndex }
 
     const parsedChildren = React.Children.map(children, child => {
-      if (!child || (
-          child.type !== Body &&
-          child.type !== Content &&
-          child.type !== Header &&
-          child.type !== Footer
-        )) {
-        warn('Modal: Child must be a sub-component of Modal.')
-        return null
-      }
-
       if (child.type === Content || child.type === Body) {
         return React.cloneElement(child, {
           scrollableRef: (node) => {

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -430,7 +430,7 @@ describe('Body', () => {
     expect(body.html()).toContain('Ron')
   })
 
-  test('Can render Modal.Body without childrent content', () => {
+  test('Can render Modal.Body without children content', () => {
     const wrapper = shallow(
       <ModalComponent>
         <Modal.Body />
@@ -538,5 +538,39 @@ describe('Content', () => {
     const o = wrapper.instance()
 
     expect(o.scrollableNode).toBeTruthy()
+  })
+})
+
+describe('Children', () => {
+  test('Can render non-sub component children', () => {
+    const wrapper = shallow(
+      <ModalComponent>
+        <div className='ron'>Test</div>
+      </ModalComponent>
+    )
+    const o = wrapper.find('.ron')
+
+    expect(o.length).toBe(1)
+  })
+
+  test('Can render wrapper-like child components', () => {
+    const WrapperComponent = props => {
+      return (
+        <Modal.Content>
+          {props.children}
+        </Modal.Content>
+      )
+    }
+
+    const wrapper = shallow(
+      <ModalComponent>
+        <WrapperComponent>
+          <div className='ron'>Test</div>
+        </WrapperComponent>
+      </ModalComponent>
+    )
+    const o = wrapper.find('.ron')
+
+    expect(o.length).toBe(1)
   })
 })

--- a/src/styles/components/List.scss
+++ b/src/styles/components/List.scss
@@ -5,9 +5,17 @@ $seed-list-namespace: "c-List";
 .#{$seed-list-namespace} {
   @import "../resets/base";
   $block: this();
-  display: flex;
+  display: block;
   margin-bottom: 0;
   margin-top: 0;
+
+
+  &.is-display-block {
+    display: block;
+  }
+  &.is-display-flex {
+    display: flex;
+  }
 
   &--inline {
     #{$block}__item {


### PR DESCRIPTION
## Modal and List: Bug Fixes

This update is a follow-up to the Modal.Content sub-component addition.
When implementing the new Modal structure, I discovered by rejecting
non-sub-component children, it causes unexpected issues for wrapper-like
components.

**This restriction has been removed for Modal.**

It is still highly recommended that you use either Modal.Body or Modal.Content to ensure that the UI looks correct.

There was a CSS bug that was introduced into Lists during the Tag
enhancement, which changed the display from `block` to `flex`.

This update fixes this by defaulting to a display of `block`, but
providing the ability to use `flex` via a prop.

Follow-up to https://github.com/helpscout/blue/releases/tag/v0.0.73