### PR TITLE
Modal: Handle null child

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -135,7 +135,7 @@ class Modal extends Component {
     }) : { zIndex }
 
     const parsedChildren = React.Children.map(children, child => {
-      if (child.type === Content || child.type === Body) {
+      if (child && (child.type === Content || child.type === Body)) {
         return React.cloneElement(child, {
           scrollableRef: (node) => {
             this.scrollableNode = node


### PR DESCRIPTION
## Modal: Handle null child

This update accounts for the rare edge case where a child component
of a Modal may be `null`.