### PR TITLE
Modal.Content: To handle null children

### DIFF
--- a/src/components/Modal/Content.js
+++ b/src/components/Modal/Content.js
@@ -26,7 +26,7 @@ const Content = props => {
   )
 
   const childrenMarkup = React.Children.map(children, child => {
-    if (child.type && child.type === Body) {
+    if (child && (child.type && child.type === Body)) {
       return React.cloneElement(child, {
         scrollableRef: (node) => {
           scrollableRef(node)

--- a/src/components/Modal/tests/Content.test.js
+++ b/src/components/Modal/tests/Content.test.js
@@ -1,0 +1,38 @@
+import React, {PureComponent as Component} from 'react'
+import { mount, shallow } from 'enzyme'
+import Content from '../Content'
+import { Scrollable } from '../../index'
+
+describe('ClassName', () => {
+  test('Has default className', () => {
+    const wrapper = shallow(<Content />)
+
+    expect(wrapper.hasClass('c-ModalContent')).toBeTruthy()
+  })
+
+  test('Applies custom className if specified', () => {
+    const customClass = 'piano-key-neck-tie'
+    const wrapper = shallow(<Content className={customClass} />)
+
+    expect(wrapper.prop('className')).toContain(customClass)
+  })
+})
+
+describe('Children', () => {
+  test('Renders child content', () => {
+    const wrapper = shallow(<Content><div className='child'>Hello</div></Content>)
+    const el = wrapper.find('div.child')
+
+    expect(el.text()).toContain('Hello')
+  })
+
+  test('Can handle null content', () => {
+    const wrapper = shallow(
+      <Content>
+        {[null]}
+      </Content>
+    )
+
+    expect(wrapper).toBeTruthy()
+  })
+})

--- a/src/components/Modal/tests/Content.test.js
+++ b/src/components/Modal/tests/Content.test.js
@@ -1,7 +1,6 @@
-import React, {PureComponent as Component} from 'react'
-import { mount, shallow } from 'enzyme'
+import React from 'react'
+import { shallow } from 'enzyme'
 import Content from '../Content'
-import { Scrollable } from '../../index'
 
 describe('ClassName', () => {
   test('Has default className', () => {

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -573,4 +573,15 @@ describe('Children', () => {
 
     expect(o.length).toBe(1)
   })
+
+
+  test('Can handle null content', () => {
+    const wrapper = shallow(
+      <ModalComponent>
+        {[null]}
+      </ModalComponent>
+    )
+
+    expect(wrapper).toBeTruthy()
+  })
 })

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -574,7 +574,6 @@ describe('Children', () => {
     expect(o.length).toBe(1)
   })
 
-
   test('Can handle null content', () => {
     const wrapper = shallow(
       <ModalComponent>


### PR DESCRIPTION
## Modal.Content: To handle null children

This update fixes the `Modal.Content` sub-component to also
handle `null` children content. Tests for `null` were added to
`Modal.Content` and `Modal`.