### PR TITLE
Modal: Allow reposition CloseButton in sub components

### DIFF
--- a/src/components/Modal/Body.js
+++ b/src/components/Modal/Body.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {PureComponent as Component} from 'react'
 import PropTypes from 'prop-types'
 import Scrollable from '../Scrollable'
 import classNames from '../../utilities/classNames'
@@ -18,44 +18,73 @@ const defaultProps = {
   scrollFade: true
 }
 
-const Body = props => {
-  const {
-    className,
-    children,
-    onScroll,
-    scrollable,
-    scrollFade,
-    scrollableRef,
-    ...rest
-  } = props
+const contextTypes = {
+  positionCloseNode: PropTypes.func
+}
 
-  const componentClassName = classNames(
-    'c-ModalBody',
-    scrollable ? 'is-scrollable' : 'is-not-scrollable',
-    className
-  )
+class Body extends Component {
+  constructor () {
+    super()
+    this.scrollableNode = null
+  }
 
-  const childrenContent = scrollable ? (
-    <Scrollable
-      className='c-ModalBody__scrollable'
-      fade={scrollFade}
-      rounded
-      onScroll={onScroll}
-      scrollableRef={scrollableRef}
-    >
-      {children}
-    </Scrollable>
-  ) : children
+  componentDidMount () {
+    this.positionCloseNode()
+  }
 
-  return (
-    <div className={componentClassName} {...rest}>
-      {childrenContent}
-    </div>
-  )
+  positionCloseNode () {
+    if (this.context.positionCloseNode) {
+      this.context.positionCloseNode(this.scrollableNode)
+    }
+  }
+
+  componentWillUnmount () {
+    this.scrollableNode = null
+  }
+
+  render () {
+    const {
+      className,
+      children,
+      onScroll,
+      scrollable,
+      scrollFade,
+      scrollableRef,
+      ...rest
+    } = this.props
+
+    const componentClassName = classNames(
+      'c-ModalBody',
+      scrollable ? 'is-scrollable' : 'is-not-scrollable',
+      className
+    )
+
+    const childrenContent = scrollable ? (
+      <Scrollable
+        className='c-ModalBody__scrollable'
+        fade={scrollFade}
+        rounded
+        onScroll={onScroll}
+        scrollableRef={node => {
+          this.scrollableNode = node
+          scrollableRef(node)
+        }}
+      >
+        {children}
+      </Scrollable>
+    ) : children
+
+    return (
+      <div className={componentClassName} {...rest}>
+        {childrenContent}
+      </div>
+    )
+  }
 }
 
 Body.propTypes = propTypes
 Body.defaultProps = defaultProps
+Body.contextTypes = contextTypes
 Body.displayName = 'ModalBody'
 
 export default Body

--- a/src/components/Modal/Content.js
+++ b/src/components/Modal/Content.js
@@ -12,7 +12,7 @@ const defaultProps = {
   scrollableRef: noop
 }
 
-const Content = props => {
+const Content = (props, context) => {
   const {
     className,
     children,

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -13,7 +13,7 @@ import PortalWrapper from '../PortalWrapper'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 import { propTypes as portalTypes } from '../Portal'
-import { hasContentOverflowY } from '../../utilities/node'
+import { isNodeElement, hasContentOverflowY } from '../../utilities/node'
 import getScrollbarWidth from '../../vendors/getScrollbarWidth'
 
 export const propTypes = Object.assign({}, portalTypes, {
@@ -47,6 +47,10 @@ const defaultProps = {
   wrapperClassName: 'c-ModalWrapper'
 }
 
+const childContextTypes = {
+  positionCloseNode: PropTypes.func
+}
+
 const modalBaseZIndex = 1040
 const portalOptions = {
   id: 'Modal',
@@ -73,19 +77,26 @@ class Modal extends Component {
     this.positionCloseNode()
   }
 
-  positionCloseNode () {
+  positionCloseNode (scrollableNode) {
+    const scrollNode = scrollableNode || this.scrollableNode
     if (
       !this.closeNode ||
-      !this.scrollableNode
+      !isNodeElement(scrollNode)
     ) return
 
     const defaultOffset = 8
     const borderOffset = 2
-    const offset = hasContentOverflowY(this.scrollableNode)
+    const offset = hasContentOverflowY(scrollNode)
       ? /* istanbul ignore next */ `${scrollbarWidth + borderOffset}px`
       : `${defaultOffset}px`
 
     this.closeNode.style.right = offset
+  }
+
+  getChildContext () {
+    return {
+      positionCloseNode: this.positionCloseNode
+    }
   }
 
   render () {
@@ -176,6 +187,7 @@ class Modal extends Component {
 
 Modal.propTypes = propTypes
 Modal.defaultProps = defaultProps
+Modal.childContextTypes = childContextTypes
 Modal.displayName = 'Modal'
 
 const ComposedModal = PortalWrapper(portalOptions)(Modal)

--- a/src/components/Modal/tests/Body.test.js
+++ b/src/components/Modal/tests/Body.test.js
@@ -74,3 +74,41 @@ describe('Scrollable', () => {
     expect(spy).toHaveBeenCalled()
   })
 })
+
+describe('ScrollableNode', () => {
+  test('Sets an internal scrollableNode on mount', () => {
+    const wrapper = mount(<Body />)
+
+    expect(wrapper.instance().scrollableNode).toBeTruthy()
+  })
+
+  test('Unsets an internal scrollableNode on unmount', () => {
+    const wrapper = mount(<Body />)
+    const o = wrapper.instance()
+    wrapper.unmount()
+
+    expect(o.scrollableNode).not.toBeTruthy()
+  })
+
+  test('scrollableRef callback prop still works', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Body scrollableRef={spy} />)
+    const o = wrapper.instance().scrollableNode
+
+    expect(spy).toHaveBeenCalledWith(o)
+  })
+})
+
+describe('Context', () => {
+  test('Position closeIcon using context', () => {
+    const spy = jest.fn()
+    mount(<Body />, {
+      context: {
+        positionCloseNode: spy
+      }
+    })
+
+    expect(spy).toHaveBeenCalled()
+    expect(spy.mock.calls[0][0]).toBeTruthy()
+  })
+})

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -584,3 +584,19 @@ describe('Children', () => {
     expect(wrapper).toBeTruthy()
   })
 })
+
+describe('Context', () => {
+  describe('positionCloseNode', () => {
+    test('Passes context to Modal.Body', () => {
+      const wrapper = mount(
+        <ModalComponent>
+          <Modal.Body />
+        </ModalComponent>
+      )
+      const o = wrapper.find(Modal.Body).getNode()
+
+      expect(o.context).toBeTruthy()
+      expect(typeof o.context.positionCloseNode).toBe('function')
+    })
+  })
+})

--- a/src/styles/components/Modal/Modal.scss
+++ b/src/styles/components/Modal/Modal.scss
@@ -27,6 +27,7 @@
 
   &__Card-container {
     display: flex;
+    max-width: 100%;
   }
 
   & {

--- a/src/styles/components/Modal/ModalBody.scss
+++ b/src/styles/components/Modal/ModalBody.scss
@@ -3,6 +3,7 @@
   display: flex;
   flex: 1;
   height: 100%;
+  max-width: 100%;
 
   &__scrollable {
     & > .c-Scrollable__content {

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -33,12 +33,14 @@ stories.add('default', () => (
 
 stories.add('open', () => (
   <Modal isOpen trigger={<Link>Clicky</Link>}>
-    <Modal.Body>
-      <Heading>Title</Heading>
-      {ContentSpec.generate(2).map(({id, content}) => (
-        <p key={id}>{content}</p>
-      ))}
-    </Modal.Body>
+    <Modal.Content>
+      <Modal.Body>
+        <Heading>Title</Heading>
+        {ContentSpec.generate(2).map(({id, content}) => (
+          <p key={id}>{content}</p>
+        ))}
+      </Modal.Body>
+    </Modal.Content>
   </Modal>
 ))
 


### PR DESCRIPTION
## Modal: Allow reposition CloseButton in sub components

This update adds the `positionCloseNode` method from Modal as context,
which allows the `Modal.Body` sub-component to call it on mount.

Typically, this should happen by default. However, there may be cases
where `Modal.Body` gets injected asynchronously (like transitioning from
loading -> loaded states).

This all fires behind the scenes. No changes are required for users of Modal
:smile: