### PR TITLE
Allow input state to be updated by passing new value prop

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -65,6 +65,15 @@ class Input extends Component {
     this.handleExpandingResize = this.handleExpandingResize.bind(this)
   }
 
+  componentWillReceiveProps (nextProps) {
+    const prevValue = this.state.value
+    const nextValue = nextProps.value
+
+    if (nextValue !== prevValue) {
+      this.setState({value: nextValue})
+    }
+  }
+
   handleOnChange (e) {
     const value = e.currentTarget.value
     this.setState({ value })

--- a/src/components/Input/tests/Input.test.js
+++ b/src/components/Input/tests/Input.test.js
@@ -84,6 +84,34 @@ describe('Events', () => {
   })
 })
 
+describe('value', () => {
+  test('Does not update the state if new value is the same as previous value', () => {
+    const lifecycleSpy = jest.spyOn(Input.prototype, 'componentWillReceiveProps')
+    const stateSpy = jest.spyOn(Input.prototype, 'setState')
+
+    const wrapper = mount(<Input value='initial value' />)
+    expect(wrapper.find('input').prop('value')).toBe('initial value')
+
+    wrapper.setProps({value: 'initial value'})
+    expect(lifecycleSpy).toHaveBeenCalled()
+    expect(stateSpy).not.toHaveBeenCalled()
+    expect(wrapper.find('input').prop('value')).toBe('initial value')
+  })
+
+  test('Does update the state if new value is different than previous value', () => {
+    const lifecycleSpy = jest.spyOn(Input.prototype, 'componentWillReceiveProps')
+    const stateSpy = jest.spyOn(Input.prototype, 'setState')
+
+    const wrapper = mount(<Input value='initial value' />)
+    expect(wrapper.find('input').prop('value')).toBe('initial value')
+
+    wrapper.setProps({value: 'new value'})
+    expect(lifecycleSpy).toHaveBeenCalled()
+    expect(stateSpy).toHaveBeenCalledWith({value: 'new value'})
+    expect(wrapper.find('input').prop('value')).toBe('new value')
+  })
+})
+
 describe('ID', () => {
   test('Automatically generates an ID if not defined', () => {
     const wrapper = mount(<Input label='Input' />)


### PR DESCRIPTION
## Input : Allow state to be updated by new `value` prop

When the input is initialized, the value property of its state is set to the passed value prop. The value prop on the internal state is then only updated via the `handleOnChange`. This is fine when the user is in control of the input. There may be times however, where we want to update the value on the internal state programatically, such as allowing a picker to inject content, as shown below. 

This PR updates the Input component such that the value on the internal state can be updated by passing a new value prop to the component.