### PR TITLE
Modal: Can open/close with isOpen prop change

### DIFF
--- a/src/components/Drop/tests/Drop.test.js
+++ b/src/components/Drop/tests/Drop.test.js
@@ -168,3 +168,40 @@ describe('wrapperClassName', () => {
     })
   })
 })
+
+describe('isOpen', () => {
+  test('Can open wrapped component with isOpen prop change to true', (done) => {
+    const TestComponent = Drop()(ContentComponent)
+    const wrapper = mount(<TestComponent />)
+
+    wait()
+      .then(() => {
+        const o = document.body.childNodes[0]
+        expect(o).not.toBeTruthy()
+
+        wrapper.setProps({ isOpen: true })
+      })
+      .then(() => wait(10))
+      .then(() => {
+        const o = document.body.childNodes[0]
+        expect(o).toBeTruthy()
+        done()
+      })
+  })
+
+  test('Can close wrapped component with isOpen prop change to false', (done) => {
+    const TestComponent = Drop()(ContentComponent)
+    const wrapper = mount(<TestComponent isOpen timeout={0} />)
+
+    wait()
+      .then(() => {
+        wrapper.setProps({ isOpen: false })
+      })
+      .then(() => wait(300))
+      .then(() => {
+        const o = document.body.childNodes[0]
+        expect(o).not.toBeTruthy()
+        done()
+      })
+  })
+})

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -600,3 +600,38 @@ describe('Context', () => {
     })
   })
 })
+
+describe('isOpen', () => {
+  test('Can open wrapped component with isOpen prop change to true', (done) => {
+    const wrapper = mount(<Modal />)
+
+    wait()
+      .then(() => {
+        const o = document.body.childNodes[0]
+        expect(o).not.toBeTruthy()
+
+        wrapper.setProps({ isOpen: true })
+      })
+      .then(() => wait(50))
+      .then(() => {
+        const o = document.body.childNodes[0]
+        expect(o).toBeTruthy()
+        done()
+      })
+  })
+
+  test('Can close wrapped component with isOpen prop change to false', (done) => {
+    const wrapper = mount(<Modal isOpen timeout={0} />)
+
+    wait()
+      .then(() => {
+        wrapper.setProps({ isOpen: false })
+      })
+      .then(() => wait(MODAL_TEST_TIMEOUT))
+      .then(() => {
+        const o = document.body.childNodes[0]
+        expect(o).not.toBeTruthy()
+        done()
+      })
+  })
+})

--- a/src/components/PortalWrapper/index.js
+++ b/src/components/PortalWrapper/index.js
@@ -62,9 +62,12 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
     }
 
     componentWillReceiveProps (nextProps) {
+      const { isOpen, path } = nextProps
       /* istanbul ignore else */
-      if (nextProps.path) {
+      if (path) {
         this.openPortal()
+      } else if (isOpen !== undefined || isOpen !== null) {
+        this.setState({ isOpen })
       }
     }
 

--- a/src/components/PortalWrapper/tests/PortalWrapper.test.js
+++ b/src/components/PortalWrapper/tests/PortalWrapper.test.js
@@ -148,3 +148,40 @@ describe('wrapperClassName', () => {
     })
   })
 })
+
+describe('isOpen', () => {
+  test('Can open wrapped component with isOpen prop change to true', (done) => {
+    const TestComponent = PortalWrapper(options)(TestButton)
+    const wrapper = mount(<TestComponent />)
+
+    wait()
+      .then(() => {
+        const o = document.body.childNodes[0]
+        expect(o).not.toBeTruthy()
+
+        wrapper.setProps({ isOpen: true })
+      })
+      .then(() => wait(10))
+      .then(() => {
+        const o = document.body.childNodes[0]
+        expect(o).toBeTruthy()
+        done()
+      })
+  })
+
+  test('Can close wrapped component with isOpen prop change to false', (done) => {
+    const TestComponent = PortalWrapper(options)(TestButton)
+    const wrapper = mount(<TestComponent isOpen timeout={0} />)
+
+    wait()
+      .then(() => {
+        wrapper.setProps({ isOpen: false })
+      })
+      .then(() => wait(300))
+      .then(() => {
+        const o = document.body.childNodes[0]
+        expect(o).not.toBeTruthy()
+        done()
+      })
+  })
+})

--- a/test/acceptance/components/Modal.spec.js
+++ b/test/acceptance/components/Modal.spec.js
@@ -133,6 +133,43 @@ describe('Modal', () => {
           done()
         })
     })
+
+    it('should be able to open with prop change', (done) => {
+      const wrapper = mount(
+        <Modal className='modal' />
+      )
+
+      wait()
+        .then(() => {
+          wrapper.setProps({ isOpen: true })
+        })
+        .then(() => wait(100))
+        .then(() => {
+          expect($('.modal').length).toBe(1)
+          wrapper.unmount()
+          done()
+        })
+    })
+
+    it('should be able to close with prop change', (done) => {
+      const wrapper = mount(
+        <Modal className='modal' isOpen timeout={0} />
+      )
+
+      wait(100)
+        .then(() => {
+          expect($('.modal').length).toBe(1)
+        })
+        .then(() => {
+          wrapper.setProps({ isOpen: false })
+        })
+        .then(() => wait(modalUnmountTime))
+        .then(() => {
+          expect($('.modal').length).toBe(0)
+          wrapper.unmount()
+          done()
+        })
+    })
   })
 
   describe('Scrollable', () => {
@@ -156,8 +193,6 @@ describe('Modal', () => {
           <div id='modals' />
         </div>
       )
-      expect($('.modal').length).toBe(0)
-
       $('.trigger')[0].click()
 
       wait(100)
@@ -188,8 +223,6 @@ describe('Modal', () => {
           <div id='modals' />
         </div>
       )
-      expect($('.modal').length).toBe(0)
-
       $('.trigger')[0].click()
 
       wait(100)

--- a/test/acceptance/test-helpers.js
+++ b/test/acceptance/test-helpers.js
@@ -16,7 +16,8 @@ document.body.appendChild(mountNode)
 
 const mountHelper = (component) => {
   window.BluePortalWrapperGlobalManager = null
-  mountNode.innerHTML = ''
+  mountNode.innerHTML = '<div id="HSBluePortalContainer"></div>'
+  // mountNode.innerHTML = ''
   const wrapper = mount(component, { attachTo: mountNode })
   return wrapper
 }


### PR DESCRIPTION
## Modal: Can open/close with isOpen prop change

This update fixes PortalWrapper to open/close the composed component
(Modal, Drop) with an isOpen prop change.

Jest tests were added for PortalWrapper, Modal and Drop. Karma tests were
also added for Modal.

Resolves: https://github.com/helpscout/blue/issues/164