### PR TITLE
Modal: Provide delay for CloseButton reposition

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -25,6 +25,6 @@ if (!process.env.CI && argv.indexOf('--coverage') < 0) {
 
 // Optimize for CI
 // https://github.com/facebook/jest/issues/3855#issuecomment-309521581
-argv.push('--maxWorkers=4')
+argv.push('--runInBand')
 
 jest.run(argv)

--- a/src/components/Collapsible/tests/Collapsible.test.js
+++ b/src/components/Collapsible/tests/Collapsible.test.js
@@ -17,7 +17,7 @@ describe('onOpen', () => {
     const wrapper = mount(<Collapsible onOpen={spy} duration={0} />)
     wrapper.setProps({ isOpen: true })
 
-    wait(60)
+    wait(120)
       .then(() => {
         expect(spy).toHaveBeenCalled()
         wrapper.unmount()

--- a/src/components/Modal/docs/Footer.md
+++ b/src/components/Modal/docs/Footer.md
@@ -1,6 +1,6 @@
 # Footer
 
-A Modal.Footer component contains content that appears at the top of a [Modal](./Modal.md). This component is constructed using [Toolbar](../Toolbar).
+A Modal.Footer component contains content that appears at the top of a [Modal](./Modal.md). This component is constructed using [Toolbar](../../Toolbar).
 
 
 ## Example
@@ -23,4 +23,4 @@ A Modal.Footer component contains content that appears at the top of a [Modal](.
 | --- | --- | --- |
 | className | `string` | Custom class names to be added to the component. |
 
-For more props, check out [Toolbar](../Toolbar).
+For more props, check out [Toolbar](../../Toolbar).

--- a/src/components/Modal/docs/Header.md
+++ b/src/components/Modal/docs/Header.md
@@ -1,6 +1,6 @@
 # Header
 
-A Modal.Header component contains content that appears at the top of a [Modal](./Modal.md). This component is constructed using [Toolbar](../Toolbar).
+A Modal.Header component contains content that appears at the top of a [Modal](./Modal.md). This component is constructed using [Toolbar](../../Toolbar).
 
 
 ## Example
@@ -40,4 +40,4 @@ By default, a [CloseButton](../CloseButton) appears at the top right-hand side o
 | --- | --- | --- |
 | className | `string` | Custom class names to be added to the component. |
 
-For more props, check out [Toolbar](../Toolbar).
+For more props, check out [Toolbar](../../Toolbar).

--- a/src/components/Modal/docs/Modal.md
+++ b/src/components/Modal/docs/Modal.md
@@ -32,12 +32,13 @@ A Modal component presents content within a container on top of the application'
 | --- | --- | --- |
 | className | `string` | Custom class names to be added to the component. |
 | closeIcon | `bool` | Shows/hides the component's close icon UI. |
+| closeIconRepositionDelay | `number ` | Amount of time before the [CloseButton](../../CloseButton) gets repositioned. |
 | exact | `bool` | Used with `path` and React Router. Renders if path matches _exactly_ |
 | isOpen | `bool` | Shows/hides the component. |
 | path | `string` | Renders component based on a [React Router path](https://reacttraining.com/react-router/web/api/Route/path-string). |
 | seamless | `bool` | Renders content with the standard [Card](../Card) UI. |
 | trigger | `element` | The UI the user clicks to trigger the modal. |
-| wrapperClassName | `string` | Custom className to add to the [PortalWrapper](../PortalWrapper) component. |
+| wrapperClassName | `string` | Custom className to add to the [PortalWrapper](../../PortalWrapper) component. |
 
 
 ### Render hooks
@@ -51,4 +52,4 @@ This component has special callback props tied into it's mounting cycle.
 | onBeforeClose | `function` | Fires when the component is about to unmount. |
 | onClose | `function` | Fires after the component is unmounted. |
 
-See [Portal's documentation](../Portal#render-hooks) for more details.
+See [Portal's documentation](../../Portal#render-hooks) for more details.

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -36,7 +36,7 @@ const defaultProps = {
   closeIcon: true,
   seamless: false,
   isOpen: false,
-  closeIconRepositionDelay: 100,
+  closeIconRepositionDelay: 50,
   modalAnimationDelay: {
     in: 200,
     out: 100

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -19,6 +19,7 @@ import getScrollbarWidth from '../../vendors/getScrollbarWidth'
 export const propTypes = Object.assign({}, portalTypes, {
   closeIcon: PropTypes.bool,
   seamless: PropTypes.bool,
+  closeIconRepositionDelay: PropTypes.number,
   modalAnimationDelay: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.object
@@ -35,6 +36,7 @@ const defaultProps = {
   closeIcon: true,
   seamless: false,
   isOpen: false,
+  closeIconRepositionDelay: 100,
   modalAnimationDelay: {
     in: 200,
     out: 100
@@ -63,9 +65,10 @@ const scrollbarWidth = getScrollbarWidth()
 class Modal extends Component {
   constructor () {
     super()
-    this.handleOnResize = this.handleOnResize.bind(this)
     this.closeNode = null
     this.scrollableNode = null
+    this.handleOnResize = this.handleOnResize.bind(this)
+    this.positionCloseNode = this.positionCloseNode.bind(this)
   }
 
   componentDidMount () {
@@ -78,19 +81,27 @@ class Modal extends Component {
   }
 
   positionCloseNode (scrollableNode) {
+    const { modalAnimationDelay, closeIconRepositionDelay } = this.props
     const scrollNode = scrollableNode || this.scrollableNode
     if (
       !this.closeNode ||
       !isNodeElement(scrollNode)
     ) return
 
+    let delay = modalAnimationDelay && modalAnimationDelay.in
+    /* istanbul ignore next */
+    delay = delay < modalAnimationDelay ? delay : closeIconRepositionDelay
+
     const defaultOffset = 8
     const borderOffset = 2
-    const offset = hasContentOverflowY(scrollNode)
-      ? /* istanbul ignore next */ `${scrollbarWidth + borderOffset}px`
-      : `${defaultOffset}px`
 
-    this.closeNode.style.right = offset
+    setTimeout(() => {
+      const offset = hasContentOverflowY(scrollNode)
+        ? /* istanbul ignore next */ `${scrollbarWidth + borderOffset}px`
+        : `${defaultOffset}px`
+
+      this.closeNode.style.right = offset
+    }, delay)
   }
 
   getChildContext () {
@@ -104,17 +115,18 @@ class Modal extends Component {
       children,
       className,
       closeIcon,
+      closeIconRepositionDelay,
       closePortal,
       exact,
       isOpen,
       modalAnimationDelay,
-      openPortal,
       onClose,
       onScroll,
+      openPortal,
       overlayAnimationDelay,
       path,
-      portalIsOpen,
       portalIsMounted,
+      portalIsOpen,
       seamless,
       style,
       timeout,

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -609,14 +609,14 @@ describe('isOpen', () => {
   test('Can open wrapped component with isOpen prop change to true', (done) => {
     const wrapper = mount(<Modal />)
 
-    wait()
+    wait(60)
       .then(() => {
         const o = document.body.childNodes[0]
         expect(o).not.toBeTruthy()
 
         wrapper.setProps({ isOpen: true })
       })
-      .then(() => wait(50))
+      .then(() => wait(MODAL_TEST_TIMEOUT))
       .then(() => {
         const o = document.body.childNodes[0]
         expect(o).toBeTruthy()

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -49,7 +49,7 @@ describe('Key events', () => {
   test('Closes modal when ESCAPE is pressed', (done) => {
     mount(<Modal isOpen trigger={trigger} />)
 
-    wait(40)
+    wait(60)
       .then(() => {
         const portal = document.body.childNodes[0]
         const modal = portal.getElementsByClassName('c-Modal')[0]
@@ -71,7 +71,7 @@ describe('CloseIcon', () => {
   test('Does not render closeIcon if specified', (done) => {
     const wrapper = mount(<Modal isOpen trigger={trigger} closeIcon={false} />)
 
-    wait(40)
+    wait(60)
       .then(() => {
         const portal = document.body.childNodes[0]
         const modal = portal.getElementsByClassName('c-Modal')[0]
@@ -112,7 +112,7 @@ describe('Portal', () => {
   test('Renders at the body', (done) => {
     const wrapper = mount(<Modal isOpen trigger={trigger} />)
 
-    wait(40)
+    wait(60)
       .then(() => {
         const portal = document.body.childNodes[0]
         const modal = portal.getElementsByClassName('c-Modal')[0]
@@ -150,7 +150,7 @@ describe('Route', () => {
       </Router>
     , { attachTo: testBody })
 
-    wait(40)
+    wait(60)
       .then(() => {
         const modal = global.document.getElementsByClassName('c-Modal')[0]
 
@@ -178,7 +178,7 @@ describe('Route', () => {
       .then(() => {
         wrapper.node.history.goBack()
       })
-      .then(() => wait(40))
+      .then(() => wait(60))
       .then(() => {
         const modal = global.document.getElementsByClassName('c-Modal')[0]
 
@@ -202,7 +202,7 @@ describe('Route', () => {
       </Router>
     , { attachTo: testBody })
 
-    wait(40)
+    wait(60)
       .then(() => {
         const modal = global.document.getElementsByClassName('c-Modal')[0]
 
@@ -221,7 +221,7 @@ describe('Style', () => {
       <Modal isOpen trigger={trigger} closeIcon={false} style={style} />
     )
 
-    wait(40)
+    wait(60)
       .then(() => {
         const portal = document.body.childNodes[0]
         const modal = portal.getElementsByClassName('c-Modal')[0]
@@ -242,7 +242,7 @@ describe('Style', () => {
     const style = { background: 'red' }
     const wrapper = mount(<Modal isOpen trigger={trigger} closeIcon={false} style={style} zIndex={2000} />)
 
-    wait(40)
+    wait(60)
       .then(() => {
         const portal = document.body.childNodes[0]
         const modal = portal.getElementsByClassName('c-Modal')[0]
@@ -263,7 +263,7 @@ describe('Style', () => {
   test('Can render zIndex, without style prop', (done) => {
     const wrapper = mount(<Modal isOpen trigger={trigger} closeIcon={false} zIndex={2000} />)
 
-    wait(40)
+    wait(60)
       .then(() => {
         const portal = document.body.childNodes[0]
         const modal = portal.getElementsByClassName('c-Modal')[0]
@@ -297,7 +297,7 @@ describe('PortalWrapper', () => {
       <Modal onBeforeClose={onBeforeClose} isOpen />
     , { attachTo: testBody })
 
-    wait(40)
+    wait(60)
       .then(() => {
         wrapper.unmount()
       })
@@ -342,7 +342,7 @@ describe('wrapperClassName', () => {
   test('Adds default wrapperClassName', (done) => {
     mount(<Modal isOpen trigger={trigger} />)
 
-    wait(40).then(() => {
+    wait(60).then(() => {
       const o = document.body.childNodes[0]
       expect(o.className).toContain('c-ModalWrapper')
       done()
@@ -352,7 +352,7 @@ describe('wrapperClassName', () => {
   test('Can customize wrapperClassName', (done) => {
     mount(<Modal isOpen trigger={trigger} wrapperClassName='ron' />)
 
-    wait(40).then(() => {
+    wait(60).then(() => {
       const o = document.body.childNodes[0]
       expect(o.className).toContain('ron')
       expect(o.className).toContain('c-ModalWrapper')

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -84,7 +84,7 @@ describe('CloseIcon', () => {
       })
   })
 
-  test('Adjusts CloseButton position on mount', () => {
+  test('Adjusts CloseButton position on mount', (done) => {
     const wrapper = mount(
       <ModalComponent isOpen>
         <Modal.Body />
@@ -92,7 +92,11 @@ describe('CloseIcon', () => {
     )
     const o = wrapper.find('.c-Modal__close')
 
-    expect(o.html()).toContain('right:')
+    wait(200)
+      .then(() => {
+        expect(o.html()).toContain('right:')
+        done()
+      })
   })
 })
 

--- a/test/acceptance/components/Modal.spec.js
+++ b/test/acceptance/components/Modal.spec.js
@@ -225,7 +225,7 @@ describe('Modal', () => {
       )
       $('.trigger')[0].click()
 
-      wait(100)
+      wait(300)
         .then(() => {
           const scrollbarWidth = getScrollbarWidth()
           const right = parseInt($('.c-Modal__close').css('right'), 10)


### PR DESCRIPTION
## Modal: Provide delay for CloseButton reposition

This update adds a new prop to `Modal`, which provides a delayed time before
the CloseButton is repositiioned (if the CloseButton is enabled).

This is necessary for certain situations where content that's injected into
the `Modal.Body` changes size, from a no-scrollbar state to a scrollbar state.
An example would be media (like images) unfurling during the mount state,
which is hidden via the Animation transition.

This is very edge-case, but it's something that I saw during Beacon
integration.