### PR TITLE
Card: Add fullHeight styles

### DIFF
--- a/src/components/Card/docs/Card.md
+++ b/src/components/Card/docs/Card.md
@@ -30,6 +30,7 @@ If a `to` or `href` prop is passed into the Card component, it will render the [
 | borderless | `bool` | Removes the border from the component. |
 | className | `string` | Custom class names to be added to the component. |
 | flex | `bool` | Adds flexbox styles to the component. |
+| fullHeight | `bool` | Adds full height styles. Often used with flex containers. |
 | hover | `bool` | Adds a hover style to the component. |
 | href | `string` | Adds an `href` to the component. Transforms it into an `<a>` tag. |
 | onBlur | `function` | Callback when the component is blurred. |

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -11,6 +11,7 @@ export const propTypes = Object.assign({}, linkPropTypes, {
   className: PropTypes.string,
   floating: PropTypes.bool,
   flex: PropTypes.bool,
+  fullHeight: PropTypes.bool,
   hover: PropTypes.bool,
   href: PropTypes.string,
   onBlur: PropTypes.func,
@@ -21,6 +22,10 @@ export const propTypes = Object.assign({}, linkPropTypes, {
 })
 
 const defaultProps = {
+  borderless: false,
+  flex: false,
+  floating: false,
+  fullHeight: false,
   hover: false,
   onBlur: noop,
   onClick: noop,
@@ -36,6 +41,7 @@ const Card = props => {
     children,
     floating,
     flex,
+    fullHeight,
     hover,
     href,
     onClick,
@@ -54,6 +60,7 @@ const Card = props => {
     borderless && 'is-borderless',
     floating && 'is-floating',
     flex && 'is-flex',
+    fullHeight && 'is-fullHeight',
     href && 'is-link',
     seamless && 'is-seamless',
     className

--- a/src/components/Card/tests/Card.test.js
+++ b/src/components/Card/tests/Card.test.js
@@ -212,6 +212,12 @@ describe('Styles', () => {
     expect(wrapper.hasClass('is-flex')).toBeTruthy()
   })
 
+  test('Renders fullHeight styles, if specified', () => {
+    const wrapper = shallow(<Card fullHeight />)
+
+    expect(wrapper.hasClass('is-fullHeight')).toBeTruthy()
+  })
+
   test('Renders floating styles, if specified', () => {
     const wrapper = shallow(<Card floating />)
 

--- a/src/components/Heading/README.md
+++ b/src/components/Heading/README.md
@@ -14,8 +14,10 @@ A Heading component is a light-weight text heading wrapper enhanced with a colle
 | Prop | Type | Description |
 | --- | --- | --- |
 | className | `string` | Custom class names to be added to the component. |
+| center | `bool` | Center aligns text. |
 | disableSelect | `bool` | Disables text selection. |
 | light | `bool` | Lightens the heading color. |
+| linkStyle | `bool` | Applies [Link](../Link) styles. |
 | lineHeightReset | `bool` | Sets the line-height to `1`. |
 | selector | `string` | Determines HTML selector. Default is `div`. |
 | size | `string` | Adjust heading size. |

--- a/src/components/Heading/index.js
+++ b/src/components/Heading/index.js
@@ -4,26 +4,32 @@ import classNames from '../../utilities/classNames'
 import { sizeTypes } from './propTypes'
 
 export const propTypes = {
+  center: PropTypes.bool,
   className: PropTypes.string,
   disableSelect: PropTypes.bool,
   light: PropTypes.bool,
   lineHeightReset: PropTypes.bool,
+  linkStyle: PropTypes.bool,
   selector: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   size: sizeTypes
 }
 
 const defaultProps = {
+  center: false,
   disableSelect: false,
+  linkStyle: false,
   selector: false
 }
 
 const Heading = props => {
   const {
+    center,
     children,
     className,
     disableSelect,
     light,
     lineHeightReset,
+    linkStyle,
     selector,
     size,
     ...rest
@@ -31,9 +37,11 @@ const Heading = props => {
 
   const componentClassName = classNames(
     'c-Heading',
+    center && 'is-center',
     disableSelect && 'is-disableSelect',
     light && 'is-light',
     lineHeightReset && 'is-line-height-reset',
+    linkStyle && 'is-linkStyle',
     size && `is-${size}`,
     className
   )

--- a/src/components/Heading/tests/Heading.test.js
+++ b/src/components/Heading/tests/Heading.test.js
@@ -54,6 +54,18 @@ describe('Styles', () => {
     expect(wrapper.prop('className')).toContain('is-disableSelect')
   })
 
+  test('Applies center styles if specified', () => {
+    const wrapper = shallow(<Heading center />)
+
+    expect(wrapper.prop('className')).toContain('is-center')
+  })
+
+  test('Applies link-style styles if specified', () => {
+    const wrapper = shallow(<Heading linkStyle />)
+
+    expect(wrapper.prop('className')).toContain('is-linkStyle')
+  })
+
   test('Applies light styles if specified', () => {
     const wrapper = shallow(<Heading light />)
 

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -14,9 +14,11 @@ A Text component is a light-weight text wrapper enhanced with a collection of ae
 | Prop | Type | Description |
 | --- | --- | --- |
 | className | `string` | Custom class names to be added to the component. |
+| center | `bool` | Center aligns text. |
 | disableSelect | `bool` | Disables text selection. |
 | faint | `bool` | Changes text color to a very light grey. |
 | muted | `bool`  | Changes text color to a light grey. |
+| linkStyle | `bool` | Applies [Link](../Link) styles. |
 | size | `string` | Adjust text size. |
 | state | `string` | Changes the text color based on state. |
 | subtle | `bool` | Changes text color to a lighter grey. |

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -8,9 +8,11 @@ export const propTypes = {
   allCaps: PropTypes.bool,
   block: PropTypes.bool,
   className: PropTypes.string,
+  center: PropTypes.bool,
   disableSelect: PropTypes.bool,
   faint: PropTypes.bool,
   lineHeightReset: PropTypes.bool,
+  linkStyle: PropTypes.bool,
   muted: PropTypes.bool,
   noWrap: PropTypes.bool,
   selector: PropTypes.oneOf(['span', 'pre', 'samp']),
@@ -22,7 +24,9 @@ export const propTypes = {
 }
 
 const defaultProps = {
+  center: false,
   disableSelect: false,
+  linkStyle: false,
   selector: 'span',
   truncate: false
 }
@@ -33,9 +37,11 @@ const Text = props => {
     block,
     children,
     className,
+    center,
     disableSelect,
     faint,
     lineHeightReset,
+    linkStyle,
     muted,
     noWrap,
     selector,
@@ -51,11 +57,13 @@ const Text = props => {
     'c-Text',
     allCaps && 'is-all-caps',
     block && 'is-block',
+    center && 'is-center',
     disableSelect && 'is-disableSelect',
     faint && 'is-faint',
     muted && 'is-muted',
     noWrap && 'is-no-wrap',
     lineHeightReset && 'is-line-height-reset',
+    linkStyle && 'is-linkStyle',
     selector && `is-${selector}`,
     size && `is-${size}`,
     state && `is-${state}`,

--- a/src/components/Text/tests/Text.test.js
+++ b/src/components/Text/tests/Text.test.js
@@ -70,6 +70,18 @@ describe('Styles', () => {
     expect(wrapper.prop('className')).toContain('is-truncate')
   })
 
+  test('Applies center styles if specified', () => {
+    const wrapper = shallow(<Text center />)
+
+    expect(wrapper.prop('className')).toContain('is-center')
+  })
+
+  test('Applies link-style styles if specified', () => {
+    const wrapper = shallow(<Text linkStyle />)
+
+    expect(wrapper.prop('className')).toContain('is-linkStyle')
+  })
+
   test('Applies line-height reset styles if specified', () => {
     const wrapper = shallow(<Text lineHeightReset />)
 

--- a/src/styles/components/Card/Card.scss
+++ b/src/styles/components/Card/Card.scss
@@ -43,6 +43,10 @@ $seed-card-border: 1px solid rgba(_color(border, ui, dark), 0.7);
     width: 100%;
   }
 
+  &.is-fullHeight {
+    height: 100%;
+  }
+
   &.is-hoverable {
     box-shadow: #{
       0 1px 3px 0 rgba(black, 0.1),

--- a/src/styles/components/Heading.scss
+++ b/src/styles/components/Heading.scss
@@ -3,6 +3,7 @@
 .c-Heading {
   @import "../configs/color";
   @import "../configs/font";
+  @import "../mixins/linkStyles";
   // Config
   $shades: (
     light: _color(charcoal, 200),
@@ -71,6 +72,15 @@
       color: $value;
     }
   }
+
+  &.is-center {
+    text-align: center;
+  }
+
+  &.is-linkStyle {
+    @include linkStyles();
+  }
+
 
   // Resets
   &.is-line-height-reset {

--- a/src/styles/components/Link.scss
+++ b/src/styles/components/Link.scss
@@ -1,21 +1,8 @@
-@import "../configs/color";
+@import "../mixins/linkStyles";
 
 .c-Link {
   @import "../resets/base";
-  color: _color(blue, 500);
-  cursor: pointer;
-  text-decoration: none;
-
-  &:hover {
-    color: _color(blue, 400);
-    outline-width: 0;
-    text-decoration: underline;
-  }
-
-  &:active {
-    color: _color(blue, 400);
-    outline-width: 0;
-  }
+  @include linkStyles();
 
   &:focus {
     outline: 5px auto -webkit-focus-ring-color;

--- a/src/styles/components/Text.scss
+++ b/src/styles/components/Text.scss
@@ -3,6 +3,7 @@
 
 .c-Text {
   @import "../configs/color";
+  @import "../mixins/linkStyles";
   @import "../resets/base";
   $states: $STATES;
   $shades: faint, muted, subtle;
@@ -66,6 +67,14 @@
 
   &.is-block {
     display: block;
+  }
+
+  &.is-center {
+    text-align: center;
+  }
+
+  &.is-linkStyle {
+    @include linkStyles();
   }
 
   &.is-samp {

--- a/src/styles/mixins/linkStyles.scss
+++ b/src/styles/mixins/linkStyles.scss
@@ -1,0 +1,18 @@
+@import "../configs/color";
+
+@mixin linkStyles () {
+  color: _color(blue, 500);
+  cursor: pointer;
+  text-decoration: none;
+
+  &:hover {
+    color: _color(blue, 400);
+    outline-width: 0;
+    text-decoration: underline;
+  }
+
+  &:active {
+    color: _color(blue, 400);
+    outline-width: 0;
+  }
+}


### PR DESCRIPTION
## Card: Add fullHeight styles

This update adds a new prop to the Card component allowing it to have
full height styles (`height: 100%`). This is useful for when the Card
is contained within a flex-based element, and you require the Card
to expand the entire height of the parent element.

## Text/Heading: Add `linkStyle` and `center` styles

This update updates the Text and Heading components with 2 new props:
`linkStyle` and `center`. This props apply CSS styles that make the
text look like Links and center-align text (respectively).