### PR TITLE
Utilities: Expose all of Blue's utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
       "src/**/*.{js,jsx}",
       "!src/tests/helpers/**/*.{js,jsx}",
       "!src/utilities/smoothScroll.{js,jsx}",
+      "!src/utilities/index.{js,jsx}",
       "!src/utilities/log.{js,jsx}",
       "!src/vendors/**/*.{js,jsx}",
       "!src/components/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,2 @@
-import { classNames, variantClassNames } from './utilities/classNames'
-import { createUniqueIDFactory } from './utilities/id'
-
+export {default as utilities} from './utilities'
 export * from './components'
-
-export const utilities = {
-  classNames,
-  createUniqueIDFactory,
-  variantClassNames
-}

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -1,0 +1,31 @@
+import * as animation from './animation'
+import * as classNames from './classNames'
+import * as component from './component'
+import * as easing from './easing'
+import * as focus from './focus'
+import * as globalManager from './globalManager'
+import * as id from './id'
+import * as node from './node'
+import * as nodePosition from './nodePosition'
+import * as other from './other'
+import * as scrollFade from './scrollFade'
+import * as smoothScroll from './smoothScroll'
+import * as strings from './strings'
+import * as types from './types'
+
+export default {
+  animation,
+  classNames,
+  component,
+  easing,
+  focus,
+  globalManager,
+  id,
+  node,
+  nodePosition,
+  other,
+  scrollFade,
+  smoothScroll,
+  strings,
+  types
+}

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -1,17 +1,32 @@
-import * as animation from './animation'
-import * as classNames from './classNames'
-import * as component from './component'
-import * as easing from './easing'
-import * as focus from './focus'
-import * as globalManager from './globalManager'
-import * as id from './id'
-import * as node from './node'
-import * as nodePosition from './nodePosition'
-import * as other from './other'
-import * as scrollFade from './scrollFade'
-import * as smoothScroll from './smoothScroll'
-import * as strings from './strings'
-import * as types from './types'
+import * as animationUtils from './animation'
+import * as classNamesUtils from './classNames'
+import * as componentUtils from './component'
+import * as easingUtils from './easing'
+import * as focusUtils from './focus'
+import * as globalManagerUtils from './globalManager'
+import * as idUtils from './id'
+import * as nodeUtils from './node'
+import * as nodePositionUtils from './nodePosition'
+import * as otherUtils from './other'
+import * as scrollFadeUtils from './scrollFade'
+import * as smoothScrollUtils from './smoothScroll'
+import * as stringsUtils from './strings'
+import * as typesUtils from './types'
+
+export const animation = animationUtils
+export const classNames = classNamesUtils
+export const component = componentUtils
+export const easing = easingUtils
+export const focus = focusUtils
+export const globalManager = globalManagerUtils
+export const id = idUtils
+export const node = nodeUtils
+export const nodePosition = nodePositionUtils
+export const other = otherUtils
+export const scrollFade = scrollFadeUtils
+export const smoothScroll = smoothScrollUtils
+export const strings = stringsUtils
+export const types = typesUtils
 
 export default {
   animation,

--- a/src/utilities/tests/index.test.js
+++ b/src/utilities/tests/index.test.js
@@ -1,0 +1,22 @@
+import { default as utils, easing, node, other } from '../index'
+
+test('Can import a simple utility', () => {
+  expect(other).toBeTruthy()
+  expect(typeof other).toBe('object')
+})
+
+test('Can import a utility with nested dependencies', () => {
+  expect(easing).toBeTruthy()
+  expect(typeof easing).toBe('object')
+})
+
+test('Can import all utils', () => {
+  expect(utils).toBeTruthy()
+  expect(typeof utils).toBe('object')
+  expect(utils.other).toBe(other)
+})
+
+test('Can use imported util', () => {
+  const { isNodeElement } = node
+  expect(isNodeElement(true)).not.toBe(true)
+})


### PR DESCRIPTION
## Utilities: Expose all of Blue's utils

This update exposes all of Blue's utils, making them available to be
imported and used.

All of the utilities come bundled within a `utilities` object.

**Example**
```
import { smoothScroll } from '@helpscout/blue/utilities'

// Now you can do things with smoothScroll.smoothScrollTo()!
```

Alternatively, you can do this (which might not be recommended, as it imports all the utils):
```js
import { utilities } from '@helpscout/blue'

const {
  smoothScroll
} = utilities

// Now you can do things with smoothScroll.smoothScrollTo()!
```
