### PR TITLE
Card: Fix autoWordWrap prop use for non-Links

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -36,6 +36,7 @@ const defaultProps = {
 
 const Card = props => {
   const {
+    autoWordWrap,
     borderless,
     className,
     children,
@@ -68,6 +69,7 @@ const Card = props => {
 
   const element = href || to ? (
     <Link
+      autoWordWrap={autoWordWrap}
       block
       className={componentClassName}
       onClick={onClick}

--- a/src/components/Card/tests/Card.test.js
+++ b/src/components/Card/tests/Card.test.js
@@ -164,6 +164,20 @@ describe('Link', () => {
 
     expect(spy).toHaveBeenCalled()
   })
+
+  test('Does not pass autoWordWrap prop to div', () => {
+    const wrapper = shallow(<Card autoWordWrap />)
+    const o = wrapper.find('.c-Card')
+
+    expect(o.props().autoWordWrap).toBeFalsy()
+  })
+
+  test('Can pass autoWordWrap to Link', () => {
+    const wrapper = shallow(<Card href={link} autoWordWrap />)
+    const o = wrapper.find('.c-Card')
+
+    expect(o.props().autoWordWrap).toBeTruthy()
+  })
 })
 
 describe('Click', () => {


### PR DESCRIPTION
## Card: Fix autoWordWrap prop use for non-Links

This update resolves the issue with `Card` when passing in the `autoWordWrap`
prop for non-Link use. Previously, it would pass the prop into a `div`
selector, resulting in a warning.

Tests have been added for this update! :tada: