### PR TITLE
Avatar: Adjust sizing

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -25,6 +25,7 @@ export const propTypes = {
 const defaultProps = {
   light: false,
   name: '',
+  size: 'md',
   shape: 'circle'
 }
 

--- a/src/components/AvatarStack/README.md
+++ b/src/components/AvatarStack/README.md
@@ -13,6 +13,7 @@ An AvatarStack component displays an array of [Avatars](../Avatar). This compone
 | Prop | Type | Description |
 | --- | --- | --- |
 | avatars | `array` | A list of [Avatars](../Avatar).]
+| avatarsClassName | `string` | Custom className to pass to [Avatars](../Avatar). |
 | borderColor | `string` | Color for the Avatar border. |
 | className | `string` | Custom class names to be added to the component. |
 | max | `number` | Number of avatars to display before truncating. |

--- a/src/components/AvatarStack/index.js
+++ b/src/components/AvatarStack/index.js
@@ -9,6 +9,7 @@ import { standardSizeTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   avatars: PropTypes.arrayOf(PropTypes.shape(avatarTypes)),
+  avatarsClassName: PropTypes.string,
   borderColor: PropTypes.string,
   max: PropTypes.number,
   size: standardSizeTypes
@@ -23,6 +24,7 @@ const defaultProps = {
 const AvatarStack = props => {
   const {
     avatars,
+    avatarsClassName,
     borderColor,
     className,
     max,
@@ -43,6 +45,7 @@ const AvatarStack = props => {
     <div className='c-AvatarStack__item'>
       <Avatar
         borderColor={borderColor}
+        className={avatarsClassName}
         size={size}
         name={`+${additionalAvatarCount}`}
         count={`+${additionalAvatarCount}`}
@@ -54,8 +57,17 @@ const AvatarStack = props => {
     const zIndex = (avatarList.length - index) + 1
 
     return (
-      <div className='c-AvatarStack__item' style={{zIndex}} key={`${avatarProps.name}-${index}`}>
-        <Avatar borderColor={borderColor} size={size} {...avatarProps} />
+      <div
+        className='c-AvatarStack__item'
+        key={`${avatarProps.name}-${index}`}
+        style={{zIndex}}
+      >
+        <Avatar
+          {...avatarProps}
+          borderColor={borderColor}
+          className={avatarsClassName}
+          size={size}
+        />
       </div>
     )
   })

--- a/src/components/AvatarStack/tests/AvatarStack.test.js
+++ b/src/components/AvatarStack/tests/AvatarStack.test.js
@@ -35,6 +35,15 @@ describe('Avatars', () => {
 
     expect(avatar.length).toBe(4)
   })
+
+  test('Passes avatarsClassName to Avatar', () => {
+    const wrapper = shallow(
+      <AvatarStack avatars={avatars} avatarsClassName='ron' />
+    )
+    const avatar = wrapper.find(Avatar).first()
+
+    expect(avatar.hasClass('ron')).toBe(true)
+  })
 })
 
 describe('Border Color', () => {
@@ -77,11 +86,11 @@ describe('Limit', () => {
 })
 
 describe('Size', () => {
-  test('Does not have a default size', () => {
+  test('Should have a default size', () => {
     const wrapper = shallow(<AvatarStack avatars={avatars} />)
     const avatar = wrapper.find(Avatar).first()
 
-    expect(avatar.props().size).toBe(undefined)
+    expect(avatar.props().size).toBe('md')
   })
 
   test('Apply size classes', () => {

--- a/src/styles/components/Avatar.scss
+++ b/src/styles/components/Avatar.scss
@@ -12,7 +12,7 @@
       font-size: 13px,
     ),
     md: (
-      size: 42px,
+      size: 46px,
       font-size: 13px,
     ),
     sm: (


### PR DESCRIPTION
## Avatar: Adjust sizing

![screen shot 2018-01-03 at 12 34 58 pm](https://user-images.githubusercontent.com/2322354/34532027-87ab2c58-f082-11e7-9ca4-ae47c4e6506d.jpg)

(Screenshot from Sketch)

This update adjusts the `md` sizing for the Avatars to match the
pattern library (created by @digitaldesigner). The Avatar components have also been provided with a default
`size` prop of `md`.

Lastly, `AvatarStack` has been enhanced with a new prop, `avatarClassName`.
This allows you to pass in a custom className to the child Avatars.
  