### PR TITLE
Portal: Performance

### DIFF
--- a/src/components/Animate/index.js
+++ b/src/components/Animate/index.js
@@ -276,5 +276,6 @@ export const getWait = (wait, sequence) => {
 
 Animate.propTypes = propTypes
 Animate.defaultProps = defaultProps
+Animate.displayName = 'Animate'
 
 export default Animate

--- a/src/components/Portal/index.js
+++ b/src/components/Portal/index.js
@@ -27,7 +27,7 @@ const defaultProps = {
   timeout: 0
 }
 
-class Portal extends React.Component {
+class Portal extends React.PureComponent {
   constructor (props) {
     super()
     this.node = null
@@ -182,5 +182,6 @@ class Portal extends React.Component {
 Portal.propTypes = types
 Portal.defaultProps = defaultProps
 Portal.Container = Container
+Portal.displayName = 'Portal'
 
 export default Portal

--- a/src/components/PortalWrapper/index.js
+++ b/src/components/PortalWrapper/index.js
@@ -125,7 +125,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
         path,
         renderTo,
         trigger,
-        timeout,
+        timeout: propsTimeOut,
         wrapperClassName: propsWrapperClassName,
         ...rest
       } = this.props
@@ -133,6 +133,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
       const {
         id, isOpen: portalIsMounted,
         isMounted: portalIsOpen,
+        timeout,
         wrapperClassName
       } = this.state
 
@@ -147,7 +148,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
           animateOnMount={false}
           in={portalIsMounted}
           unmountOnExit
-          wait={this.state.timeout}
+          wait={timeout}
         >
           <Portal
             className={wrapperClassName}
@@ -158,7 +159,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
             id={id}
             renderTo={renderTo}
             portalIsMounted={portalIsMounted}
-            timeout={this.state.timeout}
+            timeout={timeout}
             {...rest}
           >
             <Content
@@ -206,6 +207,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
   }
   PortalWrapper.propTypes = propTypes
   PortalWrapper.defaultProps = defaultProps
+  PortalWrapper.displayName = 'PortalWrapper'
 
   return PortalWrapper
 }


### PR DESCRIPTION
## Portal: Improve performance

This update provides a slight performance enhancement to the Portal component
by making it extend `PureComponent` instead of `Component` from React.

This prevents some re-renders during the `shouldComponentUpdate` diff'ing
during the render cycle.