### PR TITLE
Colors: Add ExtraMuted

### DIFF
--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -19,6 +19,17 @@ An Icon component renders an SVG icon.
 | muted | `bool` | Applies muted styles. |
 | name | `string` | Determines the SVG image. Required. |
 | onClick | `function` | Callback function when component is clicked. |
+| shade | `string` | Changes icon color shade. |
 | size | `number`/`string` | Adjusts the size of the component. |
 | title | `string` | Provides a name for the component. |
 | withCaret | `bool` | Renders a caret icon, next to the component's SVG icon. |
+
+
+### Shades
+
+| Prop | Description |
+| --- | --- |
+| `subtle` | Medium-light grey. |
+| `muted` | Lighter grey. |
+| `faint` | Very lighter grey. |
+| `extraMuted` | Extra light grey. |

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -4,6 +4,7 @@ import ICONS from './icons'
 import VisuallyHidden from '../VisuallyHidden'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
+import { textShadeTypes } from '../../constants/propTypes'
 import { sizeTypes } from './propTypes'
 
 export const propTypes = {
@@ -16,6 +17,7 @@ export const propTypes = {
   muted: PropTypes.bool,
   name: PropTypes.string.isRequired,
   onClick: PropTypes.func,
+  shade: textShadeTypes,
   size: sizeTypes,
   subtle: PropTypes.bool,
   title: PropTypes.string,
@@ -44,6 +46,7 @@ const Icon = props => {
     muted,
     onClick,
     name,
+    shade,
     size,
     subtle,
     title,
@@ -59,6 +62,7 @@ const Icon = props => {
     faint && 'is-faint',
     inline && 'is-inline',
     muted && 'is-muted',
+    shade && `is-${shade}`,
     subtle && 'is-subtle',
     size && `is-${size}`,
     withCaret && 'is-withCaret',

--- a/src/components/Icon/tests/Icon.test.js
+++ b/src/components/Icon/tests/Icon.test.js
@@ -47,6 +47,14 @@ describe('Sizes', () => {
   })
 })
 
+describe('Shade', () => {
+  test('Add shade styles if applied', () => {
+    const wrapper = shallow(<Icon name='emoji' shade='muted' />)
+
+    expect(wrapper.prop('className')).toContain('is-muted')
+  })
+})
+
 describe('Styles', () => {
   test('Add center styles if applied', () => {
     const wrapper = shallow(<Icon name='emoji' center />)

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -19,10 +19,21 @@ A Text component is a light-weight text wrapper enhanced with a collection of ae
 | faint | `bool` | Changes text color to a very light grey. |
 | muted | `bool`  | Changes text color to a light grey. |
 | linkStyle | `bool` | Applies [Link](../Link) styles. |
+| shade | `string` | Changes text color shade. |
 | size | `string` | Adjust text size. |
 | state | `string` | Changes the text color based on state. |
 | subtle | `bool` | Changes text color to a lighter grey. |
 | truncate | `bool` | Enables CSS truncation for text. |
+
+
+### Shades
+
+| Prop | Description |
+| --- | --- |
+| `subtle` | Medium-light grey. |
+| `muted` | Lighter grey. |
+| `faint` | Very lighter grey. |
+| `extraMuted` | Extra light grey. |
 
 
 ### States

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { sizeTypes } from './propTypes'
 import classNames from '../../utilities/classNames'
-import { stateTypes } from '../../constants/propTypes'
+import { stateTypes, textShadeTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   allCaps: PropTypes.bool,
@@ -16,6 +16,7 @@ export const propTypes = {
   muted: PropTypes.bool,
   noWrap: PropTypes.bool,
   selector: PropTypes.oneOf(['span', 'pre', 'samp']),
+  shade: textShadeTypes,
   size: sizeTypes,
   state: stateTypes,
   subtle: PropTypes.bool,
@@ -45,6 +46,7 @@ const Text = props => {
     muted,
     noWrap,
     selector,
+    shade,
     size,
     state,
     subtle,
@@ -65,6 +67,7 @@ const Text = props => {
     lineHeightReset && 'is-line-height-reset',
     linkStyle && 'is-linkStyle',
     selector && `is-${selector}`,
+    shade && `is-${shade}`,
     size && `is-${size}`,
     state && `is-${state}`,
     subtle && 'is-subtle',

--- a/src/components/Text/tests/Text.test.js
+++ b/src/components/Text/tests/Text.test.js
@@ -19,6 +19,14 @@ describe('Content', () => {
   })
 })
 
+describe('Shade', () => {
+  test('Add shade styles if applied', () => {
+    const wrapper = shallow(<Text shade='muted' />)
+
+    expect(wrapper.prop('className')).toContain('is-muted')
+  })
+})
+
 describe('Styles', () => {
   test('Has default component className', () => {
     const wrapper = shallow(<Text />)

--- a/src/constants/propTypes.js
+++ b/src/constants/propTypes.js
@@ -7,6 +7,14 @@ export const standardSizeTypes = PropTypes.oneOf([
   ''
 ])
 
+export const textShadeTypes = PropTypes.oneOf([
+  'subtle',
+  'muted',
+  'faint',
+  'extraMuted',
+  ''
+])
+
 export const statusTypes = PropTypes.oneOf([
   'error',
   'info',

--- a/src/styles/components/Icon.scss
+++ b/src/styles/components/Icon.scss
@@ -4,7 +4,7 @@
 .c-Icon {
   @import "../configs/color";
   $sizes: (8, 10, 12, 13, 14, 16, 18, 20, 24);
-  $shades: faint, muted, subtle;
+  $shades: faint, muted, subtle, extraMuted;
   $caretSize: 10px;
   $default-size: 20;
 

--- a/src/styles/components/Text.scss
+++ b/src/styles/components/Text.scss
@@ -6,7 +6,7 @@
   @import "../mixins/linkStyles";
   @import "../resets/base";
   $states: $STATES;
-  $shades: faint, muted, subtle;
+  $shades: faint, muted, subtle, extraMuted;
   $sizes: (10, 11, 12, 13, 14, 15, 16, 20, 48);
 
   line-height: 1.5;

--- a/src/styles/configs/_color.scss
+++ b/src/styles/configs/_color.scss
@@ -12,5 +12,6 @@
     subtle: _color(charcoal, 500),
     muted: _color(charcoal, 300),
     faint: _color(charcoal, 200),
+    extraMuted: _color(grey, 600),
   )
 ));

--- a/stories/Icon.js
+++ b/stories/Icon.js
@@ -80,6 +80,42 @@ stories.add('colors', () => {
   )
 })
 
+stories.add('shades', () => {
+  return (
+    <div>
+      <div>
+        <Icon name='emoji' />
+        <Text muted size='sm'>Regular</Text>
+        <br />
+      </div>
+      <br />
+      <div>
+        <Icon name='emoji' shade='subtle' />
+        <Text muted size='sm'>Subtle</Text>
+        <br />
+      </div>
+      <br />
+      <div>
+        <Icon name='emoji' shade='muted' />
+        <Text muted size='sm'>Muted</Text>
+        <br />
+      </div>
+      <br />
+      <div>
+        <Icon name='emoji' shade='faint' />
+        <Text muted size='sm'>Faint</Text>
+        <br />
+      </div>
+      <br />
+      <div>
+        <Icon name='emoji' shade='extraMuted' />
+        <Text muted size='sm'>Extra Muted</Text>
+        <br />
+      </div>
+    </div>
+  )
+})
+
 stories.add('withCaret', () => {
   const icons = [
     '14', '16', '18', '24'


### PR DESCRIPTION
## Colors: Add ExtraMuted 🖌 

![screen shot 2018-01-25 at 2 45 16 pm](https://user-images.githubusercontent.com/2322354/35408858-94c9e98e-01de-11e8-8c78-9ad75602893f.jpg)

This update adds a new 'extraMuted' shade to both the `Text` and `Icon`
components. This is done via a new `shade` prop, which accepts an
string value of pre-defined shades.

Tests + Storybook (Icon) have been updated :D