### PR TITLE
Avatar Feature: Fallback to initials on image error

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -30,6 +30,22 @@ const defaultProps = {
 }
 
 class Avatar extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      // Assume image will load so that we only re-render on error
+      imageLoaded: true
+    }
+    this.onImageLoadedError = this.onImageLoadedError.bind(this)
+  }
+
+  onImageLoadedError () {
+    this.setState({
+      imageLoaded: false
+    })
+  }
+
   render () {
     const {
       borderColor,
@@ -46,9 +62,11 @@ class Avatar extends Component {
       ...rest
     } = this.props
 
+    const { imageLoaded } = this.state
+
     const componentClassName = classNames(
       'c-Avatar',
-      image && 'has-image',
+      image && imageLoaded && 'has-image',
       light && 'is-light',
       shape && `is-${shape}`,
       size && `is-${size}`,
@@ -56,17 +74,18 @@ class Avatar extends Component {
       className
     )
 
-    const imageStyle = image ? { backgroundImage: `url('${image}')` } : null
+    const imageStyle = image && imageLoaded ? { backgroundImage: `url('${image}')` } : null
 
     const text = count || initials || nameToInitials(name)
 
-    const contentMarkup = image
+    const contentMarkup = image && imageLoaded
       ? (
         <div className='c-Avatar__image' style={imageStyle}>
           <div className='c-Avatar__name'>
             <VisuallyHidden>
               {name}
             </VisuallyHidden>
+            <img alt='' onError={this.onImageLoadedError} src={image} style={{display: 'none'}} />
           </div>
         </div>
       )

--- a/src/components/Avatar/tests/Avatar.test.js
+++ b/src/components/Avatar/tests/Avatar.test.js
@@ -5,7 +5,7 @@ import { StatusDot } from '../../index'
 
 const classNames = {
   root: '.c-Avatar',
-  image: '.c-Avatar__photo',
+  image: '.c-Avatar__image',
   initials: '.c-Avatar__title'
 }
 
@@ -55,7 +55,7 @@ describe('Name', () => {
 describe('Image', () => {
   test('Has the correct className', () => {
     const wrapper = mount(<Avatar name='Buddy the Elf' image='buddy.jpg' />)
-    const image = wrapper.find('.c-Avatar__image')
+    const image = wrapper.find(classNames.image)
 
     expect(image.exists()).toBeTruthy()
   })
@@ -63,7 +63,7 @@ describe('Image', () => {
   test('Render image if image prop is specified', () => {
     const src = 'buddy.jpg'
     const wrapper = mount(<Avatar name='Buddy the Elf' image={src} />)
-    const image = wrapper.find('.c-Avatar__image')
+    const image = wrapper.find(classNames.image)
 
     expect(image.exists()).toBeTruthy()
     expect(image.prop('style').backgroundImage).toContain(src)
@@ -72,7 +72,7 @@ describe('Image', () => {
   test('Rendered image should have name within', () => {
     const name = 'Buddy the Elf'
     const wrapper = mount(<Avatar name={name} image='buddy.jpg' />)
-    const image = wrapper.find('.c-Avatar__image')
+    const image = wrapper.find(classNames.image)
 
     expect(image.text()).toBe(name)
   })
@@ -82,6 +82,17 @@ describe('Image', () => {
     const initials = wrapper.find(classNames.initials)
 
     expect(initials.exists()).toBeFalsy()
+  })
+
+  test('Replaces image with initials on error', () => {
+    const wrapper = mount(<Avatar name='Buddy the Elf' image='buddy.jpg' />)
+    wrapper.find('img').first().simulate('error')
+
+    const initials = wrapper.find(classNames.initials)
+    const image = wrapper.find(classNames.image)
+
+    expect(initials.exists()).toBeTruthy()
+    expect(image.exists()).toBeFalsy()
   })
 
   test('Sets `title` attribute to the `name`', () => {

--- a/stories/Avatar/index.js
+++ b/stories/Avatar/index.js
@@ -10,6 +10,10 @@ stories.add('default', () => (
   <Avatar name={fixture.name} image={fixture.image} />
 ))
 
+stories.add('fallback', () => (
+  <Avatar name={fixture.name} image='https://notfound' />
+))
+
 stories.add('status', () => (
   <div>
     <Flexy just='left'>


### PR DESCRIPTION
This PR introduces a new Avatar feature whereby if the image fails to load, the Avatar will fallback to rendering the initials.

This feature makes use of the HTMLImageElement `onError` callback to detect errors and update the `imageLoaded` property on the component's state. This causes the component to re-render with the initials instead of the image.

Because we cannot programmatically detect errors on background images, we use a hidden image element to detect and act on errors.