### PR TITLE
Apply transparent background when Avatar has image

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -63,10 +63,11 @@ class Avatar extends Component {
     } = this.props
 
     const { imageLoaded } = this.state
+    const hasImage = image && imageLoaded
 
     const componentClassName = classNames(
       'c-Avatar',
-      image && imageLoaded && 'has-image',
+      hasImage && 'has-image',
       light && 'is-light',
       shape && `is-${shape}`,
       size && `is-${size}`,
@@ -74,11 +75,11 @@ class Avatar extends Component {
       className
     )
 
-    const imageStyle = image && imageLoaded ? { backgroundImage: `url('${image}')` } : null
+    const imageStyle = hasImage ? { backgroundImage: `url('${image}')` } : null
 
     const text = count || initials || nameToInitials(name)
 
-    const contentMarkup = image && imageLoaded
+    const contentMarkup = hasImage
       ? (
         <div className='c-Avatar__image' style={imageStyle}>
           <div className='c-Avatar__name'>
@@ -93,10 +94,16 @@ class Avatar extends Component {
         {text}
       </div>
 
-    const styles = borderColor ? {
+    let styles = borderColor ? {
       border: '2px solid',
       borderColor
-    } : null
+    } : {}
+
+    hasImage && Object.assign(styles, {
+      backgroundColor: 'transparent'
+    })
+
+    styles = Object.keys(styles).length ? styles : null
 
     const statusMarkup = status ? (
       <div className='c-Avatar__status'>

--- a/src/components/Avatar/tests/Avatar.test.js
+++ b/src/components/Avatar/tests/Avatar.test.js
@@ -5,6 +5,7 @@ import { StatusDot } from '../../index'
 
 const classNames = {
   root: '.c-Avatar',
+  crop: '.c-Avatar__crop',
   image: '.c-Avatar__image',
   initials: '.c-Avatar__title'
 }
@@ -58,6 +59,14 @@ describe('Image', () => {
     const image = wrapper.find(classNames.image)
 
     expect(image.exists()).toBeTruthy()
+  })
+
+  test('Background is transparent to prevent flash of color before image loads', () => {
+    const wrapper = mount(<Avatar name='Buddy the Elf' image='buddy.jpg' />)
+    const crop = wrapper.find(classNames.crop)
+
+    expect(crop.exists()).toBeTruthy()
+    expect(crop.prop('style').backgroundColor).toEqual('transparent')
   })
 
   test('Render image if image prop is specified', () => {
@@ -119,7 +128,7 @@ describe('ClassNames', () => {
 describe('Border color', () => {
   test('Can apply borderColor', () => {
     const wrapper = shallow(<Avatar name='Buddy' borderColor='green' />)
-    const crop = wrapper.find('.c-Avatar__crop')
+    const crop = wrapper.find(classNames.crop)
     const style = crop.props().style
 
     expect(style).toBeTruthy()
@@ -129,7 +138,7 @@ describe('Border color', () => {
 
   test('Does not have a border by default', () => {
     const wrapper = shallow(<Avatar name='Buddy' />)
-    const crop = wrapper.find('.c-Avatar__crop')
+    const crop = wrapper.find(classNames.crop)
     const style = crop.props().style
 
     expect(style).not.toBeTruthy()

--- a/src/components/Avatar/tests/Avatar.test.js
+++ b/src/components/Avatar/tests/Avatar.test.js
@@ -104,6 +104,15 @@ describe('Image', () => {
     expect(image.exists()).toBeFalsy()
   })
 
+  test('Background style is unset on error', () => {
+    const wrapper = mount(<Avatar name='Buddy the Elf' image='buddy.jpg' />)
+    wrapper.find('img').first().simulate('error')
+
+    const crop = wrapper.find(classNames.crop)
+
+    expect(crop.prop('style')).toBe(null)
+  })
+
   test('Sets `title` attribute to the `name`', () => {
     const wrapper = shallow(<Avatar name='Bobby McGee' />)
     const root = wrapper.find(classNames.root)


### PR DESCRIPTION
Currently, the Avatar component has a background color even when an image is used instead of initials. This results a flash of color before the image loads that is particularly pronounced when the image is not cached in the browser.

This PR introduces a change to use a transparent background when an image is used. The effect of this change is that the space for the avatar is rendered when waiting for an image to load with a transparent background, making for a more seamless loading effect.

Note that in the render function we are building up a style object and that object is reassigned to null if no styles are added. This is to make it easier for testing to simply verify that styles are falsy.