### PR TITLE
Modal: Add additional classNames

### DIFF
--- a/src/components/Modal/docs/Modal.md
+++ b/src/components/Modal/docs/Modal.md
@@ -30,12 +30,14 @@ A Modal component presents content within a container on top of the application'
 
 | Prop | Type | Description |
 | --- | --- | --- |
+| cardClassName | `string` | Custom class names to be added to the child [Card](../Card) component. |
 | className | `string` | Custom class names to be added to the component. |
 | closeIcon | `bool` | Shows/hides the component's close icon UI. |
 | closeIconRepositionDelay | `number ` | Amount of time before the [CloseButton](../../CloseButton) gets repositioned. |
 | exact | `bool` | Used with `path` and React Router. Renders if path matches _exactly_ |
 | isOpen | `bool` | Shows/hides the component. |
 | path | `string` | Renders component based on a [React Router path](https://reacttraining.com/react-router/web/api/Route/path-string). |
+| overlayClassName | `string` | Custom class names to be added to the child [Overlay](../Overlay) component. |
 | seamless | `bool` | Renders content with the standard [Card](../Card) UI. |
 | trigger | `element` | The UI the user clicks to trigger the modal. |
 | wrapperClassName | `string` | Custom className to add to the [PortalWrapper](../../PortalWrapper) component. |

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -17,8 +17,8 @@ import { isNodeElement, hasContentOverflowY } from '../../utilities/node'
 import getScrollbarWidth from '../../vendors/getScrollbarWidth'
 
 export const propTypes = Object.assign({}, portalTypes, {
+  cardClassName: PropTypes.string,
   closeIcon: PropTypes.bool,
-  seamless: PropTypes.bool,
   closeIconRepositionDelay: PropTypes.number,
   modalAnimationDelay: PropTypes.oneOfType([
     PropTypes.number,
@@ -28,6 +28,8 @@ export const propTypes = Object.assign({}, portalTypes, {
     PropTypes.number,
     PropTypes.object
   ]),
+  overlayClassName: PropTypes.string,
+  seamless: PropTypes.bool,
   trigger: PropTypes.element,
   wrapperClassName: PropTypes.string
 })
@@ -112,6 +114,7 @@ class Modal extends Component {
 
   render () {
     const {
+      cardClassName,
       children,
       className,
       closeIcon,
@@ -124,6 +127,7 @@ class Modal extends Component {
       onScroll,
       openPortal,
       overlayAnimationDelay,
+      overlayClassName,
       path,
       portalIsMounted,
       portalIsOpen,
@@ -171,7 +175,7 @@ class Modal extends Component {
     })
 
     const modalContentMarkup = !seamless ? (
-      <Card className='c-Modal__Card' seamless role='dialog'>
+      <Card className={`${cardClassName} c-Modal__Card`} seamless role='dialog'>
         {closeMarkup}
         {parsedChildren}
       </Card>
@@ -196,7 +200,7 @@ class Modal extends Component {
           </Animate>
         </div>
         <Animate sequence='fade' in={portalIsOpen} wait={overlayAnimationDelay}>
-          <Overlay onClick={closePortal} role='presentation' />
+          <Overlay className={overlayClassName} onClick={closePortal} role='presentation' />
         </Animate>
       </div>
     )

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { shallow, mount } from 'enzyme'
 import { MemoryRouter as Router } from 'react-router'
 import { default as Modal, ModalComponent } from '..'
-import { Card, Portal, Scrollable } from '../../index'
+import { Card, Portal, Overlay, Scrollable } from '../../index'
 import Keys from '../../../constants/Keys'
 import wait from '../../../tests/helpers/wait'
 
@@ -358,6 +358,39 @@ describe('wrapperClassName', () => {
       expect(o.className).toContain('c-ModalWrapper')
       done()
     })
+  })
+})
+
+describe('cardClassName', () => {
+  test('Can customize the Card className', () => {
+    const wrapper = mount(
+      <ModalComponent cardClassName='mugatu' />
+    )
+    const o = wrapper.find(Card)
+    const m = wrapper.find('.mugatu')
+
+    expect(o.hasClass('mugatu')).toBeTruthy()
+    expect(m.length).toBe(1)
+  })
+
+  test('Does not add custom className to seamless Modals', () => {
+    const wrapper = mount(
+      <ModalComponent cardClassName='mugatu' seamless />
+    )
+    const o = wrapper.find('.mugatu')
+
+    expect(o.length).toBe(0)
+  })
+})
+
+describe('overlayClassName', () => {
+  test('Can customize the Overlay className', () => {
+    const wrapper = mount(
+      <ModalComponent overlayClassName='mugatu' />
+    )
+    const o = wrapper.find(Overlay)
+
+    expect(o.hasClass('mugatu')).toBeTruthy()
   })
 })
 


### PR DESCRIPTION
## Modal: Add additional classNames ✨ 

This update enhances the `Modal` component with 2 new props:
* `cardClassName`
* `overlayClassName`

This allow you to provide the child `Card` and `Overlay` components
with custom classNames.

Docs and tests have been updated :rocket: