### PR TITLE
Controls: Adjust styles for Button, Input and Select

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -7,6 +7,7 @@ import { standardSizeTypes, stateTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   accessibilityLabel: PropTypes.string,
+  block: PropTypes.bool,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   onBlur: PropTypes.func,
@@ -22,6 +23,7 @@ export const propTypes = {
 
 const defaultProps = {
   accessibilityLabel: '',
+  block: false,
   disabled: false,
   onBlur: noop,
   onClick: noop,
@@ -36,6 +38,7 @@ const defaultProps = {
 const Button = props => {
   const {
     accessibilityLabel,
+    block,
     buttonRef,
     children,
     className,
@@ -55,11 +58,12 @@ const Button = props => {
   const componentClassName = classNames(
     'c-Button',
     isActive && 'is-selected',
+    block && 'c-Button--block',
     size && `c-Button--${size}`,
     state && `is-${state}`,
     plain && 'c-Button--link',
     primary && 'c-Button--primary',
-    props.className
+    className
   )
 
   const type = submit ? 'submit' : 'button'

--- a/src/components/Button/tests/Button.test.js
+++ b/src/components/Button/tests/Button.test.js
@@ -32,6 +32,18 @@ describe('Types', () => {
 
     expect(button.prop('type')).toBe('submit')
   })
+
+  test('Can create block buttons, if specified', () => {
+    const o = wrap(<Button primary>Primary</Button>)
+
+    expect(o.hasClass('c-Button--block')).toBeFalsy()
+  })
+
+  test('Can create block buttons, if specified', () => {
+    const o = wrap(<Button primary block>Primary</Button>)
+
+    expect(o.hasClass('c-Button--block')).toBeTruthy()
+  })
 })
 
 describe('Sizes', () => {

--- a/src/components/Select/README.md
+++ b/src/components/Select/README.md
@@ -9,6 +9,7 @@ A Select component is an enhanced version of the default HTML `<select>`.
 <Select placeholder="Pick one" options={['You sit on a throne of lies!', 'Son of a nutcracker!']} autoFocus />
 ```
 
+
 ### Option groups
 
 ```jsx
@@ -21,6 +22,19 @@ A Select component is an enhanced version of the default HTML `<select>`.
     ]
   }
   ]} autoFocus />
+```
+
+
+### Children options
+
+This component also accepts regular `<option>` elements as children.
+
+```jsx
+<Select placeholder="Pick one">
+  <option>...</option>
+  <option>...</option>
+  <option>...</option>
+</Select>
 ```
 
 

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -85,6 +85,7 @@ class Select extends Component {
 
   render () {
     const {
+      children,
       className,
       disabled,
       helpText,
@@ -149,7 +150,7 @@ class Select extends Component {
       }
     }
 
-    const optionsMarkup = Array.isArray(options) ? options.map(renderOptions) : renderOptions(options)
+    const optionsMarkup = children || (Array.isArray(options) ? options.map(renderOptions) : renderOptions(options))
 
     const placeholderMarkup = hasPlaceholder
       ? <option

--- a/src/components/Select/tests/Select.test.js
+++ b/src/components/Select/tests/Select.test.js
@@ -43,6 +43,31 @@ describe('Option', () => {
     expect(selectOptions.length).toBe(options.length)
   })
 
+  test('Renders children, if specified', () => {
+    const wrapper = mount(
+      <Select>
+        <option>Hello</option>
+      </Select>
+    )
+    const selectOptions = wrapper.find('select').children()
+
+    expect(selectOptions.first().text()).toBe('Hello')
+    expect(selectOptions.length).toBe(1)
+  })
+
+  test('Renders children over option prop', () => {
+    const options = ['Champ Kind', 'Brian Fantana', 'Brick Tamland']
+    const wrapper = mount(
+      <Select options={options}>
+        <option>Hello</option>
+      </Select>
+    )
+    const selectOptions = wrapper.find('select').children()
+
+    expect(selectOptions.first().text()).toBe('Hello')
+    expect(selectOptions.length).toBe(1)
+  })
+
   test('Renders with a correct object schema', () => {
     const options = {
       label: 'Champ Kind',

--- a/src/styles/components/Button.scss
+++ b/src/styles/components/Button.scss
@@ -1,4 +1,6 @@
 $seed-button-namespace: "c-Button";
+$seed-button-font-weight: 600;
+@import "../configs/seed-control";
 @import "pack/seed-button/_index";
 
 button.#{$seed-button-namespace} {

--- a/src/styles/components/Input/Input.scss
+++ b/src/styles/components/Input/Input.scss
@@ -10,7 +10,7 @@
 .c-Input {
   $InputField: ".c-InputField";
   $block: this();
-  $padding: 8px;
+  $padding: 16px;
 
   @import "../../configs/color";
   @import "../../resets/base";

--- a/src/styles/components/Input/InputField.scss
+++ b/src/styles/components/Input/InputField.scss
@@ -1,7 +1,7 @@
-@import "pack/seed-control/_index";
 @import "pack/seed-dash/_index";
 @import "pack/seed-family/_index";
 @import "../../configs/constants";
+@import "../../configs/seed-control";
 @import "../../mixins/input-styles";
 
 .c-InputField {
@@ -9,7 +9,7 @@
   @import "../../resets/base";
   $border-width: 1px;
   $offset: 1px;
-  $default-height: _get($seed-control-sizes, md, height);
+  $default-height: 40px;
   $states: $STATES;
 
   // Scoped functions

--- a/src/styles/components/Select/Select.scss
+++ b/src/styles/components/Select/Select.scss
@@ -4,7 +4,7 @@
 .c-Select {
   $InputField: ".c-InputField";
   $arrowSize: 20px;
-  $padding: 8px;
+  $padding: 16px;
   $states: $STATES;
 
   @import "../../configs/color";
@@ -24,13 +24,16 @@
   #{$InputField} {
     padding-left: ceil($padding / 2);
     padding-right: $arrowSize;
-
     // Removes outline in Firefox
     // https://stackoverflow.com/questions/3773430/remove-outline-from-select-box-in-ff/11603104#11603104
     @-moz-document url-prefix() {
       color: transparent;
       text-shadow: 0 0 0 black;
     }
+  }
+
+  & > *:first-child {
+    padding-left: 0;
   }
 
   &.has-placeholder {

--- a/src/styles/components/Select/SelectIcon.scss
+++ b/src/styles/components/Select/SelectIcon.scss
@@ -4,7 +4,7 @@
 
   $arrowOffset: 2px;
   $arrowSize: 3px;
-  $offset: 4px;
+  $offset: 12px;
 
   align-self: center;
   color: _color(charcoal, 400);

--- a/src/styles/configs/_seed-control.scss
+++ b/src/styles/configs/_seed-control.scss
@@ -1,0 +1,17 @@
+$seed-control-sizes: (
+  sm: (
+    font-size: 13px,
+    height: 28px,
+    padding: 0 0.5em,
+  ),
+  md: (
+    font-size: 13px,
+    height: 32px,
+    padding: 0 1em,
+  ),
+  lg: (
+    font-size: 14px,
+    height: 48px,
+    padding: 0 1.5em,
+  ),
+);

--- a/src/styles/configs/_seed-control.scss
+++ b/src/styles/configs/_seed-control.scss
@@ -1,12 +1,12 @@
 $seed-control-sizes: (
   sm: (
     font-size: 13px,
-    height: 28px,
+    height: 32px,
     padding: 0 0.5em,
   ),
   md: (
     font-size: 13px,
-    height: 32px,
+    height: 40px,
     padding: 0 1em,
   ),
   lg: (

--- a/src/styles/mixins/backdrop-styles.scss
+++ b/src/styles/mixins/backdrop-styles.scss
@@ -41,9 +41,13 @@
   @each $state in $states {
     &.is-#{$state} {
       border-color: _color(state, $state, border-color);
+      box-shadow: 0 0 0 1px _color(state, $state, border-color) inset;
       @include parent("#{$InputField}:focus ~ ") {
         border-color: _color(state, $state, border-color);
-        box-shadow: 0 0 0 1px _color(state, $state, border-color) inset;
+        box-shadow: #{
+          0 0 0 1px _color(state, $state, border-color) inset,
+          0 0 0 2px rgba(_color(state, $state, border-color), 0.2)
+        };
       }
     }
   }

--- a/src/styles/mixins/backdrop-styles.scss
+++ b/src/styles/mixins/backdrop-styles.scss
@@ -47,7 +47,7 @@
         box-shadow: #{
           0 0 0 1px _color(state, $state, border-color) inset,
           0 0 0 2px rgba(_color(state, $state, border-color), 0.2)
-        };
+          };
       }
     }
   }

--- a/src/styles/themes/hs-app/components/Button.scss
+++ b/src/styles/themes/hs-app/components/Button.scss
@@ -7,9 +7,9 @@
     padding: 0 0.5em;
   }
   &--md {
-    font-size: 14px,
-    height: 30px,
-    padding: 0 1em,
+    font-size: 14px;
+    height: 30px;
+    padding: 0 1em;
   }
   &--lg {
     font-size: 16px;

--- a/src/styles/themes/hs-app/components/Button.scss
+++ b/src/styles/themes/hs-app/components/Button.scss
@@ -1,3 +1,19 @@
 .c-Button {
   font-weight: normal;
+
+  &--sm {
+    font-size: 14px;
+    height: 28px;
+    padding: 0 0.5em;
+  }
+  &--md {
+    font-size: 14px,
+    height: 30px,
+    padding: 0 1em,
+  }
+  &--lg {
+    font-size: 16px;
+    height: 42px;
+    padding: 0 1.25em;
+  }
 }

--- a/src/styles/themes/hs-app/components/Button.scss
+++ b/src/styles/themes/hs-app/components/Button.scss
@@ -1,0 +1,3 @@
+.c-Button {
+  font-weight: normal;
+}

--- a/src/styles/themes/hs-app/components/__index.scss
+++ b/src/styles/themes/hs-app/components/__index.scss
@@ -1,3 +1,4 @@
+@import "./Button";
 @import "./Choice";
 @import "./Input";
 @import "./HelpText";


### PR DESCRIPTION
## Controls: Adjust styles for Button, Input and Select 💅 

![screen shot 2018-01-29 at 8 13 01 pm](https://user-images.githubusercontent.com/2322354/35543058-09585f92-0531-11e8-91f1-bfbb33db8b55.jpg)

This update adjusts the font-size, weight, and size for the Buttons.
This is all done via CSS, mainly Seed's `seed-button` pack's SCSS configs.

Adjustments have also been made for the Input and Select components.

![screen recording 2018-01-29 at 09 07 pm](https://user-images.githubusercontent.com/2322354/35544482-8dd9e27a-0538-11e8-87fc-9669c3ea2f8b.gif)

Stateful control borders also receive a 1px bump in size. A new focus style has been added to accommodate the size change.
