### PR TITLE
Input/Select: Add ability to removeStateStylesOnFocus

### DIFF
--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -22,9 +22,6 @@ An Input component is an enhanced version of the default HTML `<input>`. Input c
 
 | Prop | Type | Description |
 | --- | --- | --- |
-| onBlur | `function` | Callback when input is blurred. |
-| onChange | `function` | Callback when input value is changed. |
-| onFocus | `function` | Callback when input is focused. |
 | autoFocus | `bool` | Automatically focuses the input. |
 | className | `string` | Custom class names to be added to the component. |
 | disabled | `bool` | Disable the input. |
@@ -34,9 +31,13 @@ An Input component is an enhanced version of the default HTML `<input>`. Input c
 | label | `string` | Label for the input. |
 | multiline | `bool`/`number` | Transforms input into an auto-expanding textarea. |
 | name | `string` | Name for the input. |
+| onBlur | `function` | Callback when input is blurred. |
+| onChange | `function` | Callback when input value is changed. |
+| onFocus | `function` | Callback when input is focused. |
 | placeholder | `string` | Placeholder text for the input. |
 | prefix | `string` | Text to appear before the input. |
 | readOnly | `bool` | Disable editing of the input. |
+| removeStateStylesOnFocus | `bool` | Removes the `state` styles on input focus. Default `false`. |
 | resizable | `bool` | Enables resizing for the textarea (only enabled for `multiline`). |
 | seamless | `bool` | Removes the border around the input. |
 | size | `string` | Determines the size of the input. |

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -27,6 +27,7 @@ export const propTypes = {
   placeholder: PropTypes.string,
   prefix: PropTypes.string,
   readOnly: PropTypes.bool,
+  removeStateStylesOnFocus: PropTypes.bool,
   resizable: PropTypes.bool,
   seamless: PropTypes.bool,
   size: standardSizeTypes,
@@ -45,6 +46,7 @@ const defaultProps = {
   onChange: noop,
   onFocus: noop,
   readOnly: false,
+  removeStateStylesOnFocus: false,
   resizable: false,
   seamless: false,
   type: 'text',
@@ -59,18 +61,25 @@ class Input extends Component {
     this.state = {
       id: props.id || uniqueID(),
       height: null,
+      state: props.state,
       value: props.value
     }
     this.handleOnChange = this.handleOnChange.bind(this)
+    this.handleOnInputFocus = this.handleOnInputFocus.bind(this)
     this.handleExpandingResize = this.handleExpandingResize.bind(this)
   }
 
   componentWillReceiveProps (nextProps) {
+    const { value, state } = nextProps
     const prevValue = this.state.value
-    const nextValue = nextProps.value
+    const prevState = this.state.state
 
-    if (nextValue !== prevValue) {
-      this.setState({value: nextValue})
+    if (value !== prevValue) {
+      this.setState({value})
+    }
+
+    if (state !== prevState) {
+      this.setState({state})
     }
   }
 
@@ -78,6 +87,15 @@ class Input extends Component {
     const value = e.currentTarget.value
     this.setState({ value })
     this.props.onChange(value)
+  }
+
+  handleOnInputFocus (e) {
+    const { onFocus, removeStateStylesOnFocus } = this.props
+    const { state } = this.state
+    if (removeStateStylesOnFocus && state) {
+      this.setState({ state: null })
+    }
+    onFocus(e)
   }
 
   handleExpandingResize (height) {
@@ -101,18 +119,20 @@ class Input extends Component {
       placeholder,
       prefix,
       readOnly,
+      removeStateStylesOnFocus,
       resizable,
       seamless,
       size,
-      state,
+      state: stateProp,
       suffix,
       type,
       ...rest
     } = this.props
 
-    const { height, id: inputID, value } = this.state
+    const { height, id: inputID, value, state } = this.state
 
     const handleOnChange = this.handleOnChange
+    const handleOnInputFocus = this.handleOnInputFocus
     const handleExpandingResize = this.handleExpandingResize
 
     const componentClassName = classNames(
@@ -182,7 +202,7 @@ class Input extends Component {
       disabled,
       name,
       onBlur,
-      onFocus,
+      onFocus: handleOnInputFocus,
       placeholder,
       readOnly,
       style,

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -78,6 +78,7 @@ class Input extends Component {
       this.setState({value})
     }
 
+    /* istanbul ignore else */
     if (state !== prevState) {
       this.setState({state})
     }

--- a/src/components/Input/tests/Input.test.js
+++ b/src/components/Input/tests/Input.test.js
@@ -294,6 +294,21 @@ describe('States', () => {
 
     expect(o.prop('className')).toContain('is-warning')
   })
+
+  test('Updates state.state on prop change', () => {
+    const wrapper = mount(<Input state='warning' />)
+    const input = wrapper.find('.c-Input')
+
+    wrapper.setProps({ state: 'success' })
+
+    expect(wrapper.state().state).toBe('success')
+    expect(input.hasClass('is-success')).toBe(true)
+
+    wrapper.setProps({ state: null })
+
+    expect(wrapper.state().state).toBe(null)
+    expect(input.hasClass('is-success')).toBe(false)
+  })
 })
 
 describe('Stateful helper label', () => {
@@ -303,5 +318,29 @@ describe('Stateful helper label', () => {
 
     expect(helperLabel.exists()).toBeTruthy()
     expect(helperLabel.text()).toBe('Error')
+  })
+})
+
+describe('removeStateStylesOnFocus', () => {
+  test('Does not remove state style on focus, by default', () => {
+    const wrapper = mount(<Input state='error' />)
+    const input = wrapper.find('.c-Input')
+    const o = wrapper.find('input')
+
+    o.simulate('focus')
+
+    expect(wrapper.state().state).toBe('error')
+    expect(input.hasClass('is-error')).toBe(true)
+  })
+
+  test('Removes state style on focus, by specified', () => {
+    const wrapper = mount(<Input state='error' removeStateStylesOnFocus />)
+    const input = wrapper.find('.c-Input')
+    const o = wrapper.find('input')
+
+    o.simulate('focus')
+
+    expect(wrapper.state().state).toBeFalsy()
+    expect(input.hasClass('is-error')).toBe(false)
   })
 })

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -147,6 +147,14 @@ class Modal extends Component {
       isOpen && 'is-open',
       className
     )
+    const cardComponentClassName = classNames(
+      'c-Modal__Card',
+      cardClassName
+    )
+    const overlayComponentClassName = classNames(
+      'c-Modal__Overlay',
+      overlayClassName
+    )
 
     const closeMarkup = closeIcon ? (
       <div
@@ -175,7 +183,7 @@ class Modal extends Component {
     })
 
     const modalContentMarkup = !seamless ? (
-      <Card className={`${cardClassName} c-Modal__Card`} seamless role='dialog'>
+      <Card className={cardComponentClassName} seamless role='dialog'>
         {closeMarkup}
         {parsedChildren}
       </Card>
@@ -200,7 +208,7 @@ class Modal extends Component {
           </Animate>
         </div>
         <Animate sequence='fade' in={portalIsOpen} wait={overlayAnimationDelay}>
-          <Overlay className={overlayClassName} onClick={closePortal} role='presentation' />
+          <Overlay className={overlayComponentClassName} onClick={closePortal} role='presentation' />
         </Animate>
       </div>
     )

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -370,6 +370,7 @@ describe('cardClassName', () => {
     const m = wrapper.find('.mugatu')
 
     expect(o.hasClass('mugatu')).toBeTruthy()
+    expect(o.hasClass('c-Modal__Card')).toBeTruthy()
     expect(m.length).toBe(1)
   })
 
@@ -390,6 +391,7 @@ describe('overlayClassName', () => {
     )
     const o = wrapper.find(Overlay)
 
+    expect(o.hasClass('c-Modal__Overlay')).toBeTruthy()
     expect(o.hasClass('mugatu')).toBeTruthy()
   })
 })

--- a/src/components/Select/README.md
+++ b/src/components/Select/README.md
@@ -56,6 +56,7 @@ This component also accepts regular `<option>` elements as children.
 | placeholder | `string` | Placeholder text for the select. |
 | prefix | `string` | Text to appear before the select. |
 | readOnly | `bool` | Disable editing of the select. |
+| removeStateStylesOnFocus | `bool` | Removes the `state` styles on input focus. Default `false`. |
 | seamless | `bool` | Removes the border around the select. |
 | size | `bool` | Determines the size of the select. |
 | state | `string` | Change select to state color. |

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -77,6 +77,7 @@ class Select extends Component {
     const { state } = nextProps
     const prevState = this.state.state
 
+    /* istanbul ignore else */
     if (state !== prevState) {
       this.setState({state})
     }

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -43,6 +43,7 @@ export const propTypes = {
   onFocus: PropTypes.func,
   placeholder: PropTypes.string,
   prefix: PropTypes.string,
+  removeStateStylesOnFocus: PropTypes.bool,
   size: standardSizeTypes,
   state: stateTypes,
   value: PropTypes.string
@@ -55,6 +56,7 @@ const defaultProps = {
   onChange: noop,
   onFocus: noop,
   options: [],
+  removeStateStylesOnFocus: false,
   value: ''
 }
 
@@ -65,7 +67,18 @@ class Select extends Component {
     super()
     this.state = {
       placeholder: props.placeholder,
+      state: props.state,
       value: props.value
+    }
+    this.handleOnFocus = this.handleOnFocus.bind(this)
+  }
+
+  componentWillReceiveProps (nextProps) {
+    const { state } = nextProps
+    const prevState = this.state.state
+
+    if (state !== prevState) {
+      this.setState({state})
     }
   }
 
@@ -77,6 +90,15 @@ class Select extends Component {
       placeholder: false,
       value
     })
+  }
+
+  handleOnFocus (e) {
+    const { onFocus, removeStateStylesOnFocus } = this.props
+    const { state } = this.state
+    if (removeStateStylesOnFocus && state) {
+      this.setState({ state: null })
+    }
+    onFocus(e)
   }
 
   hasPlaceholder () {
@@ -92,17 +114,22 @@ class Select extends Component {
       id,
       label,
       onChange,
+      onFocus,
       options,
       placeholder,
       prefix,
+      removeStateStylesOnFocus,
       seamless,
       size,
-      state,
+      state: stateProp,
       success,
       value,
       ...rest
     } = this.props
 
+    const { state } = this.state
+
+    const handleOnFocus = this.handleOnFocus
     const hasPlaceholder = this.hasPlaceholder()
 
     const componentClassName = classNames(
@@ -189,6 +216,7 @@ class Select extends Component {
             disabled={disabled}
             id={id}
             onChange={e => this.handleOnChange(e)}
+            onFocus={handleOnFocus}
             value={selectedValue}
             {...rest}
           >

--- a/src/components/Select/tests/Select.test.js
+++ b/src/components/Select/tests/Select.test.js
@@ -258,6 +258,21 @@ describe('States', () => {
       expect(o.text()).toContain(message)
     })
   })
+
+  test('Updates state.state on prop change', () => {
+    const wrapper = mount(<Select state='warning' />)
+    const select = wrapper.find('.c-Select')
+
+    wrapper.setProps({ state: 'success' })
+
+    expect(wrapper.state().state).toBe('success')
+    expect(select.hasClass('is-success')).toBe(true)
+
+    wrapper.setProps({ state: null })
+
+    expect(wrapper.state().state).toBe(null)
+    expect(select.hasClass('is-success')).toBe(false)
+  })
 })
 
 describe('Styles', () => {
@@ -273,5 +288,29 @@ describe('Styles', () => {
     const o = wrapper.find('.c-InputField')
 
     expect(o.prop('className')).toContain('is-sm')
+  })
+})
+
+describe('removeStateStylesOnFocus', () => {
+  test('Does not remove state style on focus, by default', () => {
+    const wrapper = mount(<Select state='error' />)
+    const select = wrapper.find('.c-Select')
+    const o = wrapper.find('select')
+
+    o.simulate('focus')
+
+    expect(wrapper.state().state).toBe('error')
+    expect(select.hasClass('is-error')).toBe(true)
+  })
+
+  test('Removes state style on focus, by specified', () => {
+    const wrapper = mount(<Select state='error' removeStateStylesOnFocus />)
+    const select = wrapper.find('.c-Select')
+    const o = wrapper.find('select')
+
+    o.simulate('focus')
+
+    expect(wrapper.state().state).toBeFalsy()
+    expect(select.hasClass('is-error')).toBe(false)
   })
 })

--- a/stories/Input.js
+++ b/stories/Input.js
@@ -75,9 +75,9 @@ stories.add('readonly', () => (
 
 stories.add('states', () => (
   <div>
-    <Input state='error' autoFocus /><br />
-    <Input state='success' helpText="You're Awesome!" hintText="You're awesome!" autoFocus /><br />
-    <Input state='warning' autoFocus />
+    <Input state='error' /><br />
+    <Input state='success' helpText="You're Awesome!" hintText="You're awesome!" /><br />
+    <Input state='warning' removeStateStylesOnFocus />
   </div>
 ))
 


### PR DESCRIPTION
## Input/Select: Add ability to removeStateStylesOnFocus 🚦 

![screen recording 2018-01-30 at 04 42 pm](https://user-images.githubusercontent.com/2322354/35592983-a4722552-05dc-11e8-9750-48a6021d765a.gif)

This update enhances the Input and Select components with the ability to remove
state-based styles onFocus. The default value for this prop is set
to `false`.

### Modal: Fix `cardClassName`/`overlayClassName` 🐛 

This update also fixes how these prop-based classNames are rendered into the child components.