### PR TITLE
Controls: Style and multiline

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -125,6 +125,7 @@ class Input extends Component {
       seamless,
       size,
       state: stateProp,
+      style: styleProp,
       suffix,
       type,
       ...rest
@@ -212,7 +213,7 @@ class Input extends Component {
     })
 
     return (
-      <div className='c-InputWrapper'>
+      <div className='c-InputWrapper' style={styleProp}>
         {labelMarkup}
         {hintTextMarkup}
         <div className={componentClassName}>

--- a/src/components/Input/tests/Input.test.js
+++ b/src/components/Input/tests/Input.test.js
@@ -253,6 +253,12 @@ describe('Styles', () => {
 
     expect(o.prop('className')).toContain('is-sm')
   })
+
+  test('Passes style prop to wrapper', () => {
+    const wrapper = shallow(<Input size='sm' style={{background: 'red'}} />)
+
+    expect(wrapper.prop('style').background).toBe('red')
+  })
 })
 
 describe('States', () => {

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -123,6 +123,7 @@ class Select extends Component {
       seamless,
       size,
       state: stateProp,
+      style: styleProp,
       success,
       value,
       ...rest
@@ -208,7 +209,7 @@ class Select extends Component {
     const selectedValue = hasPlaceholder ? PLACEHOLDER_VALUE : this.state.value
 
     return (
-      <div className='c-InputWrapper'>
+      <div className='c-InputWrapper' style={styleProp}>
         {labelMarkup}
         <div className={componentClassName}>
           {prefixMarkup}

--- a/src/components/Select/tests/Select.test.js
+++ b/src/components/Select/tests/Select.test.js
@@ -289,6 +289,12 @@ describe('Styles', () => {
 
     expect(o.prop('className')).toContain('is-sm')
   })
+
+  test('Passes style prop to wrapper', () => {
+    const wrapper = shallow(<Select style={{background: 'red'}} />)
+
+    expect(wrapper.prop('style').background).toBe('red')
+  })
 })
 
 describe('removeStateStylesOnFocus', () => {

--- a/src/styles/components/Input/Input.scss
+++ b/src/styles/components/Input/Input.scss
@@ -30,7 +30,7 @@
       margin-top: 1px;
       margin-left: -($padding);
       margin-right: -($padding);
-      padding: 0.6em $padding;
+      padding: 12px $padding;
       resize: none;
       top: 1px; // to match the line-height of <input>
       width: calc(100% + #{ceil($padding * 2)});

--- a/src/styles/components/Input/InputGhost.scss
+++ b/src/styles/components/Input/InputGhost.scss
@@ -1,6 +1,6 @@
 .c-InputGhost {
   border: 1px solid transparent;
-  padding: 0.6em 8px;
+  padding: 12px 16px;
   line-height: normal;
   white-space: pre-wrap;
   word-wrap: break-word;

--- a/stories/Input.js
+++ b/stories/Input.js
@@ -33,11 +33,14 @@ stories.add('hintText', () => (
 ))
 
 stories.add('multiline', () => (
-  <Input
-    multiline
-    autoFocus
-    placeholder='This is a textarea!'
-  />
+  <div>
+    <Input placeholder='This is an input!' style={{marginBottom: '5px'}} />
+    <Input
+      autoFocus
+      multiline={3}
+      placeholder='This is a textarea!'
+    />
+  </div>
 ))
 
 stories.add('multiline + resizable', () => (


### PR DESCRIPTION
## Controls: Style and multiline

![screen shot 2018-01-30 at 7 58 49 pm](https://user-images.githubusercontent.com/2322354/35599747-4aa0ee98-05f8-11e8-9766-06705b9bb09e.jpg)

This update ensures that "multiline" mode for `Input` has the same
padding as the default "input" mode. This update also fixes a :bug:
where the style prop was being passed to the child input/select,
instead of the parent wrapper.