### PR TITLE
Skeleton: Add Control

### DIFF
--- a/src/components/Skeleton/Control.js
+++ b/src/components/Skeleton/Control.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import Block from './Block'
+import classNames from '../../utilities/classNames'
+import { standardSizeTypes } from '../../constants/propTypes'
+
+export const propTypes = {
+  sizes: standardSizeTypes
+}
+
+const defaultProps = {
+  size: 'md'
+}
+
+const Control = props => {
+  const {
+    className,
+    size,
+    ...rest
+  } = props
+
+  const componentClassName = classNames(
+    'c-SkeletonControl',
+    size && `is-${size}`,
+    className
+  )
+
+  return (
+    <Block className={componentClassName} {...rest} />
+  )
+}
+
+Control.propTypes = propTypes
+Control.defaultProps = defaultProps
+Control.displayName = 'SkeletonControl'
+
+export default Control

--- a/src/components/Skeleton/README.md
+++ b/src/components/Skeleton/README.md
@@ -20,6 +20,7 @@ The default `export` of Skeleton is a plain JS-object, which contains a collecti
 
 * [Avatar](./docs/Avatar.md)
 * [Block](./docs/Block.md)
+* [Control](./docs/Control.md)
 * [Heading](./docs/Heading.md)
 * [Image](./docs/Image.md)
 * [Paragraph](./docs/Paragraph.md)

--- a/src/components/Skeleton/docs/Control.md
+++ b/src/components/Skeleton/docs/Control.md
@@ -1,0 +1,18 @@
+# Control
+
+A Skeleton.Control component is a placeholder component for form/control-based UI.
+
+
+## Example
+
+```jsx
+<Skeleton.Control />
+```
+
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| className | `string` | Custom class names to be added to the component. |
+| size | `string` | Size of the control/field. |

--- a/src/components/Skeleton/index.js
+++ b/src/components/Skeleton/index.js
@@ -1,5 +1,6 @@
 import Avatar from './Avatar'
 import Block from './Block'
+import Control from './Control'
 import Heading from './Heading'
 import Image from './Image'
 import Paragraph from './Paragraph'
@@ -9,6 +10,7 @@ const Skeleton = {}
 
 Skeleton.Avatar = Avatar
 Skeleton.Block = Block
+Skeleton.Control = Control
 Skeleton.Heading = Heading
 Skeleton.Image = Image
 Skeleton.Paragraph = Paragraph

--- a/src/components/Skeleton/tests/Control.test.js
+++ b/src/components/Skeleton/tests/Control.test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Control from '../Control'
+
+describe('className', () => {
+  test('Has default className', () => {
+    const wrapper = shallow(
+      <Control />
+    )
+
+    expect(wrapper.hasClass('c-SkeletonControl')).toBeTruthy()
+  })
+
+  test('Accepts custom classNames', () => {
+    const wrapper = shallow(
+      <Control className='ron' />
+    )
+
+    expect(wrapper.hasClass('c-SkeletonControl')).toBeTruthy()
+    expect(wrapper.hasClass('ron')).toBeTruthy()
+  })
+})
+
+describe('Styles', () => {
+  test('Can render size styles, if defined', () => {
+    const wrapper = shallow(
+      <Control size='sm' />
+    )
+
+    expect(wrapper.hasClass('is-sm')).toBeTruthy()
+  })
+})

--- a/src/styles/components/Input/InputField.scss
+++ b/src/styles/components/Input/InputField.scss
@@ -22,6 +22,7 @@
   appearance: none;
   background-color: transparent;
   border: none;
+  box-shadow: none;
   color: currentColor;
   display: block;
   height: get-height();

--- a/src/styles/components/Skeleton/SkeletonControl.scss
+++ b/src/styles/components/Skeleton/SkeletonControl.scss
@@ -1,0 +1,17 @@
+.c-SkeletonControl {
+  @import "../../resets/base";
+  $sizes: (
+    lg: 48px,
+    md: 40px,
+    sm: 32px,
+  );
+  border-radius: 4px;
+  height: 40px;
+  width: 100%;
+
+  @each $size, $height in $sizes {
+    &.is-#{$size} {
+      height: $height;
+    }
+  }
+}

--- a/src/styles/components/Skeleton/__index.scss
+++ b/src/styles/components/Skeleton/__index.scss
@@ -1,5 +1,6 @@
 @import "./SkeletonAvatar";
 @import "./SkeletonBlock";
+@import "./SkeletonControl";
 @import "./SkeletonImage";
 @import "./SkeletonParagraph";
 @import "./SkeletonText";

--- a/stories/Skeleton.js
+++ b/stories/Skeleton.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Flexy, Skeleton } from '../src/index.js'
+import { FormGroup, Flexy, Skeleton } from '../src/index.js'
 
 const stories = storiesOf('Skeleton', module)
 
@@ -30,6 +30,18 @@ stories.add('avatar', () => (
 stories.add('heading', () => (
   <div>
     <Skeleton.Heading width='70%' />
+  </div>
+))
+
+stories.add('form', () => (
+  <div style={{width: 300}}>
+    <FormGroup>
+      <Skeleton.Control size='sm' style={{marginBottom: 5}} />
+      <Skeleton.Control size='sm' />
+    </FormGroup>
+    <FormGroup>
+      <Skeleton.Control />
+    </FormGroup>
   </div>
 ))
 


### PR DESCRIPTION
## Skeleton: Add Control 💀 

![screen shot 2018-01-31 at 11 46 07 am](https://user-images.githubusercontent.com/2322354/35635775-31eefbd0-067d-11e8-8a82-b791d0109a4a.jpg)

This update adds a new Skeleton component - `Skeleton.Control`.
This component acts as a placeholder for things like
Dropdowns, Selects, Inputs, and Buttons. It has been
set up with the `size` prop that all of the components
share for their control elements.

### Firefox: Bug fix for Input red border color :bug:

![screen shot 2018-01-31 at 11 46 37 am](https://user-images.githubusercontent.com/2322354/35635769-2ec9f7de-067d-11e8-80d4-18ab28eeb7f9.jpg)

This update also fixes the red border issue for `InputField`
elements on Firefox.