### PR TITLE
AnimateGroup/Animate enhancements + Avatar size tweak

### DIFF
--- a/src/components/Animate/README.md
+++ b/src/components/Animate/README.md
@@ -35,6 +35,6 @@ An Animate component is a wrapper component that provides CSS-based animations. 
 | onExit | `function` | Callback after the component's `exit` animation sequence. |
 | onExit | `function` | Callback before the component's `exit` animation sequence. |
 | onExiting | `function` | Callback during the component's `exit` animation sequence. |
-| sequence | `string` | Names of animation styles to apply. |
+| sequence | `array`/`string` | Names of animation styles to apply. |
 | timeout | `number` | The duration (in `ms`) to apply/remove the animations. Default `0`. |
 | transitionProperty | `string` | Determines the CSS transition property. Default `all`. |

--- a/src/components/AnimateGroup/README.md
+++ b/src/components/AnimateGroup/README.md
@@ -21,6 +21,7 @@ This component is a light wrapper for `TransitionGroup` from the [react-transiti
 | className | `string` | Custom class names to be added to the component. |
 | delay | `number` | The duration (in `ms`) to delay the child animations. |
 | duration | `number` | The duration (in `ms`) for the child animation sequence. | 
+| sequence | `array`/`string` | Names of animation styles to apply to child `Animate`. |
 | stagger | `bool` | Adds an incremental delay between child `Animate` components. |
 | staggerDelay | `number` | Amount of time (`ms`) to delay for `stagger`. |
 | staggerDuration | `number` | Time (`ms`) to for staggering animation durations. |

--- a/src/components/AnimateGroup/index.js
+++ b/src/components/AnimateGroup/index.js
@@ -12,6 +12,7 @@ export const propTypes = {
   easing: PropTypes.string,
   delay: PropTypes.number,
   duration: PropTypes.number,
+  sequence: PropTypes.string,
   stagger: PropTypes.bool,
   staggerDelay: PropTypes.number,
   staggerDuration: PropTypes.number
@@ -31,6 +32,7 @@ class AnimateGroup extends Component {
       delay,
       duration,
       easing,
+      sequence,
       stagger,
       staggerDelay,
       staggerDuration,
@@ -45,25 +47,30 @@ class AnimateGroup extends Component {
     const childrenMarkup = stagger ? (
       React.Children.map(children, (child, index) => {
         if (!React.isValidElement(child)) return null
-
-        const key = child.props.id || index
-        const easingProp = child.props.easing || easing
-        /* istanbul ignore next */
-        const durationProp = (stagger && staggerDuration ? staggerDuration : duration) || child.props.duration
-        const staggerIndexDelay = (child.props.delay + ((index + 1) * staggerDelay))
-        /* istanbul ignore next */
-        const delayProp = stagger ? staggerIndexDelay : delay
-
         if (
           child.type === Animate ||
           child.type === Transition ||
           child.type === CSSTransition
         ) {
+          const key = child.props.id || child.key || index
+          // Ignoring all these because, for whatever reason, the props
+          // get lost in the JSDOM/Enzyme setup. It works in browser though.
+          /* istanbul ignore next */
+          const easingProp = child.props.easing || easing
+          /* istanbul ignore next */
+          const durationProp = (stagger && staggerDuration ? staggerDuration : duration) || child.props.duration
+          const staggerIndexDelay = (child.props.delay + ((index + 1) * staggerDelay))
+          /* istanbul ignore next */
+          const delayProp = stagger ? staggerIndexDelay : delay
+          /* istanbul ignore next */
+          const sequenceProp = child.props.sequence || sequence
+
           return React.cloneElement(child, {
             ...child.props,
             duration: durationProp,
             delay: delayProp,
             easing: easingProp,
+            sequence: sequenceProp,
             key
           })
         } else {

--- a/src/components/AnimateGroup/tests/AnimateGroup.test.js
+++ b/src/components/AnimateGroup/tests/AnimateGroup.test.js
@@ -179,3 +179,16 @@ describe('duration', () => {
     expect(o.prop('delay')).toBe(66)
   })
 })
+
+describe('sequence', () => {
+  test('Does not set sequence by default', () => {
+    const wrapper = shallow(
+      <AnimateGroup>
+        <Animate sequence='down' />
+      </AnimateGroup>
+    )
+    const o = wrapper.find(Animate)
+
+    expect(o.prop('sequence')).toContain('down')
+  })
+})

--- a/src/components/Modal/docs/Modal.md
+++ b/src/components/Modal/docs/Modal.md
@@ -36,8 +36,18 @@ A Modal component presents content within a container on top of the application'
 | closeIconRepositionDelay | `number ` | Amount of time before the [CloseButton](../../CloseButton) gets repositioned. |
 | exact | `bool` | Used with `path` and React Router. Renders if path matches _exactly_ |
 | isOpen | `bool` | Shows/hides the component. |
-| path | `string` | Renders component based on a [React Router path](https://reacttraining.com/react-router/web/api/Route/path-string). |
 | overlayClassName | `string` | Custom class names to be added to the child [Overlay](../Overlay) component. |
+| modalAnimationDelay | `number` | Custom [animation](../Animate) delay for the child [Card](../Card) component. |
+| modalAnimationDuration | `number` | Custom [animation](../Animate) duration for the child [Card](../Card) component. |
+| modalAnimationEasing | `string` | Custom [animation](../Animate) easing for the child [Card](../Card) component. |
+| modalAnimationSequence | `array`/`string` | Custom [animation](../Animate) sequence for the child [Card](../Card) component. |
+| overlayClassName | `string` | Custom class names to be added to the child [Overlay](../Overlay) component. |
+| overlayAnimationDelay | `number` | Custom [animation](../Animate) delay for the child [Overlay](../Overlay) component. |
+| overlayAnimationDuration | `number` | Custom [animation](../Animate) duration for the child [Overlay](../Overlay) component. |
+| overlayAnimationEasing | `string` | Custom [animation](../Animate) easing for the child [Overlay](../Overlay) component. |
+| overlayAnimationSequence | `array`/`string` | Custom [animation](../Animate) sequence for the child [Overlay](../Overlay) component. |
+| overlayClassName | `string` | Custom class names to be added to the child [Overlay](../Overlay) component. |
+| path | `string` | Renders component based on a [React Router path](https://reacttraining.com/react-router/web/api/Route/path-string). |
 | seamless | `bool` | Renders content with the standard [Card](../Card) UI. |
 | trigger | `element` | The UI the user clicks to trigger the modal. |
 | wrapperClassName | `string` | Custom className to add to the [PortalWrapper](../../PortalWrapper) component. |

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -21,7 +21,19 @@ export const propTypes = Object.assign({}, portalTypes, {
   closeIcon: PropTypes.bool,
   closeIconRepositionDelay: PropTypes.number,
   modalAnimationDelay: PropTypes.number,
+  modalAnimationDuration: PropTypes.number,
+  modalAnimationEasing: PropTypes.string,
+  modalAnimationSequence: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string
+  ]),
   overlayAnimationDelay: PropTypes.number,
+  overlayAnimationDuration: PropTypes.number,
+  overlayAnimationEasing: PropTypes.string,
+  overlayAnimationSequence: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string
+  ]),
   overlayClassName: PropTypes.string,
   seamless: PropTypes.bool,
   trigger: PropTypes.element,
@@ -34,10 +46,16 @@ const defaultProps = {
   seamless: false,
   isOpen: false,
   closeIconRepositionDelay: 50,
-  modalAnimationDelay: 180,
-  overlayAnimationDelay: 180,
+  modalAnimationDelay: 0,
+  modalAnimationDuration: 200,
+  modalAnimationEasing: 'bounce',
+  modalAnimationSequence: 'fade down',
+  overlayAnimationDelay: 0,
+  overlayAnimationDuration: 200,
+  overlayAnimationEasing: 'ease',
+  overlayAnimationSequence: 'fade',
   onScroll: noop,
-  timeout: 180,
+  timeout: 80,
   wrapperClassName: 'c-ModalWrapper'
 }
 
@@ -79,9 +97,10 @@ class Modal extends Component {
       !isNodeElement(scrollNode)
     ) return
 
-    let delay = modalAnimationDelay && modalAnimationDelay.in
     /* istanbul ignore next */
-    delay = delay < modalAnimationDelay ? delay : closeIconRepositionDelay
+    const delay = modalAnimationDelay < closeIconRepositionDelay
+      ? closeIconRepositionDelay
+      : modalAnimationDelay
 
     const defaultOffset = 8
     const borderOffset = 2
@@ -112,10 +131,16 @@ class Modal extends Component {
       exact,
       isOpen,
       modalAnimationDelay,
+      modalAnimationDuration,
+      modalAnimationEasing,
+      modalAnimationSequence,
       onClose,
       onScroll,
       openPortal,
       overlayAnimationDelay,
+      overlayAnimationDuration,
+      overlayAnimationEasing,
+      overlayAnimationSequence,
       overlayClassName,
       path,
       portalIsMounted,
@@ -189,14 +214,20 @@ class Modal extends Component {
           <Animate
             className='c-Modal__Card-container'
             delay={modalAnimationDelay}
+            duration={modalAnimationDuration}
             easing='elastic'
             in={portalIsOpen}
-            sequence='fade down'
+            sequence={modalAnimationSequence}
           >
             {modalContentMarkup}
           </Animate>
         </div>
-        <Animate sequence='fade' in={portalIsOpen} delay={overlayAnimationDelay}>
+        <Animate
+          delay={overlayAnimationDelay}
+          duration={overlayAnimationDuration}
+          in={portalIsOpen}
+          sequence={overlayAnimationSequence}
+        >
           <Overlay className={overlayComponentClassName} onClick={closePortal} role='presentation' />
         </Animate>
       </div>

--- a/src/styles/components/Animate/sequences/_fade.scss
+++ b/src/styles/components/Animate/sequences/_fade.scss
@@ -7,4 +7,7 @@
     opacity: 1;
     pointer-events: auto;
   }
+  &.ax-exiting {
+    pointer-events: none;
+  }
 }

--- a/src/styles/components/Avatar.scss
+++ b/src/styles/components/Avatar.scss
@@ -16,7 +16,7 @@
       font-size: 13px,
     ),
     sm: (
-      size: 26px,
+      size: 30px,
       font-size: 10px,
     ),
   );

--- a/stories/AnimateGroup/index.js
+++ b/stories/AnimateGroup/index.js
@@ -7,7 +7,7 @@ const stories = storiesOf('AnimateGroup', module)
 stories.add('default', () => (
   <div>
     <p>Stagger fade in</p>
-    <AnimateGroup stagger staggerDelay={500}>
+    <AnimateGroup stagger>
       <Animate sequence='fade'>
         <div>Fade in</div>
       </Animate>
@@ -31,28 +31,28 @@ stories.add('expand', () => (
       <Card>
         <div>Card</div>
       </Card>
-      <AnimateGroup stagger staggerDelay={700}>
-        <Animate sequence='fade up' duration={700}>
+      <AnimateGroup stagger>
+        <Animate sequence='fade up'>
           <Card>
             <div>Expand, Up</div>
           </Card>
         </Animate>
-        <Animate sequence='expand fade scale' duration={700}>
+        <Animate sequence='expand fade scale'>
           <Card>
             <div>Expand, Fade, Scale</div>
           </Card>
         </Animate>
-        <Animate sequence='expand fade left' duration={700}>
+        <Animate sequence='expand fade left'>
           <Card>
             <div>Expand, Fade, Left</div>
           </Card>
         </Animate>
-        <Animate sequence='expand fade right' duration={700}>
+        <Animate sequence='expand fade right'>
           <Card>
             <div>Expand, Fade, Right</div>
           </Card>
         </Animate>
-        <Animate sequence='expand fade down' duration={700}>
+        <Animate sequence='expand fade down'>
           <Card>
             <div>Expand, Fade, Down</div>
           </Card>
@@ -62,5 +62,28 @@ stories.add('expand', () => (
         <div>Card</div>
       </Card>
     </div>
+  </div>
+))
+
+stories.add('sequence', () => (
+  <div>
+    <p>Sequence defined by Group</p>
+    <AnimateGroup stagger sequence='fade left'>
+      <Animate>
+        <div>Element</div>
+      </Animate>
+      <Animate>
+        <div>Element</div>
+      </Animate>
+      <Animate>
+        <div>Element</div>
+      </Animate>
+      <Animate>
+        <div>Element</div>
+      </Animate>
+      <Animate>
+        <div>Element</div>
+      </Animate>
+    </AnimateGroup>
   </div>
 ))


### PR DESCRIPTION
## AnimateGroup/Animate enhancements + Avatar size tweak ✨ 

This update enhances the AnimateGroup to better pass down props to
Animate, specifically the `sequence` prop. This allows you to more easily
write markup for your AnimateGroup + Animate components.

![screen recording 2018-02-01 at 02 15 pm](https://user-images.githubusercontent.com/2322354/35699158-3ef83a36-075d-11e8-93e3-3611c798586e.gif)

(Modals feel a lot more snappier + responsive)

Modal's (user) experience has also been greatly improved be adjusting
the delay/duration/timeout props. All of these properties have now
been exposed to the user for custom adjustments, if they so choose.

Lastly, the Avatar component's small size has been bumped up to 30px.