### PR TITLE
Select: Fix placeholder for Firefox

### DIFF
--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -117,7 +117,7 @@ class Select extends Component {
       onChange,
       onFocus,
       options,
-      placeholder,
+      placeholder: placeholderProp,
       prefix,
       removeStateStylesOnFocus,
       seamless,
@@ -129,7 +129,7 @@ class Select extends Component {
       ...rest
     } = this.props
 
-    const { state } = this.state
+    const { placeholder, state } = this.state
 
     const handleOnFocus = this.handleOnFocus
     const hasPlaceholder = this.hasPlaceholder()
@@ -181,14 +181,16 @@ class Select extends Component {
 
     const optionsMarkup = children || (Array.isArray(options) ? options.map(renderOptions) : renderOptions(options))
 
-    const placeholderMarkup = hasPlaceholder
-      ? <option
-        label={this.state.placeholder}
+    const placeholderMarkup = hasPlaceholder ? (
+      <option
+        label={placeholder}
         value={PLACEHOLDER_VALUE}
         disabled
         hidden
-        />
-      : null
+      >
+        {placeholder}
+      </option>
+    ) : null
 
     const labelMarkup = label
       ? <Label for={id}>{label}</Label>

--- a/src/components/Select/tests/Select.test.js
+++ b/src/components/Select/tests/Select.test.js
@@ -9,8 +9,10 @@ describe('Placeholder', () => {
     const wrapper = mount(<Select options={options} placeholder={placeholder} />)
     const select = wrapper.find('select')
     const selectOptions = select.children()
+    const option = selectOptions.first()
 
-    expect(selectOptions.first().prop('label')).toBe(placeholder)
+    expect(option.prop('label')).toBe(placeholder)
+    expect(option.text()).toBe(placeholder)
   })
 
   test('Does not render a placeholder if a value is passed', () => {

--- a/src/styles/components/Select/Select.scss
+++ b/src/styles/components/Select/Select.scss
@@ -38,7 +38,7 @@
 
   &.has-placeholder {
     #{$InputField} {
-      opacity: 0.6;
+      opacity: 0.3;
     }
   }
 }


### PR DESCRIPTION
## Select: Fix placeholder for Firefox 🦊 

![screen recording 2018-02-02 at 09 01 pm](https://user-images.githubusercontent.com/2322354/35761932-d52aedf0-085c-11e8-983f-7688c764e4f4.gif)

This update fixes the Select component to properly render a placeholder
for Firefox. The fix was to include the placeholder text as textNode
for the `<option>` element.

Previously, it was only used as a `label` prop. Chrome/Safari recognized
this, but Firefox did not.

With this update, all 3 browsers recognize the placeholder just fine.