### PR TITLE
Modal: Allow for modalAnimationEasing to be passed

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -214,7 +214,7 @@ class Modal extends Component {
             className='c-Modal__Card-container'
             delay={modalAnimationDelay}
             duration={modalAnimationDuration}
-            easing='elastic'
+            easing={modalAnimationEasing}
             in={portalIsOpen}
             sequence={modalAnimationSequence}
           >

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -674,3 +674,33 @@ describe('isOpen', () => {
       })
   })
 })
+
+
+describe('modalAnimation', () => {
+  test('modalAnimationDelay can be passed to Animate component', () => {
+    const wrapper = shallow (
+      <ModalComponent modalAnimationDelay={66} />
+    )
+    const o = wrapper.find('.c-Modal__Card-container')
+
+    expect(o.prop('delay')).toBe(66)
+  })
+
+  test('modalAnimationDuration can be passed to Animate component', () => {
+    const wrapper = shallow (
+      <ModalComponent modalAnimationDuration={66} />
+    )
+    const o = wrapper.find('.c-Modal__Card-container')
+
+    expect(o.prop('duration')).toBe(66)
+  })
+
+  test('modalAnimationEasing can be passed to Animate component', () => {
+    const wrapper = shallow (
+      <ModalComponent modalAnimationEasing='fakeBounce' />
+    )
+    const o = wrapper.find('.c-Modal__Card-container')
+
+    expect(o.prop('easing')).toBe('fakeBounce')
+  })
+})


### PR DESCRIPTION
## Modal: Allow for modalAnimationEasing to be passed

This update resolves the `modalAnimationEasing` prop in the `Modal`
component to ensure that it gets passed to the appropriate `Animate` component.

Tests has been added for the various modalAnimation props.

Resolves: https://github.com/helpscout/blue/issues/197