### PR TITLE
Modal and control enhancements

### DIFF
--- a/src/components/Drop/tests/Drop.test.js
+++ b/src/components/Drop/tests/Drop.test.js
@@ -27,6 +27,10 @@ const trigger = (
   <a className='trigger'>Trigger</a>
 )
 
+beforeEach(() => {
+  document.body.innerHTML = ''
+})
+
 afterEach(() => {
   document.body.innerHTML = ''
 })
@@ -145,9 +149,8 @@ describe('Trigger', () => {
 })
 
 describe('wrapperClassName', () => {
-  const TestComponent = Drop()(ContentComponent)
-
   test('Adds default wrapperClassName', (done) => {
+    const TestComponent = Drop()(ContentComponent)
     mount(<TestComponent isOpen />)
 
     wait(40).then(() => {
@@ -158,6 +161,7 @@ describe('wrapperClassName', () => {
   })
 
   test('Can customize wrapperClassName', (done) => {
+    const TestComponent = Drop()(ContentComponent)
     mount(<TestComponent isOpen wrapperClassName='ron' />)
 
     wait(40).then(() => {

--- a/src/components/Dropdown/Menu.js
+++ b/src/components/Dropdown/Menu.js
@@ -365,7 +365,7 @@ class Menu extends Component {
           <KeypressListener keyCode={Keys.LEFT_ARROW} handler={handleLeftArrow} type='keydown' />
           <KeypressListener keyCode={Keys.RIGHT_ARROW} handler={handleRightArrow} type='keydown' />
           <KeypressListener keyCode={Keys.ESCAPE} handler={handleEscape} />
-          <Animate sequence='fade down' in={isOpen} duration={160}>
+          <Animate sequence='fade down' in={isOpen} duration={160} timeout={80}>
             <Card seamless floating>
               <div
                 className='c-DropdownMenu__content'

--- a/src/components/Dropdown/tests/Menu.test.js
+++ b/src/components/Dropdown/tests/Menu.test.js
@@ -238,7 +238,7 @@ describe('Items', () => {
       .then(() => {
         wrapper.unmount()
       })
-      .then(() => wait(100))
+      .then(() => wait(300))
       .then(() => {
         expect(spy).toHaveBeenCalled()
         wrapper.unmount()

--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -25,9 +25,11 @@ An Input component is an enhanced version of the default HTML `<input>`. Input c
 | autoFocus | `bool` | Automatically focuses the input. |
 | className | `string` | Custom class names to be added to the component. |
 | disabled | `bool` | Disable the input. |
+| forceAutoFocusTimeout | `bool` | Determines the amount of time (`ms`) for the component to focus on mount. |
 | helpText | `string` | Displays text underneath input. |
 | hintText | `string` | Displays text above input. |
 | id | `string` | ID for the input. |
+| isFocused | `string` | Determines if the component is focused. |
 | label | `string` | Label for the input. |
 | multiline | `bool`/`number` | Transforms input into an auto-expanding textarea. |
 | name | `string` | Name for the input. |

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -79,7 +79,7 @@ class Input extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    const { value, state } = nextProps
+    const { isFocused, value, state } = nextProps
     const prevValue = this.state.value
     const prevState = this.state.state
 
@@ -91,6 +91,11 @@ class Input extends Component {
     if (state !== prevState) {
       this.setState({state})
     }
+
+    /* istanbul ignore else */
+    if (isFocused) {
+      this.forceAutoFocus()
+    }
   }
 
   componentWillUnmount () {
@@ -100,11 +105,18 @@ class Input extends Component {
   maybeForceAutoFocus () {
     const {
       autoFocus,
-      forceAutoFocusTimeout,
       isFocused
     } = this.props
 
-    if ((autoFocus || isFocused) && this.inputNode) {
+    if ((autoFocus || isFocused)) {
+      this.forceAutoFocus()
+    }
+  }
+
+  forceAutoFocus () {
+    const { forceAutoFocusTimeout } = this.props
+    /* istanbul ignore else */
+    if (this.inputNode) {
       setTimeout(() => {
         this.inputNode.focus()
       }, forceAutoFocusTimeout)

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -15,9 +15,11 @@ export const propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   hintText: PropTypes.string,
-  helpText: PropTypes.string,
+  modalhelpText: PropTypes.string,
+  forceAutoFocusTimeout: PropTypes.number,
   id: PropTypes.string,
   inputRef: PropTypes.func,
+  isFocused: PropTypes.bool,
   label: PropTypes.string,
   multiline: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
   name: PropTypes.string,
@@ -40,7 +42,9 @@ export const propTypes = {
 const defaultProps = {
   autoFocus: false,
   disabled: false,
+  forceAutoFocusTimeout: 120,
   inputRef: noop,
+  isFocused: false,
   multiline: null,
   onBlur: noop,
   onChange: noop,
@@ -64,9 +68,14 @@ class Input extends Component {
       state: props.state,
       value: props.value
     }
+    this.inputNode = null
     this.handleOnChange = this.handleOnChange.bind(this)
     this.handleOnInputFocus = this.handleOnInputFocus.bind(this)
     this.handleExpandingResize = this.handleExpandingResize.bind(this)
+  }
+
+  componentDidMount () {
+    this.maybeForceAutoFocus()
   }
 
   componentWillReceiveProps (nextProps) {
@@ -81,6 +90,24 @@ class Input extends Component {
     /* istanbul ignore else */
     if (state !== prevState) {
       this.setState({state})
+    }
+  }
+
+  componentWillUnmount () {
+    this.inputNode = null
+  }
+
+  maybeForceAutoFocus () {
+    const {
+      autoFocus,
+      forceAutoFocusTimeout,
+      isFocused
+    } = this.props
+
+    if ((autoFocus || isFocused) && this.inputNode) {
+      setTimeout(() => {
+        this.inputNode.focus()
+      }, forceAutoFocusTimeout)
     }
   }
 
@@ -108,10 +135,12 @@ class Input extends Component {
       autoFocus,
       className,
       disabled,
+      forceAutoFocusTimeout,
       helpText,
       hintText,
       id,
       inputRef,
+      isFocused,
       label,
       multiline,
       name,
@@ -199,7 +228,10 @@ class Input extends Component {
       className: fieldClassName,
       id: inputID,
       onChange: handleOnChange,
-      ref: inputRef,
+      ref: (node) => {
+        this.inputNode = node
+        inputRef(node)
+      },
       autoFocus,
       disabled,
       name,

--- a/src/components/Input/tests/Input.test.js
+++ b/src/components/Input/tests/Input.test.js
@@ -350,3 +350,46 @@ describe('removeStateStylesOnFocus', () => {
     expect(input.hasClass('is-error')).toBe(false)
   })
 })
+
+describe('inputNode', () => {
+  test('Sets inputNode on mount', () => {
+    const wrapper = mount(<Input />)
+
+    expect(wrapper.node.inputNode).toBeTruthy()
+  })
+
+  test('Unsets inputNode on unmount', () => {
+    const wrapper = mount(<Input />)
+    wrapper.unmount()
+
+    expect(wrapper.node.inputNode).not.toBeTruthy()
+  })
+})
+
+describe('isFocused', () => {
+  test('Can focus input using isFocused prop', (done) => {
+    const wrapper = mount(<Input isFocused />)
+    const o = wrapper.node.inputNode
+    setTimeout(() => {
+      expect(document.activeElement.isEqualNode(o)).toBeTruthy()
+      done()
+    }, 160)
+  })
+
+  test('Can focus input using custom timeout', (done) => {
+    const wrapper = mount(
+      <Input
+        isFocused
+        forceAutoFocusTimeout={20}
+      />
+    )
+    const o = wrapper.node.inputNode
+
+    expect(document.activeElement.isEqualNode(o)).not.toBeTruthy()
+
+    setTimeout(() => {
+      expect(document.activeElement.isEqualNode(o)).toBeTruthy()
+      done()
+    }, 40)
+  })
+})

--- a/src/components/Input/tests/Input.test.js
+++ b/src/components/Input/tests/Input.test.js
@@ -368,15 +368,19 @@ describe('inputNode', () => {
 
 describe('isFocused', () => {
   test('Can focus input using isFocused prop', (done) => {
+    const spy = jest.fn()
     const wrapper = mount(<Input isFocused />)
     const o = wrapper.node.inputNode
+    o.onfocus = spy
+
     setTimeout(() => {
-      expect(document.activeElement.isEqualNode(o)).toBeTruthy()
+      expect(spy).toHaveBeenCalled()
       done()
     }, 160)
   })
 
   test('Can focus input using custom timeout', (done) => {
+    const spy = jest.fn()
     const wrapper = mount(
       <Input
         isFocused
@@ -384,11 +388,32 @@ describe('isFocused', () => {
       />
     )
     const o = wrapper.node.inputNode
+    o.onfocus = spy
 
-    expect(document.activeElement.isEqualNode(o)).not.toBeTruthy()
+    expect(spy).not.toHaveBeenCalled()
 
     setTimeout(() => {
-      expect(document.activeElement.isEqualNode(o)).toBeTruthy()
+      expect(spy).toHaveBeenCalled()
+      done()
+    }, 40)
+  })
+
+  test('Can toggle isFocused', (done) => {
+    const spy = jest.fn()
+    const wrapper = mount(
+      <Input
+        onFocus={spy}
+        isFocused={false}
+        forceAutoFocusTimeout={20}
+      />
+    )
+    const o = wrapper.node.inputNode
+    o.onfocus = spy
+
+    wrapper.setProps({isFocused: true})
+
+    setTimeout(() => {
+      expect(spy).toHaveBeenCalled()
       done()
     }, 40)
   })

--- a/src/components/PortalWrapper/tests/PortalWrapper.test.js
+++ b/src/components/PortalWrapper/tests/PortalWrapper.test.js
@@ -281,3 +281,84 @@ describe('Mounting', () => {
     expect(o._isMounted).toBe(false)
   })
 })
+
+describe('Trigger', () => {
+  test('Sets triggerNode on mount', () => {
+    const TestComponent = PortalWrapper(options)(TestButton)
+    const trigger = (
+      <button>Trigger</button>
+    )
+    const wrapper = mount(<TestComponent timeout={0} trigger={trigger} />)
+    const o = wrapper.node
+
+    expect(o.triggerComponent).toBeTruthy()
+    expect(o.triggerNode).toBeTruthy()
+  })
+
+  test('Unsets triggerNode on unmount', () => {
+    const TestComponent = PortalWrapper(options)(TestButton)
+    const trigger = (
+      <button>Trigger</button>
+    )
+    const wrapper = mount(<TestComponent timeout={0} trigger={trigger} />)
+    const o = wrapper.node
+
+    wrapper.unmount()
+
+    expect(o.triggerNode).not.toBeTruthy()
+  })
+
+  test('Focuses triggerNode if prop change remains false', (done) => {
+    const TestComponent = PortalWrapper(options)(TestButton)
+    const trigger = (
+      <button>Trigger</button>
+    )
+    const wrapper = mount(<TestComponent timeout={0} trigger={trigger} />)
+    wrapper.setProps({ isOpen: false })
+
+    setTimeout(() => {
+      expect(document.activeElement.isEqualNode(wrapper.node.triggerNode)).toBeTruthy()
+      done()
+    }, 100)
+  })
+
+  test('Focuses triggerNode on isOpen prop change to false', (done) => {
+    const TestComponent = PortalWrapper(options)(TestButton)
+    const trigger = (
+      <button>Trigger</button>
+    )
+    const wrapper = mount(<TestComponent timeout={0} trigger={trigger} isOpen />)
+    wrapper.setProps({ isOpen: false })
+
+    setTimeout(() => {
+      expect(document.activeElement.isEqualNode(wrapper.node.triggerNode)).toBeTruthy()
+      document.activeElement.blur()
+      done()
+    }, 100)
+  })
+
+  test('Allows for ref', () => {
+    const TestComponent = PortalWrapper(options)(TestButton)
+    let refNode = null
+    const trigger = (
+      <div ref={node => { refNode = node }}>Trigger</div>
+    )
+    mount(<TestComponent timeout={0} trigger={trigger} isOpen />)
+
+    expect(refNode).not.toBe(null)
+  })
+
+  test('Allows for onClick', () => {
+    const spy = jest.fn()
+    const TestComponent = PortalWrapper(options)(TestButton)
+    const trigger = (
+      <div onClick={spy} className='trigger'>Trigger</div>
+    )
+    const wrapper = mount(<TestComponent timeout={0} trigger={trigger} isOpen />)
+    const o = wrapper.find('.trigger')
+
+    o.simulate('click')
+
+    expect(spy).toHaveBeenCalled()
+  })
+})

--- a/src/components/Select/README.md
+++ b/src/components/Select/README.md
@@ -45,8 +45,10 @@ This component also accepts regular `<option>` elements as children.
 | autoFocus | `bool` | Automatically focuses the select. |
 | className | `string` | Custom class names to be added to the component. |
 | disabled | `bool` | Disable the select. |
+| forceAutoFocusTimeout | `bool` | Determines the amount of time (`ms`) for the component to focus on mount. |
 | helpText | `string` | Displays text underneath select. |
 | id | `string` | ID for the select. |
+| isFocused | `string` | Determines if the component is focused. |
 | label | `string` | Label for the select. |
 | name | `string` | Name for the select. |
 | onBlur | `function` | Callback when select is blurred. |

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -27,8 +27,10 @@ export const propTypes = {
   autoFocus: PropTypes.bool,
   className: PropTypes.string,
   disabled: PropTypes.bool,
+  forceAutoFocusTimeout: PropTypes.number,
   helpText: PropTypes.string,
   id: PropTypes.string,
+  isFocused: PropTypes.bool,
   label: PropTypes.string,
   name: PropTypes.string,
   options: PropTypes.oneOfType([
@@ -52,6 +54,7 @@ export const propTypes = {
 const defaultProps = {
   autoFocus: false,
   disabled: false,
+  forceAutoFocusTimeout: 120,
   onBlur: noop,
   onChange: noop,
   onFocus: noop,
@@ -70,6 +73,11 @@ class Select extends Component {
       value: props.value
     }
     this.handleOnFocus = this.handleOnFocus.bind(this)
+    this.selectNode = null
+  }
+
+  componentDidMount () {
+    this.maybeForceAutoFocus()
   }
 
   componentWillReceiveProps (nextProps) {
@@ -79,6 +87,24 @@ class Select extends Component {
     /* istanbul ignore else */
     if (state !== prevState) {
       this.setState({state})
+    }
+  }
+
+  componentWillUnmount () {
+    this.selectNode = null
+  }
+
+  maybeForceAutoFocus () {
+    const {
+      autoFocus,
+      forceAutoFocusTimeout,
+      isFocused
+    } = this.props
+
+    if ((autoFocus || isFocused) && this.selectNode) {
+      setTimeout(() => {
+        this.selectNode.focus()
+      }, forceAutoFocusTimeout)
     }
   }
 
@@ -109,8 +135,10 @@ class Select extends Component {
       children,
       className,
       disabled,
+      forceAutoFocusTimeout,
       helpText,
       id,
+      isFocused,
       label,
       onChange,
       onFocus,
@@ -218,6 +246,7 @@ class Select extends Component {
             id={id}
             onChange={e => this.handleOnChange(e)}
             onFocus={handleOnFocus}
+            ref={node => { this.selectNode = node }}
             value={selectedValue}
             {...rest}
           >

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -81,12 +81,17 @@ class Select extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    const { state } = nextProps
+    const { isFocused, state } = nextProps
     const prevState = this.state.state
 
     /* istanbul ignore else */
     if (state !== prevState) {
       this.setState({state})
+    }
+
+    /* istanbul ignore else */
+    if (isFocused) {
+      this.forceAutoFocus()
     }
   }
 
@@ -97,11 +102,18 @@ class Select extends Component {
   maybeForceAutoFocus () {
     const {
       autoFocus,
-      forceAutoFocusTimeout,
       isFocused
     } = this.props
 
-    if ((autoFocus || isFocused) && this.selectNode) {
+    if ((autoFocus || isFocused)) {
+      this.forceAutoFocus()
+    }
+  }
+
+  forceAutoFocus () {
+    const { forceAutoFocusTimeout } = this.props
+    /* istanbul ignore else */
+    if (this.selectNode) {
       setTimeout(() => {
         this.selectNode.focus()
       }, forceAutoFocusTimeout)

--- a/src/components/Select/tests/Select.test.js
+++ b/src/components/Select/tests/Select.test.js
@@ -340,15 +340,19 @@ describe('selectNode', () => {
 
 describe('isFocused', () => {
   test('Can focus select using isFocused prop', (done) => {
+    const spy = jest.fn()
     const wrapper = mount(<Select isFocused />)
     const o = wrapper.node.selectNode
+    o.onfocus = spy
+
     setTimeout(() => {
-      expect(document.activeElement.isEqualNode(o)).toBeTruthy()
+      expect(spy).toHaveBeenCalled()
       done()
     }, 160)
   })
 
   test('Can focus select using custom timeout', (done) => {
+    const spy = jest.fn()
     const wrapper = mount(
       <Select
         isFocused
@@ -356,9 +360,32 @@ describe('isFocused', () => {
       />
     )
     const o = wrapper.node.selectNode
+    o.onfocus = spy
+
+    expect(spy).not.toHaveBeenCalled()
 
     setTimeout(() => {
-      expect(document.activeElement.isEqualNode(o)).toBeTruthy()
+      expect(spy).toHaveBeenCalled()
+      done()
+    }, 40)
+  })
+
+  test('Can toggle isFocused', (done) => {
+    const spy = jest.fn()
+    const wrapper = mount(
+      <Select
+        onFocus={spy}
+        isFocused={false}
+        forceAutoFocusTimeout={20}
+      />
+    )
+    const o = wrapper.node.selectNode
+    o.onfocus = spy
+
+    wrapper.setProps({isFocused: true})
+
+    setTimeout(() => {
+      expect(spy).toHaveBeenCalled()
       done()
     }, 40)
   })

--- a/src/components/Select/tests/Select.test.js
+++ b/src/components/Select/tests/Select.test.js
@@ -322,3 +322,44 @@ describe('removeStateStylesOnFocus', () => {
     expect(select.hasClass('is-error')).toBe(false)
   })
 })
+
+describe('selectNode', () => {
+  test('Sets selectNode on mount', () => {
+    const wrapper = mount(<Select />)
+
+    expect(wrapper.node.selectNode).toBeTruthy()
+  })
+
+  test('Unsets selectNode on unmount', () => {
+    const wrapper = mount(<Select />)
+    wrapper.unmount()
+
+    expect(wrapper.node.selectNode).not.toBeTruthy()
+  })
+})
+
+describe('isFocused', () => {
+  test('Can focus select using isFocused prop', (done) => {
+    const wrapper = mount(<Select isFocused />)
+    const o = wrapper.node.selectNode
+    setTimeout(() => {
+      expect(document.activeElement.isEqualNode(o)).toBeTruthy()
+      done()
+    }, 160)
+  })
+
+  test('Can focus select using custom timeout', (done) => {
+    const wrapper = mount(
+      <Select
+        isFocused
+        forceAutoFocusTimeout={20}
+      />
+    )
+    const o = wrapper.node.selectNode
+
+    setTimeout(() => {
+      expect(document.activeElement.isEqualNode(o)).toBeTruthy()
+      done()
+    }, 40)
+  })
+})

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Perf from 'react-addons-perf'
 import { storiesOf } from '@storybook/react'
-import { Button, EmojiPicker, Heading, Modal, Link, Toolbar } from '../src/index.js'
+import { Button, EmojiPicker, Heading, Modal, Link, Input, Toolbar } from '../src/index.js'
 import { MemoryRouter } from 'react-router'
 import { Route } from 'react-router-dom'
 import { createSpec, faker } from '@helpscout/helix'
@@ -15,6 +15,90 @@ const ContentSpec = createSpec({
   content: faker.lorem.paragraph(),
   id: faker.random.uuid()
 })
+
+class StatefulComponent extends React.Component {
+  constructor () {
+    super()
+    this.state = {
+      showModal: false,
+      value: ''
+    }
+    this.handleOnButtonClick = this.handleOnButtonClick.bind(this)
+    this.handleOnInputChange = this.handleOnInputChange.bind(this)
+    this.handleOnSubmit = this.handleOnSubmit.bind(this)
+    this.handleOnModalOpen = this.handleOnModalOpen.bind(this)
+    this.handleOnModalClose = this.handleOnModalClose.bind(this)
+  }
+
+  handleOnButtonClick () {
+    this.setState({
+      showModal: !this.state.showModal
+    })
+  }
+
+  handleOnInputChange (value) {
+    this.setState({
+      value
+    })
+  }
+
+  handleOnModalOpen () {
+    const inputNode = document.querySelector('input')
+    if (inputNode) {
+      inputNode.focus()
+    }
+  }
+
+  handleOnModalClose () {
+    this.setState({
+      showModal: false
+    })
+  }
+
+  handleOnSubmit () {
+    this.setState({
+      showModal: false,
+      value: ''
+    })
+  }
+
+  render () {
+    const { showModal, value } = this.state
+
+    const triggerMarkup = (
+      <Button
+        onClick={this.handleOnButtonClick}
+        theme={value ? 'editing' : null}
+      >
+        {value ? 'Keep Editing' : 'Reply'}
+      </Button>
+    )
+
+    return (
+      <Modal
+        closeIcon={false}
+        isOpen={showModal}
+        trigger={triggerMarkup}
+        onOpen={this.handleOnModalOpen}
+        onClose={this.handleOnModalClose}
+      >
+        <Modal.Body>
+          <Modal.Content>
+            <Input
+              autoFocus
+              multiline={3}
+              onChange={this.handleOnInputChange}
+              value={value}
+            />
+            <Button onClick={this.handleOnSubmit} primary>
+              Submit
+            </Button>
+          </Modal.Content>
+        </Modal.Body>
+      </Modal>
+    )
+  }
+}
 
 stories.addDecorator(story => (
   <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>
@@ -288,3 +372,11 @@ stories.add('routes', () => {
     </div>
   )
 })
+
+stories.add('stateful example', () => (
+  <div>
+    <button>Does Nothing</button>
+    <hr />
+    <StatefulComponent />
+  </div>
+))

--- a/test/acceptance/components/Dropdown.spec.js
+++ b/test/acceptance/components/Dropdown.spec.js
@@ -10,7 +10,7 @@ const simulateKeyPress = (keyCode) => {
   document.dispatchEvent(event)
 }
 
-const waitTime = 400
+const waitTime = 420
 
 describe('Dropdown', () => {
   it('should open menu on trigger click', (done) => {


### PR DESCRIPTION
## Modal and control enhancements 🙌 

![screen recording 2018-02-03 at 05 35 pm](https://user-images.githubusercontent.com/2322354/35772253-acb85ab8-0908-11e8-8b6c-bdad0348eb52.gif)

### PortalWrapper (Modal and Dropdown) enhancements

This update fixes and imporoves PortalWrapper (and Modal/Drop
components indirectly) by changing how the `isOpen` state/prop determines
the PortalWrapper's open state.

This allows for Portal'ed components to **remain open** even if there are
prop/state changes for their composed/children components determined by
a parent component (e.g. a Redux setup).

PortalWrapper has also been enhanced to refocus the trigger node after
closing, if the Trigger node is available.

Lastly, the `timeout` prop (and HOC option) is resolved, allowing for
ComposedComponents to be unmounted in the expected `setTimeout` value.


### Input/Select: Add ability to toggle isFocused

This update enhances the isFocused prop on Input and Select to be able
to force focus when the isFocused prop is changed to `true`

Tests have been updated to check for this functionality.


### Input + Select: (Force) autoFocus

This update enhances the Input and Select components to be able to
(better) autoFocus when they mount. It also allows for the user to
set the focus state using the new `isFocused` prop.

Lastly, there's a `forceAutoFocusTimeout` prop that allows the user to
fine tune when they would like the `setTimeout` based autofocus function
to fire (which is required for this technique to work).