### PR TITLE
Button: Add themes (and adjust styles)

### DIFF
--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -37,4 +37,5 @@ This component is extended by the `RouteWrapper` higher order component, and can
 | size | `string` | Sets the size of the button. Can be one of `"sm"`, `"md"` or `"lg"`. |
 | state | `string` | Applies state styles to the button. Can be one of `"success"`, `"error"` or `"warning"`. |
 | submit | `bool` | Sets the `type` of the button to `"submit"`. |
+| theme | `string` | Applies a theme based style to the button. |
 | to | `string` | React Router path to navigate on click. |

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -14,11 +14,13 @@ export const propTypes = {
   onClick: PropTypes.func,
   onFocus: PropTypes.func,
   isActive: PropTypes.bool,
+  outline: PropTypes.bool,
   plain: PropTypes.bool,
   primary: PropTypes.bool,
   size: standardSizeTypes,
   state: stateTypes,
-  submit: PropTypes.bool
+  submit: PropTypes.bool,
+  theme: PropTypes.string
 }
 
 const defaultProps = {
@@ -28,6 +30,7 @@ const defaultProps = {
   onBlur: noop,
   onClick: noop,
   onFocus: noop,
+  outline: false,
   plain: false,
   primary: false,
   size: '',
@@ -47,11 +50,13 @@ const Button = props => {
     onBlur,
     onClick,
     onFocus,
+    outline,
     plain,
     primary,
     size,
     state,
     submit,
+    theme,
     ...rest
   } = props
 
@@ -59,10 +64,12 @@ const Button = props => {
     'c-Button',
     isActive && 'is-selected',
     block && 'c-Button--block',
-    size && `c-Button--${size}`,
-    state && `is-${state}`,
+    outline && 'c-Button--outline',
     plain && 'c-Button--link',
     primary && 'c-Button--primary',
+    size && `c-Button--${size}`,
+    state && `is-${state}`,
+    theme && `c-Button--${theme}`,
     className
   )
 

--- a/src/components/Button/tests/Button.test.js
+++ b/src/components/Button/tests/Button.test.js
@@ -85,6 +85,34 @@ describe('States', () => {
   })
 })
 
+describe('Outline', () => {
+  test('Does not have outline by default', () => {
+    const o = wrap(<Button />)
+
+    expect(o.props().outline).not.toBeTruthy()
+  })
+
+  test('Can apply outline styles', () => {
+    const o = wrap(<Button outline />)
+
+    expect(o.hasClass('c-Button--outline')).toBeTruthy()
+  })
+})
+
+describe('Themes', () => {
+  test('Does not have a theme className by default', () => {
+    const o = wrap(<Button />)
+
+    expect(o.props().theme).not.toBeTruthy()
+  })
+
+  test('Can add theme className', () => {
+    const o = wrap(<Button theme='editing' />)
+
+    expect(o.hasClass('c-Button--editing')).toBeTruthy()
+  })
+})
+
 describe('RouteWrapper', () => {
   let options
   let push

--- a/src/styles/components/Button.scss
+++ b/src/styles/components/Button.scss
@@ -2,14 +2,55 @@ $seed-button-namespace: "c-Button";
 $seed-button-font-weight: 600;
 @import "../configs/seed-control";
 @import "pack/seed-button/_index";
+@import "pack/seed-dash/_index";
+@import "pack/seed-button/mixins/generate-button-styles";
 
 button.#{$seed-button-namespace} {
   @import "../resets/base";
 }
 
-// Not necessary with System font.
-// @-moz-document url-prefix() {
-//   .#{$seed-button-namespace} {
-//     padding-top: 1px;
-//   }
-// }
+.c-Button {
+  @import "../configs/color";
+  $themes: (
+    editing: (
+      _generate-states: false,
+      background: (
+        default: _color(yellow, 100),
+        hover: _color(yellow, 200),
+        active: darken(_color(yellow, 200), 3%),
+        focus: _color(yellow, 100),
+      ),
+      border: (
+        default: _color(yellow, 600),
+        hover: _color(yellow, 600),
+        active: _color(yellow, 700),
+        focus: darken(_color(yellow, 700), 1%),
+      ),
+      box-shadow: (
+        default: 0 0 0 1px _color(yellow, 600) inset,
+        hover: 0 0 0 1px _color(yellow, 600) inset,
+        active: 0 0 0 1px _color(yellow, 700) inset,
+        focus: 0 0 0 1px darken(_color(yellow, 700), 1%) inset,
+      ),
+      text: (
+        default: _color(yellow, 700),
+        hover: darken(_color(yellow, 700), 5%),
+        active: darken(_color(yellow, 700), 8%),
+        focus: darken(_color(yellow, 700), 5%),
+      ),
+      text-decoration: (
+        default: none,
+        hover: none,
+        active: none,
+        focus: none,
+      )
+    )
+  );
+
+  // Themes
+  @each $theme, $config in $themes {
+    &--#{$theme} {
+      @include generate-button-styles($config);
+    }
+  }
+}

--- a/stories/Button.js
+++ b/stories/Button.js
@@ -2,31 +2,43 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Button } from '../src/index.js'
 
-storiesOf('Button', module)
-  .add('default', () => <Button>Click Me</Button>)
-  .add('types', () => (
-    <div>
-      <Button>Regular</Button>
-      <Button primary>Primary</Button>
-      <Button plain>Plain</Button>
-    </div>
-  ))
-  .add('sizes', () => (
-    <div>
-      <Button size='lg'>Large</Button>
-      <Button size='md'>Medium</Button>
-      <Button size='sm'>Small</Button>
-    </div>
-  ))
-  .add('states', () => (
-    <div>
-      <Button state='success'>Success</Button>
-      <Button state='error'>Error</Button>
-      <Button state='warning'>Warning</Button>
-    </div>
-  ))
-  .add('disabled', () => (
-    <div>
-      <Button disabled>Can't touch this!</Button>
-    </div>
-  ))
+const stories = storiesOf('Button', module)
+
+stories.add('default', () => <Button>Click Me</Button>)
+
+stories.add('types', () => (
+  <div>
+    <Button>Regular</Button>
+    <Button primary>Primary</Button>
+    <Button plain>Plain</Button>
+  </div>
+))
+
+stories.add('sizes', () => (
+  <div>
+    <Button size='lg'>Large</Button>
+    <Button size='md'>Medium</Button>
+    <Button size='sm'>Small</Button>
+  </div>
+))
+
+stories.add('states', () => (
+  <div>
+    <Button state='success'>Success</Button>
+    <Button state='error'>Error</Button>
+    <Button state='warning'>Warning</Button>
+  </div>
+))
+
+stories.add('disabled', () => (
+  <div>
+    <Button disabled>Can't touch this!</Button>
+  </div>
+))
+
+stories.add('themes', () => (
+  <div>
+    <Button theme='editing' block size='lg'>Block</Button><br />
+    <Button theme='editing' block disabled>Block</Button><br />
+  </div>
+))


### PR DESCRIPTION
## Button: Add themes (and adjust styles)

![screen recording 2018-02-03 at 06 05 pm](https://user-images.githubusercontent.com/2322354/35772447-dd9781e6-090c-11e8-8284-62fe0d5bff8d.gif)

This update provides a new `theme` prop to the Button component that allows
for additional theme styles, starting with `editing`.