### PR TITLE
Avatar: Update max logic for Stack, List and Grid

### DIFF
--- a/src/components/AvatarGrid/index.js
+++ b/src/components/AvatarGrid/index.js
@@ -49,7 +49,9 @@ class AvatarGrid extends Component {
       .filter(child => child.type && child.type === Avatar)
 
     const totalAvatarCount = avatars.length
-    const avatarList = max ? avatars.slice(0, max) : avatars
+    const avatarList = max && totalAvatarCount > max
+      ? avatars.slice(0, (max - 1))
+      : avatars
     const additionalAvatarCount = totalAvatarCount - avatarList.length
 
     const componentWrapperClassName = classNames(

--- a/src/components/AvatarGrid/tests/AvatarGrid.test.js
+++ b/src/components/AvatarGrid/tests/AvatarGrid.test.js
@@ -99,10 +99,10 @@ describe('Limit', () => {
     )
     const avatar = wrapper.find(Avatar)
     const additionalCounter = avatar.last()
-    const limitCount = 3 // to account for the additional counter
+    const limitCount = 2 // to account for the additional counter
 
     expect(avatar.length).toBe(limitCount)
-    expect(additionalCounter.html()).toContain('+2')
+    expect(additionalCounter.html()).toContain('+3')
   })
 
   test('Cannot set limit to zero (0)', () => {

--- a/src/components/AvatarList/index.js
+++ b/src/components/AvatarList/index.js
@@ -48,7 +48,9 @@ class AvatarList extends Component {
       .filter(child => child.type && child.type === Avatar)
 
     const totalAvatarCount = avatars.length
-    const avatarList = max ? avatars.slice(0, max) : avatars
+    const avatarList = max && totalAvatarCount > max
+      ? avatars.slice(0, (max - 1))
+      : avatars
     const additionalAvatarCount = totalAvatarCount - avatarList.length
 
     const componentClassName = classNames(

--- a/src/components/AvatarList/tests/AvatarList.test.js
+++ b/src/components/AvatarList/tests/AvatarList.test.js
@@ -99,10 +99,10 @@ describe('Limit', () => {
     )
     const avatar = wrapper.find(Avatar)
     const additionalCounter = avatar.last()
-    const limitCount = 3 // to account for the additional counter
+    const limitCount = 2 // to account for the additional counter
 
     expect(avatar.length).toBe(limitCount)
-    expect(additionalCounter.html()).toContain('+2')
+    expect(additionalCounter.html()).toContain('+3')
   })
 
   test('Cannot set limit to zero (0)', () => {

--- a/src/components/AvatarStack/index.js
+++ b/src/components/AvatarStack/index.js
@@ -25,7 +25,7 @@ const defaultProps = {
   animationSequence: 'fade',
   animationStagger: 0,
   borderColor: 'white',
-  max: 4,
+  max: 5,
   shape: 'circle',
   size: 'md'
 }
@@ -51,7 +51,9 @@ class AvatarStack extends Component {
       .filter(child => child.type && child.type === Avatar)
 
     const totalAvatarCount = avatars.length
-    const avatarList = max ? avatars.slice(0, max) : avatars
+    const avatarList = max && totalAvatarCount > max
+      ? avatars.slice(0, (max - 1))
+      : avatars
     const additionalAvatarCount = totalAvatarCount - avatarList.length
 
     const componentClassName = classNames(

--- a/src/components/AvatarStack/tests/AvatarStack.test.js
+++ b/src/components/AvatarStack/tests/AvatarStack.test.js
@@ -99,10 +99,10 @@ describe('Limit', () => {
     )
     const avatar = wrapper.find(Avatar)
     const additionalCounter = avatar.last()
-    const limitCount = 3 // to account for the additional counter
+    const limitCount = 2 // to account for the additional counter
 
     expect(avatar.length).toBe(limitCount)
-    expect(additionalCounter.html()).toContain('+2')
+    expect(additionalCounter.html()).toContain('+3')
   })
 
   test('Cannot set limit to zero (0)', () => {

--- a/stories/AvatarStack/index.js
+++ b/stories/AvatarStack/index.js
@@ -4,7 +4,7 @@ import { Avatar, AvatarStack } from '../../src/index.js'
 import AvatarSpec from '../AvatarGrid/specs/Avatar'
 
 const stories = storiesOf('AvatarStack', module)
-const fixtures = AvatarSpec.generate(20)
+const fixtures = AvatarSpec.generate(5)
 
 const avatarsMarkup = fixtures.map(avatar => {
   const {
@@ -38,7 +38,7 @@ class TestComponent extends Component {
     console.log(`AvatarStack: TestComponent: render(${this.state.someProp})`)
     return (
       <div>
-        <AvatarStack max={4}>
+        <AvatarStack max={5}>
           {avatarsMarkup}
         </AvatarStack>
         <button onClick={this.updateState}>Update: State</button>
@@ -48,7 +48,7 @@ class TestComponent extends Component {
 }
 
 stories.add('default', () => (
-  <AvatarStack max={4}>
+  <AvatarStack max={5}>
     {avatarsMarkup}
   </AvatarStack>
 ))


### PR DESCRIPTION
## Avatar: Update max logic for Stack, List and Grid 😄 

This update adjusts the `max` limit logic for the group-based components
that contain Avatars.

The `max` now determines the total number of Avatar (circles) to show,
not the total amount of Avatars before the truncated `+n` additional
Avatar bubble.