### PR TITLE
Color: Add getColorShade function

### DIFF
--- a/src/utilities/color.js
+++ b/src/utilities/color.js
@@ -1,6 +1,8 @@
 const isHex = hex => (hex && typeof hex === 'string')
 const isNumber = value => (typeof value === 'number')
 
+const lightThreshold = 0.61
+
 // Source
 // https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
 
@@ -33,9 +35,12 @@ export const rgbToHex = (r, g, b) => {
   return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`
 }
 
-// Source
-// https://24ways.org/2010/calculating-color-contrast/
-// https://stackoverflow.com/questions/11867545/change-text-color-based-on-brightness-of-the-covered-background-area
+export const hexToHsl = (hex) => {
+  if (!isHex(hex)) return null
+  const rgb = hexToRgb(hex)
+  return rgbToHsl(rgb.r, rgb.g, rgb.b)
+}
+
 export const optimalTextColor = (backgroundHex) => {
   if (!isHex(backgroundHex)) return null
   const backgroundRgb = hexToRgb(backgroundHex)
@@ -48,6 +53,44 @@ export const optimalTextColor = (backgroundHex) => {
   )
 
   return (shade >= 128) ? 'black' : 'white'
+}
+
+export const rgbToHsl = (red, green, blue) => {
+  if (!isNumber(red) || !isNumber(green) || !isNumber(blue)) return null
+  let r = red / 255
+  let g = green / 255
+  let b = blue / 255
+
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+
+  let h
+  let s
+  let l = (max + min) / 2
+
+  if (max === min) {
+    h = 0
+    s = 0
+  } else {
+    const d = max - min
+    s = l > 0.5
+      ? d / (2 - max - min)
+      : d / (max + min)
+
+    /* istanbul ignore next */
+    switch (max) {
+      case r: h = (g - b) / d + (g < b ? 6 : 0); break
+      case g: h = (b - r) / d + 2; break
+      case b: h = (r - g) / d + 4; break
+    }
+    h /= 6
+  }
+
+  return {
+    h: h % 1 !== 0 ? (Math.round(h * 1e2) / 1e2) : h,
+    s: s % 1 !== 0 ? (Math.round(s * 1e2) / 1e2) : s,
+    l: l % 1 !== 0 ? (Math.round(l * 1e2) / 1e2) : l
+  }
 }
 
 // Source
@@ -88,4 +131,21 @@ export const lighten = (hex, value = 20) => {
 export const darken = (hex, value = 20) => {
   if (!isHex(hex) || typeof value !== 'number') return null
   return lightenDarkenColor(hex, ((value * 2.55) * -1))
+}
+
+export const getColorShade = (hex) => {
+  if (!isHex(hex)) return null
+  const hsl = hexToHsl(hex)
+  const l = hsl.l
+  const isDarkText = optimalTextColor(hex) === 'black'
+
+  if (l >= 0.9) {
+    return 'lightest'
+  } else if (l >= lightThreshold) {
+    return isDarkText ? 'light' : 'dark'
+  } else if (l >= 0.16) {
+    return isDarkText ? 'light' : 'dark'
+  } else {
+    return 'darkest'
+  }
 }

--- a/src/utilities/tests/color/getColorShade.test.js
+++ b/src/utilities/tests/color/getColorShade.test.js
@@ -1,0 +1,48 @@
+import {
+  getColorShade
+} from '../../color'
+
+test('Returns null, if invalid arguments', () => {
+  expect(getColorShade()).toBe(null)
+  expect(getColorShade(true)).toBe(null)
+  expect(getColorShade(111)).toBe(null)
+})
+
+test('Returns "lightest" for lightest colors', () => {
+  expect(getColorShade('#fff')).toBe('lightest')
+  expect(getColorShade('#eee')).toBe('lightest')
+  expect(getColorShade('#e6e6e6')).toBe('lightest')
+  expect(getColorShade('#e5e5e5')).toBe('lightest')
+})
+
+test('Returns "light" for light colors', () => {
+  expect(getColorShade('#e4e4d4')).toBe('light')
+  expect(getColorShade('#ddd')).toBe('light')
+  expect(getColorShade('#ccc')).toBe('light')
+  expect(getColorShade('#bbb')).toBe('light')
+  expect(getColorShade('#aaa')).toBe('light')
+  expect(getColorShade('#9e9e9e')).toBe('light')
+  expect(getColorShade('#2ec1a0')).toBe('light')
+  expect(getColorShade('#60a6f8')).toBe('light')
+})
+
+test('Returns "dark" for dark colors', () => {
+  expect(getColorShade('#9c9c9c')).toBe('dark')
+  expect(getColorShade('#999')).toBe('dark')
+  expect(getColorShade('#888')).toBe('dark')
+  expect(getColorShade('#777')).toBe('dark')
+  expect(getColorShade('#666')).toBe('dark')
+  expect(getColorShade('#555')).toBe('dark')
+  expect(getColorShade('#444')).toBe('dark')
+  expect(getColorShade('#333')).toBe('dark')
+  expect(getColorShade('#282828')).toBe('dark')
+  expect(getColorShade('#2dc09f')).toBe('dark')
+  expect(getColorShade('#5fa5f7')).toBe('dark')
+})
+
+test('Returns "darkest" for light colors', () => {
+  expect(getColorShade('#272727')).toBe('darkest')
+  expect(getColorShade('#222')).toBe('darkest')
+  expect(getColorShade('#111')).toBe('darkest')
+  expect(getColorShade('#000')).toBe('darkest')
+})

--- a/src/utilities/tests/color/hexToHsl.test.js
+++ b/src/utilities/tests/color/hexToHsl.test.js
@@ -1,0 +1,36 @@
+import {
+  hexToHsl
+} from '../../color'
+
+test('Returns null, if invalid arguments', () => {
+  expect(hexToHsl()).toBe(null)
+  expect(hexToHsl(true)).toBe(null)
+  expect(hexToHsl(111)).toBe(null)
+})
+
+test('Returns hsl object with valid hex', () => {
+  // Based on:
+  // https://www.rapidtables.com/convert/color/rgb-to-hsl.html
+  expect(hexToHsl('#00ff00'))
+    .toEqual({
+      h: 0.33,
+      s: 1,
+      l: 0.50
+    })
+
+  // Silver
+  expect(hexToHsl('#c0c0c0'))
+    .toEqual({
+      h: 0,
+      s: 0,
+      l: 0.75
+    })
+
+  // Teal
+  expect(hexToHsl('#008080'))
+  .toEqual({
+    h: 0.50,
+    s: 1,
+    l: 0.25
+  })
+})

--- a/src/utilities/tests/color/rgbToHsl.test.js
+++ b/src/utilities/tests/color/rgbToHsl.test.js
@@ -1,0 +1,60 @@
+import {
+  rgbToHsl
+} from '../../color'
+
+test('Returns null for invalid arguments', () => {
+  expect(rgbToHsl()).toEqual(null)
+  expect(rgbToHsl(true)).toEqual(null)
+  expect(rgbToHsl(111)).toEqual(null)
+  expect(rgbToHsl({r: 1, g: 123, b: '5'})).toEqual(null)
+})
+
+test('Correctly converts white to HSL values', () => {
+  const hsl = rgbToHsl(255, 255, 255)
+  expect(hsl.h).toBe(0)
+  expect(hsl.s).toBe(0)
+  expect(hsl.l).toBe(1)
+})
+
+test('Correctly converts dark to HSL values', () => {
+  const hsl = rgbToHsl(0, 0, 0)
+  expect(hsl.h).toBe(0)
+  expect(hsl.s).toBe(0)
+  expect(hsl.l).toBe(0)
+})
+
+test('Correctly converts darkish to HSL values', () => {
+  const hsl = rgbToHsl(0, 0, 0)
+  expect(hsl.h).toBe(0)
+  expect(hsl.s).toBe(0)
+  expect(hsl.l).toBe(0)
+})
+
+test('Correctly converts rgb values to HSL', () => {
+  // Based on:
+  // https://www.rapidtables.com/convert/color/rgb-to-hsl.html
+
+  // Lime
+  expect(rgbToHsl(0, 255, 0))
+    .toEqual({
+      h: 0.33,
+      s: 1,
+      l: 0.50
+    })
+
+  // Silver
+  expect(rgbToHsl(192, 192, 192))
+    .toEqual({
+      h: 0,
+      s: 0,
+      l: 0.75
+    })
+
+  // Teal
+  expect(rgbToHsl(0, 128, 128))
+  .toEqual({
+    h: 0.50,
+    s: 1,
+    l: 0.25
+  })
+})

--- a/stories/Color/index.js
+++ b/stories/Color/index.js
@@ -3,7 +3,8 @@ import { storiesOf } from '@storybook/react'
 import {
   darken as darkenFn,
   lighten as lightenFn,
-  optimalTextColor
+  optimalTextColor,
+  getColorShade
 } from '../../src/utilities/color'
 
 const stories = storiesOf('Utilities/Color', module)
@@ -38,6 +39,59 @@ const Color = props => {
     <div style={styles}>
       {background}<br />
       ({amount})
+    </div>
+  )
+}
+
+const Shade = props => {
+  const {
+    color,
+    lighten,
+    darken
+  } = props
+
+  const hex = color.indexOf('#') === 0 ? color : `#${color}`
+
+  const background = lighten
+    ? lightenFn(hex, lighten) : darken
+    ? darkenFn(hex, darken)
+    : hex
+
+  const styles = {
+    background,
+    borderLeft: `10px solid ${lightenFn(background, 10)}`,
+    borderRight: `10px solid ${darkenFn(background, 10)}`,
+    boxSizing: 'border-box',
+    color: optimalTextColor(background),
+    display: 'inline-block',
+    margin: 5,
+    padding: 5,
+    width: 80,
+    textAlign: 'center'
+  }
+
+  return (
+    <div style={styles}>
+      {background}<br />
+      ({getColorShade(background)})
+    </div>
+  )
+}
+
+const ShadeList = props => {
+  const { color } = props
+  return (
+    <div>
+      {[...Array(201)].map((c, index) => {
+        return (
+          <Shade color={color} lighten={((201 - index) / 2)} key={`c-l-${index}`} />
+        )
+      })}
+      {[...Array(201)].map((c, index) => {
+        return (
+          <Shade color={color} darken={(index / 2)} key={`c-${index}`} />
+        )
+      })}
     </div>
   )
 }
@@ -99,6 +153,22 @@ stories.add('darken', () => {
           <Color color='ffdd44' darken={index} key={`c-${index}`} />
         )
       })}
+    </div>
+  )
+})
+
+stories.add('shades', () => {
+  return (
+    <div>
+      <ShadeList color='#D0021B' />
+      <ShadeList color='#F8E71C' />
+      <ShadeList color='#F5A623' />
+      <ShadeList color='#7ED321' />
+      <ShadeList color='#50E3C2' />
+      <ShadeList color='#4A90E2' />
+      <ShadeList color='#BD10E0' />
+      <ShadeList color='#999999' />
+      <ShadeList color='#7e80e7' />
     </div>
   )
 })


### PR DESCRIPTION
## Color: Add getColorShade function 🖌 

![screen recording 2018-02-08 at 03 21 pm](https://user-images.githubusercontent.com/2322354/35996197-ceec80a8-0ce3-11e8-96cf-c77dd7d0f386.gif)

This update adds a new `getColorShade` color utility function that returns
whether a color (`hex`) is considered `lightest`, `light`, `dark`, or
`darkest`.

This is done by converting the Hex to RGB to HSL and using **MATH** to
figure things out.