### PR TITLE
Modal: Enhance with keyboard Tab focus handling

### DIFF
--- a/src/components/Modal/docs/Modal.md
+++ b/src/components/Modal/docs/Modal.md
@@ -31,6 +31,7 @@ A Modal component presents content within a container on top of the application'
 | Prop | Type | Description |
 | --- | --- | --- |
 | cardClassName | `string` | Custom class names to be added to the child [Card](../Card) component. |
+| containTabKeyPress | `bool` | Prevents tab/shift+tab focus from leaving the Modal. Default `true`. |
 | className | `string` | Custom class names to be added to the component. |
 | closeIcon | `bool` | Shows/hides the component's close icon UI. |
 | closeIconRepositionDelay | `number ` | Amount of time before the [CloseButton](../../CloseButton) gets repositioned. |
@@ -41,6 +42,7 @@ A Modal component presents content within a container on top of the application'
 | modalAnimationDuration | `number` | Custom [animation](../Animate) duration for the child [Card](../Card) component. |
 | modalAnimationEasing | `string` | Custom [animation](../Animate) easing for the child [Card](../Card) component. |
 | modalAnimationSequence | `array`/`string` | Custom [animation](../Animate) sequence for the child [Card](../Card) component. |
+| modalFocusTimeout | `number` | Amount of time (`ms`) before the Modal force focuses. |
 | overlayClassName | `string` | Custom class names to be added to the child [Overlay](../Overlay) component. |
 | overlayAnimationDelay | `number` | Custom [animation](../Animate) delay for the child [Overlay](../Overlay) component. |
 | overlayAnimationDuration | `number` | Custom [animation](../Animate) duration for the child [Overlay](../Overlay) component. |

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -144,9 +144,11 @@ class Modal extends Component {
 
   focusModalCard () {
     const { modalFocusTimeout } = this.props
-    if (!this.cardNode) return
     setTimeout(() => {
-      this.cardNode.focus()
+      /* istanbul ignore else */
+      if (this.cardNode) {
+        this.cardNode.focus()
+      }
     }, modalFocusTimeout)
   }
 

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -21,9 +21,12 @@ afterEach(() => {
   document.body.innerHTML = ''
 })
 
-const simulateKeyPress = (keyCode) => {
-  const event = new Event('keyup')
+const simulateKeyPress = (keyCode, eventType = 'keyup', modifier) => {
+  const event = new Event(eventType)
   event.keyCode = keyCode
+  if (modifier) {
+    event[modifier] = true
+  }
 
   document.dispatchEvent(event)
 }
@@ -701,5 +704,124 @@ describe('modalAnimation', () => {
     const o = wrapper.find('.c-Modal__Card-container')
 
     expect(o.prop('easing')).toBe('fakeBounce')
+  })
+})
+
+describe('Keyboard: Tab', () => {
+  test('handleOnTab fires if Tab is pressed', () => {
+    const wrapper = mount(
+      <ModalComponent isOpen />
+    )
+    const spy = jest.spyOn(wrapper.instance(), 'handleOnTab')
+    wrapper.instance().forceUpdate()
+
+    simulateKeyPress(Keys.TAB, 'keydown')
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('prevents tab from focusing next node, if current node is last focusable node', () => {
+    const spy = jest.fn()
+    const wrapper = mount(
+      <ModalComponent isOpen>
+        <button className='one'>one</button>
+        <button className='two'>two</button>
+        <button className='three'>three</button>
+      </ModalComponent>
+    )
+    const o = wrapper.find('.three').node
+
+    wrapper.instance().handleOnTab({
+      target: o,
+      preventDefault: spy
+    })
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('pressing tab on non-last focusable child nodes does not preventDefault', () => {
+    const spy = jest.fn()
+    const wrapper = mount(
+      <ModalComponent isOpen>
+        <button className='one'>one</button>
+        <button className='two'>two</button>
+        <button className='three'>three</button>
+      </ModalComponent>
+    )
+    const o = wrapper.find('.two').node
+
+    wrapper.instance().handleOnTab({
+      target: o,
+      preventDefault: spy
+    })
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  test('handleOnShiftTab fires if Tab + shift is pressed', () => {
+    const wrapper = mount(
+      <ModalComponent isOpen />
+    )
+    const spy = jest.spyOn(wrapper.instance(), 'handleOnShiftTab')
+    wrapper.instance().forceUpdate()
+
+    simulateKeyPress(Keys.TAB, 'keydown', 'shiftKey')
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('prevents shift and tab from focusing prev node, if current node is first focusable node', () => {
+    const spy = jest.fn()
+    const wrapper = mount(
+      <ModalComponent isOpen>
+        <button className='one'>one</button>
+        <button className='two'>two</button>
+        <button className='three'>three</button>
+      </ModalComponent>
+    )
+    const o = wrapper.find('.one').node
+
+    wrapper.instance().handleOnShiftTab({
+      target: o,
+      preventDefault: spy
+    })
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('pressing tab on non-first focusable child nodes does not preventDefault', () => {
+    const spy = jest.fn()
+    const wrapper = mount(
+      <ModalComponent isOpen>
+        <button className='one'>one</button>
+        <button className='two'>two</button>
+        <button className='three'>three</button>
+      </ModalComponent>
+    )
+    const o = wrapper.find('.two').node
+
+    wrapper.instance().handleOnShiftTab({
+      target: o,
+      preventDefault: spy
+    })
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+})
+
+describe('Card: Focus', () => {
+  test('Autofocuses card on mount', (done) => {
+    const spy = jest.fn()
+    const wrapper = mount(
+      <ModalComponent />
+    )
+    const o = wrapper.instance().cardNode
+    o.onfocus = spy
+    wrapper.setProps({ isOpen: true })
+
+    setTimeout(() => {
+      expect(spy).toHaveBeenCalled()
+      done()
+    }, 350)
   })
 })

--- a/src/styles/components/Modal/Modal.scss
+++ b/src/styles/components/Modal/Modal.scss
@@ -33,6 +33,10 @@
     min-height: 0;
   }
 
+  &__Card {
+    outline: none;
+  }
+
   & {
     #{$block}__Card { // Increase specificity on this style
       display: flex;

--- a/src/utilities/focus.js
+++ b/src/utilities/focus.js
@@ -1,6 +1,6 @@
 import { getNodeScope, isNodeElement } from './node'
 
-export const FOCUSABLE_SELECTOR = 'a,frame,iframe,input:not([type=hidden]),select,textarea,button,*[tabindex]:not([tabindex="-1"])'
+export const FOCUSABLE_SELECTOR = 'a,frame,iframe,input:not([type=hidden]),select,textarea,button:not([tabindex="-1"]),*[tabindex]:not([tabindex="-1"])'
 
 export const findFocusableNodes = (nodeScope) => {
   const scope = getNodeScope(nodeScope)

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -390,3 +390,23 @@ stories.add('stateful example', () => (
     <StatefulComponent />
   </div>
 ))
+
+stories.add('tabbing', () => (
+  <Modal isOpen trigger={<Link>Clicky</Link>}>
+    <Modal.Content>
+      <Modal.Body>
+        <Heading>Title</Heading>
+        <button>One</button>
+        {ContentSpec.generate(6).map(({id, content}) => (
+          <p key={id}>{content}</p>
+        ))}
+        <button>Two</button>
+        <button>Three</button>
+        {ContentSpec.generate(6).map(({id, content}) => (
+          <p key={id}>{content}</p>
+        ))}
+        <button>Four</button>
+      </Modal.Body>
+    </Modal.Content>
+  </Modal>
+))


### PR DESCRIPTION
## Modal: Enhance with keyboard Tab focus handling ⌨️ 

![screen recording 2018-02-09 at 05 14 pm](https://user-images.githubusercontent.com/2322354/36052726-d2db198e-0dbc-11e8-8b02-0e5ddaa3774a.gif)

This update enhances the Modal component to contain tab/shift+tab based
focusing events to focusable nodes within the Modal.

This was done using the same focus util functions as Dropdown.Menu.

The CloseButton is now no longer tab focusable, encouraging the user to
use ESCAPE to close a Modal instead. This also prevents accidentally focus/
enter triggering.

Lastly, the Modal now autofocuses on mount (or at least it tries to). This
will help with keyboard-based user flow.