### PR TITLE
Sortable: Remove will-change

### DIFF
--- a/src/styles/components/Sortable/SortableItem.scss
+++ b/src/styles/components/Sortable/SortableItem.scss
@@ -1,4 +1,3 @@
 .c-SortableItem {
   @import "../../resets/base";
-  will-change: transform;
 }

--- a/src/styles/components/Sortable/SortableList.scss
+++ b/src/styles/components/Sortable/SortableList.scss
@@ -1,4 +1,3 @@
 .c-SortableList {
   @import "../../resets/base";
-  will-change: contents;
 }


### PR DESCRIPTION
## Sortable: Remove will-change

This update removes the `will-change` CSS property from the Sortable
components, as it caused unexpected behaviour when integrating with
3rd party dropdowns.