### PR TITLE
Color: Adjust values + provide ability to override

### DIFF
--- a/src/utilities/color.js
+++ b/src/utilities/color.js
@@ -2,6 +2,11 @@ const isHex = hex => (hex && typeof hex === 'string')
 const isNumber = value => (typeof value === 'number')
 
 const lightThreshold = 0.61
+const optimalTextColorValues = {
+  r: 129,
+  g: 522,
+  b: 49
+}
 
 // Source
 // https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
@@ -41,14 +46,23 @@ export const hexToHsl = (hex) => {
   return rgbToHsl(rgb.r, rgb.g, rgb.b)
 }
 
-export const optimalTextColor = (backgroundHex) => {
+export const optimalTextColor = (
+  backgroundHex,
+  propValues = optimalTextColorValues
+) => {
   if (!isHex(backgroundHex)) return null
+  // Defaults from original formula:
+  // r: 299
+  // g: 587
+  // b: 114
+  const defaultPropValues = optimalTextColorValues
+  const { r, g, b } = Object.assign({}, defaultPropValues, propValues)
   const backgroundRgb = hexToRgb(backgroundHex)
   const shade = Math.round(
     (
-      (backgroundRgb.r * 179) + // Default: 299
-      (backgroundRgb.g * 557) + // Default: 587
-      (backgroundRgb.b * 74)    // Default: 114
+      (backgroundRgb.r * r) +
+      (backgroundRgb.g * g) +
+      (backgroundRgb.b * b)
     ) / 1000
   )
 
@@ -133,11 +147,11 @@ export const darken = (hex, value = 20) => {
   return lightenDarkenColor(hex, ((value * 2.55) * -1))
 }
 
-export const getColorShade = (hex) => {
+export const getColorShade = (hex, propValues = optimalTextColorValues) => {
   if (!isHex(hex)) return null
   const hsl = hexToHsl(hex)
   const l = hsl.l
-  const isDarkText = optimalTextColor(hex) === 'black'
+  const isDarkText = optimalTextColor(hex, propValues) === 'black'
 
   if (l >= 0.9) {
     return 'lightest'

--- a/src/utilities/tests/color/getColorShade.test.js
+++ b/src/utilities/tests/color/getColorShade.test.js
@@ -20,13 +20,15 @@ test('Returns "light" for light colors', () => {
   expect(getColorShade('#ddd')).toBe('light')
   expect(getColorShade('#ccc')).toBe('light')
   expect(getColorShade('#bbb')).toBe('light')
-  expect(getColorShade('#aaa')).toBe('light')
-  expect(getColorShade('#9e9e9e')).toBe('light')
-  expect(getColorShade('#2ec1a0')).toBe('light')
-  expect(getColorShade('#60a6f8')).toBe('light')
+  expect(getColorShade('#ffa3ff')).toBe('light')
+  expect(getColorShade('#50E3C2')).toBe('light')
 })
 
 test('Returns "dark" for dark colors', () => {
+  expect(getColorShade('#aaa')).toBe('dark')
+  expect(getColorShade('#9e9e9e')).toBe('dark')
+  expect(getColorShade('#2ec1a0')).toBe('dark')
+  expect(getColorShade('#60a6f8')).toBe('dark')
   expect(getColorShade('#9c9c9c')).toBe('dark')
   expect(getColorShade('#999')).toBe('dark')
   expect(getColorShade('#888')).toBe('dark')
@@ -38,6 +40,9 @@ test('Returns "dark" for dark colors', () => {
   expect(getColorShade('#282828')).toBe('dark')
   expect(getColorShade('#2dc09f')).toBe('dark')
   expect(getColorShade('#5fa5f7')).toBe('dark')
+  expect(getColorShade('#8db058')).toBe('dark')
+  expect(getColorShade('#f144ff')).toBe('dark')
+  expect(getColorShade('#6eb4ff')).toBe('dark')
 })
 
 test('Returns "darkest" for light colors', () => {
@@ -45,4 +50,19 @@ test('Returns "darkest" for light colors', () => {
   expect(getColorShade('#222')).toBe('darkest')
   expect(getColorShade('#111')).toBe('darkest')
   expect(getColorShade('#000')).toBe('darkest')
+})
+
+test('Can provide custom RGB prop values', () => {
+  const darkValues = {
+    r: 9,
+    g: 9,
+    b: 9
+  }
+  const lightValues = {
+    r: 999,
+    g: 999,
+    b: 999
+  }
+  expect(getColorShade('#ff6688', darkValues)).toEqual('dark')
+  expect(getColorShade('#ff6688', lightValues)).toEqual('light')
 })

--- a/src/utilities/tests/color/optimalTextColor.test.js
+++ b/src/utilities/tests/color/optimalTextColor.test.js
@@ -24,3 +24,12 @@ test('Returns black, if backgroundColor is too bright', () => {
   expect(optimalTextColor('#d9d9dd')).toEqual('black')
   expect(optimalTextColor('#c1cbd4')).toEqual('black')
 })
+
+test('Can provide custom RGB prop values', () => {
+  const customValues = {
+    r: 999,
+    g: 999,
+    b: 999
+  }
+  expect(optimalTextColor('#ff6688'), customValues).toEqual('white')
+})

--- a/stories/Color/index.js
+++ b/stories/Color/index.js
@@ -160,6 +160,7 @@ stories.add('darken', () => {
 stories.add('shades', () => {
   return (
     <div>
+      <ShadeList color='#8db058' />
       <ShadeList color='#D0021B' />
       <ShadeList color='#F8E71C' />
       <ShadeList color='#F5A623' />


### PR DESCRIPTION
## Color: Adjust values + provide ability to override 🖌 

This update adjusts both the `getColorShade` and `optimalTextColor`
util functions to use a different RGB weight to (subjectively) better
results for determining whether the text color should be black or white
(given a color).

The functions have also been enhanced to accept a secondary argument
(object), that allows the user to override the default suggested RGB
values with their own (to fine tune).