### PR TITLE
Input/Select: Remove state styles from hintText

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -223,15 +223,15 @@ class Input extends Component {
       </div>
       : null
 
-    const helpTextMarkup = helpText
-      ? <HelpText state={state}>
-        {helpText}
+    const hintTextMarkup = hintText
+      ? <HelpText className='c-Input__hintText' muted>
+        {hintText}
       </HelpText>
       : null
 
-    const hintTextMarkup = hintText
-      ? <HelpText state={state}>
-        {hintText}
+    const helpTextMarkup = helpText
+      ? <HelpText className='c-Input__helpText' state={state}>
+        {helpText}
       </HelpText>
       : null
 

--- a/src/components/Input/tests/Input.test.js
+++ b/src/components/Input/tests/Input.test.js
@@ -192,6 +192,12 @@ describe('Multiline', () => {
 })
 
 describe('HelpText', () => {
+  test('Does not render by default', () => {
+    const wrapper = mount(<Input />)
+    const o = wrapper.find('.c-Input__helpText')
+    expect(o.length).not.toBeTruthy()
+  })
+
   test('Adds helpText if specified', () => {
     const wrapper = mount(<Input helpText='Help text' />)
     const helpText = wrapper.find('div').last()
@@ -201,11 +207,23 @@ describe('HelpText', () => {
 })
 
 describe('HintText', () => {
+  test('Does not render by default', () => {
+    const wrapper = mount(<Input />)
+    const o = wrapper.find('.c-Input__hintText')
+    expect(o.length).not.toBeTruthy()
+  })
+
   test('Adds hintText if specified', () => {
     const wrapper = mount(<Input hintText='Hint text' />)
     const hintText = wrapper.find('div').first()
     expect(hintText.exists()).toBeTruthy()
     expect(hintText.text()).toBe('Hint text')
+  })
+
+  test('Does not pass state to hintText', () => {
+    const wrapper = mount(<Input hintText='Hint text' state='error' />)
+    const o = wrapper.find('.c-Input__hintText')
+    expect(o.props().state).not.toBeTruthy()
   })
 })
 

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -29,6 +29,7 @@ export const propTypes = {
   disabled: PropTypes.bool,
   forceAutoFocusTimeout: PropTypes.number,
   helpText: PropTypes.string,
+  hintText: PropTypes.string,
   id: PropTypes.string,
   isFocused: PropTypes.bool,
   label: PropTypes.string,
@@ -149,6 +150,7 @@ class Select extends Component {
       disabled,
       forceAutoFocusTimeout,
       helpText,
+      hintText,
       id,
       isFocused,
       label,
@@ -239,8 +241,14 @@ class Select extends Component {
       </div>
       : null
 
+    const hintTextMarkup = hintText
+      ? <HelpText className='c-Select__hintText' muted>
+        {hintText}
+      </HelpText>
+      : null
+
     const helpTextMarkup = helpText
-      ? <HelpText state={state}>
+      ? <HelpText className='c-Select__helpText' state={state}>
         {helpText}
       </HelpText>
       : null
@@ -250,6 +258,7 @@ class Select extends Component {
     return (
       <div className='c-InputWrapper' style={styleProp}>
         {labelMarkup}
+        {hintTextMarkup}
         <div className={componentClassName}>
           {prefixMarkup}
           <select

--- a/src/components/Select/tests/Select.test.js
+++ b/src/components/Select/tests/Select.test.js
@@ -202,6 +202,42 @@ describe('Prefix', () => {
   })
 })
 
+describe('HelpText', () => {
+  test('Does not render by default', () => {
+    const wrapper = mount(<Select />)
+    const o = wrapper.find('.c-Select__helpText')
+    expect(o.length).not.toBeTruthy()
+  })
+
+  test('Adds helpText if specified', () => {
+    const wrapper = mount(<Select helpText='Help text' />)
+    const o = wrapper.find('.c-Select__helpText')
+    expect(o.exists()).toBeTruthy()
+    expect(o.text()).toBe('Help text')
+  })
+})
+
+describe('HintText', () => {
+  test('Does not render by default', () => {
+    const wrapper = mount(<Select />)
+    const o = wrapper.find('.c-Select__hintText')
+    expect(o.length).not.toBeTruthy()
+  })
+
+  test('Adds hintText if specified', () => {
+    const wrapper = mount(<Select hintText='Hint text' />)
+    const o = wrapper.find('.c-Select__hintText')
+    expect(o.exists()).toBeTruthy()
+    expect(o.text()).toBe('Hint text')
+  })
+
+  test('Does not pass state to hintText', () => {
+    const wrapper = mount(<Select hintText='Hint text' state='error' />)
+    const o = wrapper.find('.c-Select__hintText')
+    expect(o.props().state).not.toBeTruthy()
+  })
+})
+
 describe('States', () => {
   test('Disables select if disabled prop is true', () => {
     const wrapper = shallow(<Select disabled />)

--- a/stories/Select.js
+++ b/stories/Select.js
@@ -2,49 +2,63 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Select } from '../src/index.js'
 
-storiesOf('Select', module)
-  .add('default', () => (
-    <Select options={['one', 'two', 'three']} />
-  ))
-  .add('groups', () => {
-    const options = [
-      {
-        label: 'Group 1',
-        value: [
-          'one', 'two', 'three'
-        ]
-      },
-      {
-        label: 'Group 2',
-        value: [
-          'four', 'five', 'six', 'seven'
-        ]
-      }
-    ]
-    return (
-      <Select options={options} value='five' />
-    )
-  })
-  .add('placeholder', () => (
-    <Select
-      placeholder='Select one'
-      options={['one', 'two', 'three']}
-      onChange={v => console.log(v)}
-    />
-  ))
-  .add('prefix', () => (
-    <Select prefix='Filter by: ' options={['One']} />
-  ))
-  .add('states', () => (
-    <div>
-      <Select state='error' /><br />
-      <Select state='success' /><br />
-      <Select state='warning' />
-    </div>
-  ))
-  .add('sizes', () => (
-    <div>
-      <Select autoFocus placeholder='Regular' /><br />
-      <Select size='sm' autoFocus placeholder='Small' />
-    </div>
-  ))
+const stories = storiesOf('Select', module)
+
+stories.add('default', () => (
+  <Select options={['one', 'two', 'three']} />
+))
+
+stories.add('groups', () => {
+  const options = [
+    {
+      label: 'Group 1',
+      value: [
+        'one', 'two', 'three'
+      ]
+    },
+    {
+      label: 'Group 2',
+      value: [
+        'four', 'five', 'six', 'seven'
+      ]
+    }
+  ]
+  return (
+    <Select options={options} value='five' />
+  )
+})
+
+stories.add('placeholder', () => (
+  <Select
+    placeholder='Select one'
+    options={['one', 'two', 'three']}
+    onChange={v => console.log(v)}
+  />
+))
+
+stories.add('prefix', () => (
+  <Select prefix='Filter by: ' options={['One']} />
+))
+
+stories.add('helpText', () => (
+  <Select helpText='This text appears below the Select' />
+))
+
+stories.add('hintText', () => (
+  <Select hintText='This text appears above the Select' />
+))
+
+stories.add('states', () => (
+  <div>
+    <Select state='error' /><br />
+    <Select state='success' /><br />
+    <Select state='warning' />
+  </div>
+))
+
+stories.add('sizes', () => (
+  <div>
+    <Select autoFocus placeholder='Regular' /><br />
+    <Select size='sm' autoFocus placeholder='Small' />
+  </div>
+))


### PR DESCRIPTION
## Input/Select: Remove state styles from hintText 🚥 

![screen shot 2018-02-14 at 12 07 41 pm](https://user-images.githubusercontent.com/2322354/36217609-e719ecce-117f-11e8-930a-8e58863ee485.jpg)

This update removes the state-based stylings of an Input/Select from it's
hintText (HelpText component).

Just a heads up, content passed as `helpText` will **still** receive state-based styles if defined.