### PR TITLE
Input/Select: Allow text props to accept Components

### DIFF
--- a/src/components/HelpText/index.js
+++ b/src/components/HelpText/index.js
@@ -4,6 +4,7 @@ import classNames from '../../utilities/classNames'
 import Text from '../Text'
 import { sizeTypes } from '../Text/propTypes'
 import { stateTypes } from '../../constants/propTypes'
+import { isString } from '../../utilities/strings'
 
 export const propTypes = {
   className: PropTypes.string,
@@ -33,9 +34,15 @@ const HelpText = props => {
     className
   )
 
+  const contentMarkup = isString(children) ? (
+    <Text className='c-HelpText__text' size={size}>
+      {children}
+    </Text>
+  ) : children
+
   return (
     <div className={componentClassName} {...rest}>
-      <Text size={size}>{children}</Text>
+      {contentMarkup}
     </div>
   )
 }

--- a/src/components/HelpText/tests/HelpText.test.js
+++ b/src/components/HelpText/tests/HelpText.test.js
@@ -17,6 +17,18 @@ describe('Content', () => {
 
     expect(wrapper.html()).toContain('Gator')
   })
+
+  test('Renders React Component as content', () => {
+    const wrapper = shallow(
+      <HelpText>
+        <div className='gator'>Gator</div>
+      </HelpText>
+    )
+    const o = wrapper.find('.gator')
+
+    expect(o.length).toBe(1)
+    expect(o.html()).toContain('Gator')
+  })
 })
 
 describe('Styles', () => {

--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -26,11 +26,11 @@ An Input component is an enhanced version of the default HTML `<input>`. Input c
 | className | `string` | Custom class names to be added to the component. |
 | disabled | `bool` | Disable the input. |
 | forceAutoFocusTimeout | `bool` | Determines the amount of time (`ms`) for the component to focus on mount. |
-| helpText | `string` | Displays text underneath input. |
-| hintText | `string` | Displays text above input. |
+| helpText | `string`/`component` | Displays text underneath input. |
+| hintText | `string`/`component` | Displays text above input. |
 | id | `string` | ID for the input. |
 | isFocused | `string` | Determines if the component is focused. |
-| label | `string` | Label for the input. |
+| label | `string`/`component` | Label for the input. |
 | multiline | `bool`/`number` | Transforms input into an auto-expanding textarea. |
 | name | `string` | Name for the input. |
 | onBlur | `function` | Callback when input is blurred. |

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -14,13 +14,14 @@ export const propTypes = {
   autoFocus: PropTypes.bool,
   className: PropTypes.string,
   disabled: PropTypes.bool,
-  hintText: PropTypes.string,
-  modalhelpText: PropTypes.string,
   forceAutoFocusTimeout: PropTypes.number,
+  helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  hintText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   id: PropTypes.string,
   inputRef: PropTypes.func,
   isFocused: PropTypes.bool,
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  modalhelpText: PropTypes.string,
   multiline: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
   name: PropTypes.string,
   onBlur: PropTypes.func,
@@ -190,7 +191,11 @@ class Input extends Component {
       className
     )
 
-    const fieldClassName = classNames('c-InputField', size && `is-${size}`)
+    const fieldClassName = classNames(
+      'c-Input__inputField',
+      'c-InputField',
+      size && `is-${size}`
+    )
 
     // Ignoring as height calculation isn't possible with JSDOM
     // (which is what Enzyme uses for tests)
@@ -208,7 +213,7 @@ class Input extends Component {
         : null
 
     const labelMarkup = label
-      ? <Label for={inputID}>{label}</Label>
+      ? <Label className='c-Input__label' for={inputID}>{label}</Label>
       : null
 
     const prefixMarkup = prefix
@@ -264,7 +269,12 @@ class Input extends Component {
           {prefixMarkup}
           {inputElement}
           {suffixMarkup}
-          <Backdrop disabled={disabled} readOnly={readOnly} state={state} />
+          <Backdrop
+            className='c-Input__backdrop'
+            disabled={disabled}
+            readOnly={readOnly}
+            state={state}
+          />
           {resizer}
         </div>
         {helpTextMarkup}

--- a/src/components/Input/tests/Input.test.js
+++ b/src/components/Input/tests/Input.test.js
@@ -3,6 +3,12 @@ import { mount, shallow } from 'enzyme'
 import Input from '..'
 import Resizer from '../Resizer'
 
+const ui = {
+  helpText: '.c-Input__helpText',
+  hintText: '.c-Input__hintText',
+  label: '.c-Input__label'
+}
+
 describe('ClassName', () => {
   test('Has default className', () => {
     const wrapper = mount(<Input />)
@@ -194,46 +200,79 @@ describe('Multiline', () => {
 describe('HelpText', () => {
   test('Does not render by default', () => {
     const wrapper = mount(<Input />)
-    const o = wrapper.find('.c-Input__helpText')
+    const o = wrapper.find(ui.helpText)
     expect(o.length).not.toBeTruthy()
   })
 
   test('Adds helpText if specified', () => {
     const wrapper = mount(<Input helpText='Help text' />)
-    const helpText = wrapper.find('div').last()
-    expect(helpText.exists()).toBeTruthy()
-    expect(helpText.text()).toBe('Help text')
+    const o = wrapper.find(ui.helpText)
+    expect(o.exists()).toBeTruthy()
+    expect(o.text()).toBe('Help text')
+  })
+
+  test('Accepts React components', () => {
+    const custom = (<div className='custom'>Custom text</div>)
+    const wrapper = mount(<Input helpText={custom} />)
+    const o = wrapper.find(ui.helpText)
+    const c = o.find('.custom')
+
+    expect(o.exists()).toBeTruthy()
+    expect(c.exists()).toBeTruthy()
+    expect(c.text()).toBe('Custom text')
   })
 })
 
 describe('HintText', () => {
   test('Does not render by default', () => {
     const wrapper = mount(<Input />)
-    const o = wrapper.find('.c-Input__hintText')
+    const o = wrapper.find(ui.hintText)
     expect(o.length).not.toBeTruthy()
   })
 
   test('Adds hintText if specified', () => {
     const wrapper = mount(<Input hintText='Hint text' />)
-    const hintText = wrapper.find('div').first()
-    expect(hintText.exists()).toBeTruthy()
-    expect(hintText.text()).toBe('Hint text')
+    const o = wrapper.find(ui.hintText)
+    expect(o.exists()).toBeTruthy()
+    expect(o.text()).toBe('Hint text')
   })
 
   test('Does not pass state to hintText', () => {
     const wrapper = mount(<Input hintText='Hint text' state='error' />)
-    const o = wrapper.find('.c-Input__hintText')
+    const o = wrapper.find(ui.hintText)
     expect(o.props().state).not.toBeTruthy()
+  })
+
+  test('Accepts React components', () => {
+    const custom = (<div className='custom'>Custom text</div>)
+    const wrapper = mount(<Input hintText={custom} />)
+    const o = wrapper.find(ui.hintText)
+    const c = o.find('.custom')
+
+    expect(o.exists()).toBeTruthy()
+    expect(c.exists()).toBeTruthy()
+    expect(c.text()).toBe('Custom text')
   })
 })
 
 describe('Label', () => {
   test('Adds label if specified', () => {
     const wrapper = mount(<Input label='Channel' />)
-    const label = wrapper.find('Label')
+    const label = wrapper.find(ui.label)
 
     expect(label.exists()).toBeTruthy()
     expect(label.text()).toBe('Channel')
+  })
+
+  test('Accepts React components', () => {
+    const custom = (<div className='custom'>Custom text</div>)
+    const wrapper = mount(<Input label={custom} />)
+    const o = wrapper.find(ui.label)
+    const c = o.find('.custom')
+
+    expect(o.exists()).toBeTruthy()
+    expect(c.exists()).toBeTruthy()
+    expect(c.text()).toBe('Custom text')
   })
 })
 

--- a/src/components/Label/index.js
+++ b/src/components/Label/index.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import classNames from '../../utilities/classNames'
 import Text from '../Text'
 import { stateTypes } from '../../constants/propTypes'
+import classNames from '../../utilities/classNames'
+import { isString } from '../../utilities/strings'
 
 export const propTypes = {
   className: PropTypes.string,
@@ -13,6 +14,7 @@ export const propTypes = {
 const Label = props => {
   const {
     className,
+    children,
     for: htmlFor,
     state,
     ...rest
@@ -24,11 +26,15 @@ const Label = props => {
     className
   )
 
+  const contentMarkup = isString(children) ? (
+    <Text className='c-Label__text' faint>
+      {children}
+    </Text>
+  ) : children
+
   return (
     <label className={componentClassName} htmlFor={htmlFor} {...rest}>
-      <Text faint>
-        {props.children}
-      </Text>
+      {contentMarkup}
     </label>
   )
 }

--- a/src/components/Label/tests/Label.test.js
+++ b/src/components/Label/tests/Label.test.js
@@ -25,6 +25,18 @@ describe('Content', () => {
     expect(text.exists()).toBeTruthy()
     expect(text.text()).toBe('Channel 4')
   })
+
+  test('Renders React Component as content', () => {
+    const wrapper = shallow(
+      <Label>
+        <div className='gator'>Gator</div>
+      </Label>
+    )
+    const o = wrapper.find('.gator')
+
+    expect(o.length).toBe(1)
+    expect(o.html()).toContain('Gator')
+  })
 })
 
 describe('For', () => {

--- a/src/components/Select/README.md
+++ b/src/components/Select/README.md
@@ -46,10 +46,11 @@ This component also accepts regular `<option>` elements as children.
 | className | `string` | Custom class names to be added to the component. |
 | disabled | `bool` | Disable the select. |
 | forceAutoFocusTimeout | `bool` | Determines the amount of time (`ms`) for the component to focus on mount. |
-| helpText | `string` | Displays text underneath select. |
+| helpText | `string`/`component` | Displays text underneath select. |
+| hintText | `string`/`component` | Displays text above select. |
 | id | `string` | ID for the select. |
 | isFocused | `string` | Determines if the component is focused. |
-| label | `string` | Label for the select. |
+| label | `string`/`component` | Label for the select. |
 | name | `string` | Name for the select. |
 | onBlur | `function` | Callback when select is blurred. |
 | onChange | `function` | Callback when select value is changed. |

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -28,11 +28,11 @@ export const propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   forceAutoFocusTimeout: PropTypes.number,
-  helpText: PropTypes.string,
-  hintText: PropTypes.string,
+  helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  hintText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   id: PropTypes.string,
   isFocused: PropTypes.bool,
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   name: PropTypes.string,
   options: PropTypes.oneOfType([
     groupType,
@@ -183,7 +183,12 @@ class Select extends Component {
       className
     )
 
-    const fieldClassName = classNames('c-InputField', size && `is-${size}`)
+    const fieldClassName = classNames(
+      'c-Select__inputField',
+      'c-InputField',
+      size && `is-${size}`
+    )
+    const optionClassName = 'c-Select__option'
 
     const renderOptions = option => {
       // HTML <optgroup> only allows for single level nesting
@@ -194,7 +199,7 @@ class Select extends Component {
         const label = option.label
         // Recursion!
         return (
-          <optgroup label={label} key={label}>
+          <optgroup className='c-Select__optGroup' label={label} key={label}>
             {option.value.map(renderOptions)}
           </optgroup>
         )
@@ -202,7 +207,7 @@ class Select extends Component {
       // Option
       if (typeof option === 'string') {
         return (
-          <option key={option} value={option}>
+          <option className={optionClassName} key={option} value={option}>
             {option}
           </option>
         )
@@ -210,6 +215,7 @@ class Select extends Component {
         return (
           <option
             key={option.value}
+            className={optionClassName}
             value={option.value}
             disabled={option.disabled}
           >
@@ -223,6 +229,7 @@ class Select extends Component {
 
     const placeholderMarkup = placeholder ? (
       <option
+        className={optionClassName}
         label={placeholder}
         value={PLACEHOLDER_VALUE}
         disabled
@@ -232,7 +239,7 @@ class Select extends Component {
     ) : null
 
     const labelMarkup = label
-      ? <Label for={id}>{label}</Label>
+      ? <Label className='c-Select__label' for={id}>{label}</Label>
       : null
 
     const prefixMarkup = prefix
@@ -275,7 +282,7 @@ class Select extends Component {
             {optionsMarkup}
           </select>
           <div className='c-SelectIcon' />
-          <Backdrop disabled={disabled} state={state} />
+          <Backdrop className='c-Select__backdrop' disabled={disabled} state={state} />
         </div>
         {helpTextMarkup}
       </div>

--- a/src/components/Select/tests/Select.test.js
+++ b/src/components/Select/tests/Select.test.js
@@ -2,6 +2,12 @@ import React from 'react'
 import { mount, shallow } from 'enzyme'
 import Select from '..'
 
+const ui = {
+  helpText: '.c-Select__helpText',
+  hintText: '.c-Select__hintText',
+  label: '.c-Select__label'
+}
+
 describe('Placeholder', () => {
   test('Renders a placeholder if defined', () => {
     const placeholder = 'Choose your co-anchor…'
@@ -172,7 +178,7 @@ describe('Events', () => {
 describe('Label', () => {
   test('Adds label if specified', () => {
     const wrapper = mount(<Select label='Channel' />)
-    const label = wrapper.find('Label')
+    const label = wrapper.find(ui.label)
 
     expect(label.exists()).toBeTruthy()
     expect(label.text()).toBe('Channel')
@@ -181,12 +187,23 @@ describe('Label', () => {
   test('Sets ID on the select element', () => {
     const id = 'channel'
     const wrapper = mount(<Select label='Channel' id={id} />)
-    const label = wrapper.find('Label')
+    const label = wrapper.find(ui.label)
     const select = wrapper.find('select')
 
     expect(label.text()).toBe('Channel')
-    expect(label.prop('for')).toBe(id)
+    expect(label.prop('htmlFor')).toBe(id)
     expect(select.prop('id')).toBe(id)
+  })
+
+  test('Accepts React components', () => {
+    const custom = (<div className='custom'>Custom text</div>)
+    const wrapper = mount(<Select label={custom} />)
+    const o = wrapper.find(ui.label)
+    const c = o.find('.custom')
+
+    expect(o.exists()).toBeTruthy()
+    expect(c.exists()).toBeTruthy()
+    expect(c.text()).toBe('Custom text')
   })
 })
 
@@ -205,36 +222,58 @@ describe('Prefix', () => {
 describe('HelpText', () => {
   test('Does not render by default', () => {
     const wrapper = mount(<Select />)
-    const o = wrapper.find('.c-Select__helpText')
+    const o = wrapper.find(ui.helpText)
     expect(o.length).not.toBeTruthy()
   })
 
   test('Adds helpText if specified', () => {
     const wrapper = mount(<Select helpText='Help text' />)
-    const o = wrapper.find('.c-Select__helpText')
+    const o = wrapper.find(ui.helpText)
     expect(o.exists()).toBeTruthy()
     expect(o.text()).toBe('Help text')
+  })
+
+  test('Accepts React components', () => {
+    const custom = (<div className='custom'>Custom text</div>)
+    const wrapper = mount(<Select helpText={custom} />)
+    const o = wrapper.find(ui.helpText)
+    const c = o.find('.custom')
+
+    expect(o.exists()).toBeTruthy()
+    expect(c.exists()).toBeTruthy()
+    expect(c.text()).toBe('Custom text')
   })
 })
 
 describe('HintText', () => {
   test('Does not render by default', () => {
     const wrapper = mount(<Select />)
-    const o = wrapper.find('.c-Select__hintText')
+    const o = wrapper.find(ui.hintText)
     expect(o.length).not.toBeTruthy()
   })
 
   test('Adds hintText if specified', () => {
     const wrapper = mount(<Select hintText='Hint text' />)
-    const o = wrapper.find('.c-Select__hintText')
+    const o = wrapper.find(ui.hintText)
     expect(o.exists()).toBeTruthy()
     expect(o.text()).toBe('Hint text')
   })
 
   test('Does not pass state to hintText', () => {
     const wrapper = mount(<Select hintText='Hint text' state='error' />)
-    const o = wrapper.find('.c-Select__hintText')
+    const o = wrapper.find(ui.hintText)
     expect(o.props().state).not.toBeTruthy()
+  })
+
+  test('Accepts React components', () => {
+    const custom = (<div className='custom'>Custom text</div>)
+    const wrapper = mount(<Select hintText={custom} />)
+    const o = wrapper.find(ui.hintText)
+    const c = o.find('.custom')
+
+    expect(o.exists()).toBeTruthy()
+    expect(c.exists()).toBeTruthy()
+    expect(c.text()).toBe('Custom text')
   })
 })
 

--- a/src/styles/components/Scrollable.scss
+++ b/src/styles/components/Scrollable.scss
@@ -15,6 +15,7 @@
     background: linear-gradient($background, rgba($background, 0.7), rgba($background, 0));
     height: 28px;
     left: 0;
+    pointer-events: none;
     position: absolute;
     right: 0;
     top: 0;

--- a/src/utilities/strings.js
+++ b/src/utilities/strings.js
@@ -1,3 +1,7 @@
+export const isString = (string) => {
+  return typeof string === 'string'
+}
+
 export const nameToInitials = (name = '') => {
   if (!name || !name.length) return ''
 
@@ -9,7 +13,7 @@ export const nameToInitials = (name = '') => {
 }
 
 export const isWordString = (word) => {
-  return typeof word === 'string' && word.length
+  return isString(word) && word.length
 }
 
 export const isWord = (word) => {

--- a/src/utilities/tests/strings.test.js
+++ b/src/utilities/tests/strings.test.js
@@ -1,9 +1,31 @@
 import {
+  isString,
   isWord,
   nameToInitials,
   wordHasSpaces,
   truncateMiddle
 } from '../strings'
+
+describe('isString', () => {
+  test('Returns false for non-strings', () => {
+    expect(isString()).toBe(false)
+    expect(isString(0)).toBe(false)
+    expect(isString(1)).toBe(false)
+    expect(isString([])).toBe(false)
+    expect(isString({})).toBe(false)
+    expect(isString(undefined)).toBe(false)
+    expect(isString(null)).toBe(false)
+    expect(isString(null)).toBe(false)
+    expect(isString(/g/g)).toBe(false)
+  })
+
+  test('Returns true for strings', () => {
+    expect(isString('')).toBe(true)
+    expect(isString('word')).toBe(true)
+    expect(isString('   word')).toBe(true)
+    expect(isString('   word word2 ')).toBe(true)
+  })
+})
 
 describe('nameToInitials', () => {
   test('Returns empty string if no args are passed', () => {

--- a/stories/Input.js
+++ b/stories/Input.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Button, Input } from '../src/index.js'
+import { Button, Icon, Input } from '../src/index.js'
 
 const stories = storiesOf('Input', module)
 
@@ -25,11 +25,17 @@ stories.add('autocomplete', () => (
 ))
 
 stories.add('helpText', () => (
-  <Input helpText='This text appears below the input' />
+  <div>
+    <Input helpText='This text appears below the input' /><br />
+    <Input helpText={<div>This is custom text <Icon name='emoji' inline /></div>} />
+  </div>
 ))
 
 stories.add('hintText', () => (
-  <Input hintText='This text appears above the input' />
+  <div>
+    <Input hintText='This text appears above the input' /><br />
+    <Input hintText={<div>This is custom text <Icon name='emoji' inline /></div>} />
+  </div>
 ))
 
 stories.add('multiline', () => (


### PR DESCRIPTION
## Input/Select: Allow text props to accept Components

![screen shot 2018-02-15 at 1 08 29 pm](https://user-images.githubusercontent.com/2322354/36273206-c673605e-1251-11e8-94c5-b6b4b5ab42db.jpg)

This update enhances the `hintText`, `helpText`, and `label` props of
`<Input />` and `<Select />` to accept either strings or React components.

This provides extra flexibility, for cases where you might want to include
things like Icons, or Popovers or Tooltips with your Text.