### PR TITLE
Choice: Pass "checked" value for onChange callback

### DIFF
--- a/src/components/Choice/index.js
+++ b/src/components/Choice/index.js
@@ -68,7 +68,7 @@ class Choice extends Component {
 
   handleOnChange (value, checked) {
     this.setState({ checked })
-    this.props.onChange(value)
+    this.props.onChange(value, checked)
   }
 
   render () {

--- a/src/components/Choice/tests/Choice.test.js
+++ b/src/components/Choice/tests/Choice.test.js
@@ -181,6 +181,7 @@ describe('Events', () => {
 
     expect(spy).toHaveBeenCalledWith('Value', true)
 
+    wrapper.setProps({ checked: false })
     input.simulate('change')
 
     expect(spy).toHaveBeenCalledWith('Value', false)

--- a/src/components/Choice/tests/Choice.test.js
+++ b/src/components/Choice/tests/Choice.test.js
@@ -179,7 +179,11 @@ describe('Events', () => {
 
     input.simulate('change')
 
-    expect(spy).toHaveBeenCalledWith('Value')
+    expect(spy).toHaveBeenCalledWith('Value', true)
+
+    input.simulate('change')
+
+    expect(spy).toHaveBeenCalledWith('Value', false)
     wrapper.unmount()
   })
 })

--- a/src/components/Choice/tests/ChoiceInput.test.js
+++ b/src/components/Choice/tests/ChoiceInput.test.js
@@ -70,7 +70,7 @@ describe('Events', () => {
 
     input.simulate('change')
 
-    expect(spy).toHaveBeenCalledWith('Value')
+    expect(spy).toHaveBeenCalledWith('Value', true)
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Choice: Pass "checked" value for onChange callback

This update enhances components created with Choice to pass the
"checked" value (from Checkboxes and Radios) on the `onChange`
prop as a secondary argument.

Thanks to @tompedals for this!

Resolves: https://github.com/helpscout/blue/issues/217