### PR TITLE
PortalWrapper: Prevent ESC keypress from bubbling

### DIFF
--- a/src/components/PortalWrapper/index.js
+++ b/src/components/PortalWrapper/index.js
@@ -62,6 +62,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
       this.closePortal = this.closePortal.bind(this)
       this.openPortal = this.openPortal.bind(this)
       this.handleOnClose = this.handleOnClose.bind(this)
+      this.handleOnEsc = this.handleOnEsc.bind(this)
       this.triggerComponent = null
       this.triggerNode = null
       this._isMounted = false
@@ -174,6 +175,13 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
       requestAnimationFrame(() => onClose())
     }
 
+    handleOnEsc (event) {
+      if (this.state.isOpen) {
+        event.stopPropagation()
+        this.handleOnClose()
+      }
+    }
+
     handleOnClose (onClose) {
       const { onBeforeClose } = this.props
 
@@ -221,6 +229,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
 
       const openPortal = this.openPortal
       const handleOnClose = this.handleOnClose
+      const handleOnEsc = this.handleOnEsc
 
       const uniqueIndex = getUniqueIndex(id, options.id)
       const zIndex = options.zIndex ? options.zIndex + uniqueIndex : null
@@ -288,7 +297,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
 
       return (
         <div className='c-PortalWrapper'>
-          <KeypressListener keyCode={Keys.ESCAPE} handler={handleOnClose} />
+          <KeypressListener keyCode={Keys.ESCAPE} handler={handleOnEsc} />
           {triggerMarkup}
           {portalContainerMarkup}
         </div>

--- a/src/components/PortalWrapper/tests/PortalWrapper.test.js
+++ b/src/components/PortalWrapper/tests/PortalWrapper.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import PortalWrapper from '..'
+import Keys from '../../../constants/Keys'
 import classNames from '../../../utilities/classNames'
 import wait from '../../../tests/helpers/wait'
 
@@ -365,5 +366,49 @@ describe('Trigger', () => {
     o.simulate('click')
 
     expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('Esc keypress', () => {
+  test('Prevents event from bubbling when open', () => {
+    const globalSpy = jest.fn()
+    const event = new Event('keyup')
+    event.keyCode = Keys.ESCAPE
+
+    const TestComponent = PortalWrapper(options)(TestButton)
+    const trigger = (
+      <div className='trigger'>Trigger</div>
+    )
+    const wrapper = mount(<TestComponent timeout={0} trigger={trigger} isOpen />)
+
+    setTimeout(() => {
+      window.addEventListener('keyup', globalSpy)
+      window.dispatchEvent(event)
+
+      expect(globalSpy).not.toHaveBeenCalled()
+      wrapper.unmount()
+      window.removeEventListener('keyup', globalSpy)
+    }, 20)
+  })
+
+  test('Prevents event from bubbling when closed', () => {
+    const globalSpy = jest.fn()
+    const event = new Event('keyup')
+    event.keyCode = Keys.ESCAPE
+
+    const TestComponent = PortalWrapper(options)(TestButton)
+    const trigger = (
+      <div className='trigger'>Trigger</div>
+    )
+    const wrapper = mount(<TestComponent timeout={0} trigger={trigger} />)
+
+    setTimeout(() => {
+      window.addEventListener('keyup', globalSpy)
+      window.dispatchEvent(event)
+
+      expect(globalSpy).toHaveBeenCalled()
+      wrapper.unmount()
+      window.removeEventListener('keyup', globalSpy)
+    }, 20)
   })
 })

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -28,6 +28,19 @@ class StatefulComponent extends React.Component {
     this.handleOnSubmit = this.handleOnSubmit.bind(this)
     this.handleOnModalOpen = this.handleOnModalOpen.bind(this)
     this.handleOnModalClose = this.handleOnModalClose.bind(this)
+    this.handleOnKeyUp = this.handleOnKeyUp.bind(this)
+  }
+
+  componentWillMount () {
+    window.addEventListener('keyup', this.handleOnKeyUp)
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('keyup', this.handleOnKeyUp)
+  }
+
+  handleOnKeyUp (event) {
+    console.log(event)
   }
 
   handleOnButtonClick () {


### PR DESCRIPTION
## PortalWrapper: Prevent ESC keypress from bubbling 🛑 

This update enhances the PortalWrapper HOC to prevent an ESC keypress
from bubbling if the Portal'ed component is open.

This allows for UI like Modals to prioritize their ESC interactions.