### PR TITLE
Improve scrollbar offset detection

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -19,10 +19,8 @@ import { propTypes as portalTypes } from '../Portal'
 import { findFocusableNodes } from '../../utilities/focus'
 import {
   getClosestDocument,
-  isNodeElement,
-  hasContentOverflowY
+  isNodeElement
 } from '../../utilities/node'
-import getScrollbarWidth from '../../vendors/getScrollbarWidth'
 
 export const propTypes = Object.assign({}, portalTypes, {
   cardClassName: PropTypes.string,
@@ -80,8 +78,6 @@ const portalOptions = {
   id: 'Modal',
   zIndex: modalBaseZIndex
 }
-
-const scrollbarWidth = getScrollbarWidth()
 
 class Modal extends Component {
   constructor () {
@@ -153,29 +149,16 @@ class Modal extends Component {
   }
 
   positionCloseNode (scrollableNode) {
-    const { modalAnimationDelay, closeIconRepositionDelay } = this.props
     const scrollNode = scrollableNode || this.scrollableNode
     if (
       !this.closeNode ||
       !isNodeElement(scrollNode)
     ) return
 
-    /* istanbul ignore next */
-    const delay = modalAnimationDelay < closeIconRepositionDelay
-      ? closeIconRepositionDelay
-      : modalAnimationDelay
-
     const defaultOffset = 9
+    const offset = `${(scrollNode.offsetWidth - scrollNode.scrollWidth) + defaultOffset}px`
 
-    setTimeout(() => {
-      const offset = hasContentOverflowY(scrollNode)
-        ? /* istanbul ignore next */ `${scrollbarWidth + defaultOffset}px`
-        : `${defaultOffset}px`
-      /* istanbul ignore else */
-      if (this.closeNode) {
-        this.closeNode.style.right = offset
-      }
-    }, delay)
+    this.closeNode.style.right = offset
   }
 
   getChildContext () {

--- a/src/components/PortalWrapper/index.js
+++ b/src/components/PortalWrapper/index.js
@@ -176,6 +176,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
     }
 
     handleOnEsc (event) {
+      /* istanbul ignore else */
       if (this.state.isOpen) {
         event.stopPropagation()
         this.handleOnClose()

--- a/src/components/Scrollable/index.js
+++ b/src/components/Scrollable/index.js
@@ -2,8 +2,6 @@ import React, {PureComponent as Component} from 'react'
 import PropTypes from 'prop-types'
 import ScrollLock from '../ScrollLock'
 import classNames from '../../utilities/classNames'
-import { hasContentOverflowY } from '../../utilities/node'
-import getScrollbarWidth from '../../vendors/getScrollbarWidth'
 import { getFadeTopStyles, getFadeBottomStyles } from '../../utilities/scrollFade'
 import { noop } from '../../utilities/other'
 
@@ -26,8 +24,6 @@ const defaultProps = {
   isScrollLocked: true
 }
 
-const scrollbarWidth = getScrollbarWidth()
-
 class Scrollable extends Component {
   constructor () {
     super()
@@ -36,7 +32,6 @@ class Scrollable extends Component {
     this.faderNodeBottom = null
     this.containerNode = null
     this.handleOnScroll = this.handleOnScroll.bind(this)
-    this.scrollbarWidth = scrollbarWidth
   }
 
   componentDidMount () {
@@ -73,10 +68,12 @@ class Scrollable extends Component {
   }
 
   applyFadeStyleOffset (node) {
-    const offset = (hasContentOverflowY(this.containerNode))
-      ? /* istanbul ignore next */ `${this.scrollbarWidth}px`
-      : 0
-    node.style.right = offset
+    /* istanbul ignore else */
+    // Guard, just in case the node element is removed.
+    if (node) {
+      const offset = `${this.containerNode.offsetWidth - this.containerNode.scrollWidth}px`
+      node.style.right = offset
+    }
   }
 
   handleOnScroll (event) {

--- a/src/utilities/node.js
+++ b/src/utilities/node.js
@@ -173,16 +173,18 @@ export const getClosestDocument = (node) => {
 }
 
 export const hasContentOverflowX = (node) => {
+  // Cannot be tested in JSDOM (missing measurements for props)
+  /* istanbul ignore else */
   if (!isNodeElement(node)) return false
   /* istanbul ignore next */
-  // Cannot be tested in JSDOM (missing measurements for props)
   return node.clientWidth < node.scrollWidth
 }
 
 export const hasContentOverflowY = (node) => {
+  // Cannot be tested in JSDOM (missing measurements for props)
+  /* istanbul ignore else */
   if (!isNodeElement(node)) return false
   /* istanbul ignore next */
-  // Cannot be tested in JSDOM (missing measurements for props)
   return node.clientHeight < node.scrollHeight
 }
 


### PR DESCRIPTION
## Improve scrollbar offset detection ✨ 

This update replaces the previous getScrollbarWidth method (for offset'ing)
with direct node `offsetWidth` vs `scrollWidth` calculations.

Thanks to @Charca for this idea!!!