### PR TITLE
ChatTranscript: LineItem with timestamp

### DIFF
--- a/src/components/ChatTranscript/Item.js
+++ b/src/components/ChatTranscript/Item.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import LineItem from './LineItem'
 import Attachment from '../Attachment'
 import AttachmentList from '../AttachmentList'
 import Flexy from '../Flexy'
@@ -26,6 +27,7 @@ export const propTypes = {
   onDownloadAllAttachmentClick: PropTypes.func,
   params: PropTypes.any,
   showDownloadAllAttachments: PropTypes.bool,
+  timestamp: PropTypes.string,
   type: PropTypes.oneOf([
     ITEM_TYPES.lineItem,
     ITEM_TYPES.message,
@@ -60,6 +62,7 @@ const Item = props => {
     onDownloadAllAttachmentClick,
     params,
     showDownloadAllAttachments,
+    timestamp,
     type,
     ...rest
   } = props
@@ -75,6 +78,20 @@ const Item = props => {
     className
   )
 
+  if (maybeLineItem) {
+    const lineItemProps = {
+      body,
+      createdAt,
+      className: componentClassName,
+      timestamp,
+      ...rest
+    }
+    return (
+      <LineItem {...lineItemProps}>
+        {children}
+      </LineItem>
+    )
+  }
   const contentClassName = classNames(
     'c-ChatTranscriptItem__content',
     type && `is-${type}`
@@ -108,17 +125,18 @@ const Item = props => {
   const timestampMarkup = createdAt ? (
     <Flexy.Item>
       <Text
-        className='c-ChatTranscriptItem__timestamp'
+        className='c-ChatTranscriptItem__createdAt'
         block
         lineHeightReset
         size='12'
+        title={timestamp}
       >
         {createdAt}
       </Text>
     </Flexy.Item>
   ) : null
 
-  const headerMarkup = !maybeLineItem ? (
+  const headerMarkup = (
     <div className='c-ChatTranscriptItem__header'>
       <Flexy align='bottom' gap='xs' just='left'>
         {authorMarkup}
@@ -126,7 +144,7 @@ const Item = props => {
         {timestampMarkup}
       </Flexy>
     </div>
-  ) : null
+  )
 
   const contentMarkup = body ? (
     <div
@@ -139,7 +157,7 @@ const Item = props => {
     </div>
   )
 
-  const attachmentMarkup = !maybeLineItem && attachments.length ? (
+  const attachmentMarkup = attachments.length ? (
     <AttachmentList
       className='c-ChatTranscriptItem__attachmentList'
       onDownloadAllClick={onDownloadAllAttachmentClick}
@@ -171,5 +189,6 @@ const Item = props => {
 Item.propTypes = propTypes
 Item.defaultProps = defaultProps
 Item.displayName = 'ChatTranscript.Item'
+Item.LineItem = LineItem
 
 export default Item

--- a/src/components/ChatTranscript/LineItem.js
+++ b/src/components/ChatTranscript/LineItem.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Text from '../Text'
+import classNames from '../../utilities/classNames'
+
+export const propTypes = {
+  body: PropTypes.string,
+  createdAt: PropTypes.string,
+  timestamp: PropTypes.string
+}
+
+const defaultProps = {
+  body: '',
+  createdAt: ''
+}
+
+const LineItem = props => {
+  const {
+    body,
+    children,
+    className,
+    createdAt,
+    timestamp,
+    ...rest
+  } = props
+
+  const componentClassName = classNames(
+    'c-ChatTranscriptLineItem',
+    className
+  )
+
+  const timestampMarkup = createdAt ? (
+    <span
+      className='c-ChatTranscriptLineItem__createdAt'
+    >
+      {' '}at{' '}
+      <span
+        className='c-ChatTranscriptLineItem__timestamp'
+        title={timestamp}
+      >
+        {createdAt}
+      </span>
+    </span>
+  ) : null
+
+  const contentMarkup = body || children
+
+  return (
+    <div className={componentClassName} {...rest}>
+      <Text
+        className='c-ChatTranscriptLineItem__content'
+        block
+        lineHeightReset
+        size='12'
+      >
+        {contentMarkup}
+        {timestampMarkup}
+      </Text>
+    </div>
+  )
+}
+
+LineItem.propTypes = propTypes
+LineItem.defaultProps = defaultProps
+LineItem.displayName = 'ChatTranscript.Item.LineItem'
+
+export default LineItem

--- a/src/components/ChatTranscript/docs/Item.md
+++ b/src/components/ChatTranscript/docs/Item.md
@@ -30,6 +30,7 @@ A ChatTranscript.Item component is a list-item component for a [ChatTranscript](
 | onDownloadAllAttachmentClick | `function` | The callback when the [Download All attachment](../../AttachmentList) UI is clicked. |
 | params | `any` | Param data of the chat item. |
 | showDownloadAllAttachments | `bool` | Show/hide the "Download All" attachment UI. Default `true`. |
+| timestamp | `string` | The timestamp to show when hovering the `createdAt` UI. |
 | type | `string` | The type of chat item. |
 
 

--- a/src/components/ChatTranscript/tests/Item.test.js
+++ b/src/components/ChatTranscript/tests/Item.test.js
@@ -8,9 +8,9 @@ const ui = {
   author: '.c-ChatTranscriptItem__author',
   content: '.c-ChatTranscriptItem__content',
   contentWrapper: '.c-ChatTranscriptItem__contentWrapper',
+  createdAt: '.c-ChatTranscriptItem__createdAt',
   header: '.c-ChatTranscriptItem__header',
-  privateNote: '.c-ChatTranscriptItem__privateNote',
-  timestamp: '.c-ChatTranscriptItem__timestamp'
+  privateNote: '.c-ChatTranscriptItem__privateNote'
 }
 
 describe('ClassName', () => {
@@ -142,19 +142,19 @@ describe('Timestamp', () => {
     const wrapper = shallow(
       <Item {...props} />
     )
-    const o = wrapper.find(ui.timestamp)
+    const o = wrapper.find(ui.createdAt)
 
     expect(o.length).toBe(0)
   })
 
-  test('Renders timestamp, if provided', () => {
+  test('Renders createdAt, if provided', () => {
     const props = {
       createdAt: '9:41pm'
     }
     const wrapper = shallow(
       <Item {...props} />
     )
-    const o = wrapper.find(ui.timestamp)
+    const o = wrapper.find(ui.createdAt)
 
     expect(o.length).toBe(1)
     expect(o.html()).toContain(props.createdAt)
@@ -168,7 +168,7 @@ describe('Timestamp', () => {
       <Item {...props} />
     )
     const h = wrapper.find(ui.header)
-    const o = h.find(ui.timestamp)
+    const o = h.find(ui.createdAt)
 
     expect(h.length).toBe(1)
     expect(o.length).toBe(1)
@@ -186,7 +186,7 @@ describe('Type', () => {
       expect(wrapper.hasClass('is-line_item')).toBeTruthy()
     })
 
-    test('Does not render Header', () => {
+    test('Renders a LineItem component instead', () => {
       const props = {
         author: {
           name: 'Derek'
@@ -194,9 +194,9 @@ describe('Type', () => {
         type: ITEM_TYPES.lineItem
       }
       const wrapper = shallow(<Item {...props} />)
-      const h = wrapper.find(ui.header)
+      const o = wrapper.find(Item.LineItem)
 
-      expect(h.length).toBe(0)
+      expect(o.length).toBe(1)
     })
   })
 

--- a/src/components/ChatTranscript/tests/LineItem.test.js
+++ b/src/components/ChatTranscript/tests/LineItem.test.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import LineItem from '../LineItem'
+
+const ui = {
+  content: '.c-ChatTranscriptLineItem__content',
+  createdAt: '.c-ChatTranscriptLineItem__createdAt',
+  timestamp: '.c-ChatTranscriptLineItem__timestamp'
+}
+
+describe('ClassName', () => {
+  test('Has default className', () => {
+    const wrapper = shallow(<LineItem />)
+
+    expect(wrapper.hasClass('c-ChatTranscriptLineItem')).toBeTruthy()
+  })
+
+  test('Applies custom className if specified', () => {
+    const customClass = 'piano-key-neck-tie'
+    const wrapper = shallow(<LineItem className={customClass} />)
+
+    expect(wrapper.prop('className')).toContain(customClass)
+  })
+})
+
+describe('Children', () => {
+  test('Renders child content', () => {
+    const wrapper = shallow(<LineItem><div className='child'>Hello</div></LineItem>)
+    const el = wrapper.find('div.child')
+
+    expect(el.text()).toContain('Hello')
+  })
+})
+
+describe('CreatedAt', () => {
+  test('Does not render by default', () => {
+    const wrapper = mount(
+      <LineItem />
+    )
+    const o = wrapper.find(ui.createdAt)
+
+    expect(o.length).toBe(0)
+  })
+
+  test('Renders createdAt, if provided', () => {
+    const props = {
+      createdAt: '9:41pm'
+    }
+    const wrapper = mount(
+      <LineItem {...props} />
+    )
+    const o = wrapper.find(ui.createdAt)
+
+    expect(o.length).toBe(1)
+    expect(o.html()).toContain(props.createdAt)
+  })
+
+  test('Adds timestamp as a title/tooltip, if provided', () => {
+    const props = {
+      createdAt: '9:41pm',
+      timestamp: 'some time'
+    }
+    const wrapper = mount(
+      <LineItem {...props} />
+    )
+    const o = wrapper.find(ui.createdAt)
+    const t = o.find(ui.timestamp)
+
+    expect(t.length).toBe(1)
+    expect(t.prop('title')).toBe(props.timestamp)
+  })
+})

--- a/src/styles/components/ChatTranscript/ChatTranscriptItem.scss
+++ b/src/styles/components/ChatTranscript/ChatTranscriptItem.scss
@@ -19,22 +19,14 @@
 
   &__content {
     font-size: 14px;
-    // Types
-    &.is-line_item {
-      color: $colorMuted;
-      font-size: 12px;
-      font-weight: 600;
-      text-align: center;
-    }
-
     // Link
     a {
       @include linkStyles;
     }
   }
 
-  &__privateNote,
-  &__timestamp {
+  &__createdAt,
+  &__privateNote {
     color: $colorMuted;
   }
 
@@ -43,20 +35,6 @@
   }
 
   // Types
-  &.is-line_item {
-    margin-bottom: 20px;
-    margin-top: 20px;
-    text-align: center;
-
-    &:first-child {
-      margin-top: 0;
-    }
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-
   &.is-note {
     $bdrWidth: 3px;
     padding-top: 2px;

--- a/src/styles/components/ChatTranscript/ChatTranscriptLineItem.scss
+++ b/src/styles/components/ChatTranscript/ChatTranscriptLineItem.scss
@@ -1,0 +1,19 @@
+.c-ChatTranscriptLineItem {
+  @import "../../configs/color";
+  @import "../../resets/base";
+
+  color: _color(grey, 800);
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 20px;
+  margin-top: 20px;
+  text-align: center;
+
+  &:first-child {
+    margin-top: 0;
+  }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}

--- a/src/styles/components/ChatTranscript/__index.scss
+++ b/src/styles/components/ChatTranscript/__index.scss
@@ -1,2 +1,3 @@
 @import "./ChatTranscript";
 @import "./ChatTranscriptItem";
+@import "./ChatTranscriptLineItem";

--- a/stories/ChatTranscript/index.js
+++ b/stories/ChatTranscript/index.js
@@ -83,6 +83,8 @@ stories.add('types', () => {
       <ChatTranscript.Item
         body='Something happened (This is a line_item)'
         type='line_item'
+        createdAt='10:45pm'
+        timestamp='Monday, 10:45pm'
       />
 
       <ChatTranscript.Item


### PR DESCRIPTION
## ChatTranscript: LineItem with timestamp 🕐 

![screen recording 2018-02-23 at 03 30 pm](https://user-images.githubusercontent.com/2322354/36615733-49edb764-18af-11e8-9f63-9225dac7b6d6.gif)

This update refactors ChatTranscript.Item to better handle `line_item`
types. It now renders an internal sub-component, specific for the `line_item`
UI, ensuring it has a createdAt, with support for a timestamp, available
on hover.

ChatTranscript.Item now also has access to timestamp on hover.

In the future, I plan to replace it with an actual tooltip, when that
gets built.

Resolves: https://github.com/helpscout/blue/issues/222