### PR TITLE
Input: Allow scrolling + implement scroll-lock

### DIFF
--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -31,7 +31,7 @@ An Input component is an enhanced version of the default HTML `<input>`. Input c
 | id | `string` | ID for the input. |
 | isFocused | `string` | Determines if the component is focused. |
 | label | `string`/`component` | Label for the input. |
-| maxHeight | `number` | Sets the `max-height` for the input. Used with `multiline`. |
+| maxHeight | `number`/`string` | Sets the `max-height` for the input. Used with `multiline`. |
 | multiline | `bool`/`number` | Transforms input into an auto-expanding textarea. |
 | name | `string` | Name for the input. |
 | onBlur | `function` | Callback when input is blurred. |

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -1,10 +1,11 @@
 import React, { PureComponent as Component } from 'react'
 import PropTypes from 'prop-types'
 import Backdrop from './Backdrop'
-import HelpText from '../HelpText'
-import Label from '../Label'
 import Resizer from './Resizer'
 import Static from './Static'
+import HelpText from '../HelpText'
+import Label from '../Label'
+import { scrollLockY } from '../ScrollLock'
 import classNames from '../../utilities/classNames'
 import { createUniqueIDFactory } from '../../utilities/id'
 import { noop } from '../../utilities/other'
@@ -23,11 +24,12 @@ export const propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   modalhelpText: PropTypes.string,
   multiline: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
-  maxHeight: PropTypes.number,
+  maxHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   name: PropTypes.string,
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
+  onWheel: PropTypes.func,
   placeholder: PropTypes.string,
   prefix: PropTypes.string,
   readOnly: PropTypes.bool,
@@ -51,6 +53,7 @@ const defaultProps = {
   onBlur: noop,
   onChange: noop,
   onFocus: noop,
+  onWheel: noop,
   readOnly: false,
   removeStateStylesOnFocus: false,
   resizable: false,
@@ -73,6 +76,7 @@ class Input extends Component {
     this.inputNode = null
     this.handleOnChange = this.handleOnChange.bind(this)
     this.handleOnInputFocus = this.handleOnInputFocus.bind(this)
+    this.handleOnWheel = this.handleOnWheel.bind(this)
     this.handleExpandingResize = this.handleExpandingResize.bind(this)
   }
 
@@ -140,6 +144,13 @@ class Input extends Component {
     onFocus(e)
   }
 
+  handleOnWheel (event) {
+    const { onWheel } = this.props
+    const stopPropagation = true
+    scrollLockY(event, stopPropagation)
+    onWheel(event)
+  }
+
   handleExpandingResize (height) {
     this.setState({ height })
   }
@@ -161,6 +172,7 @@ class Input extends Component {
       name,
       onBlur,
       onFocus,
+      onWheel,
       placeholder,
       prefix,
       readOnly,
@@ -179,6 +191,7 @@ class Input extends Component {
 
     const handleOnChange = this.handleOnChange
     const handleOnInputFocus = this.handleOnInputFocus
+    const handleOnWheel = this.handleOnWheel
     const handleExpandingResize = this.handleExpandingResize
 
     const componentClassName = classNames(
@@ -260,6 +273,7 @@ class Input extends Component {
       name,
       onBlur,
       onFocus: handleOnInputFocus,
+      onWheel: handleOnWheel,
       placeholder,
       readOnly,
       style,

--- a/src/components/Input/tests/Input.test.js
+++ b/src/components/Input/tests/Input.test.js
@@ -90,6 +90,28 @@ describe('Events', () => {
 
     expect(spy).toHaveBeenCalledWith(value)
   })
+
+  test('onWheel callback can be triggered', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Input onWheel={spy} />)
+    const input = wrapper.find('input')
+
+    input.simulate('wheel')
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('onWheel callback stops event from bubbling', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Input />)
+    const input = wrapper.find('input')
+
+    input.simulate('wheel', {
+      stopPropagation: spy
+    })
+
+    expect(spy).toHaveBeenCalled()
+  })
 })
 
 describe('value', () => {
@@ -217,6 +239,13 @@ describe('Multiline', () => {
     const o = wrapper.find(ui.input)
 
     expect(o.hasClass('has-maxHeight')).toBeTruthy()
+  })
+
+  test('maxHeight Accepts string values', () => {
+    const wrapper = mount(<Input multiline={3} maxHeight='50vh' />)
+    const o = wrapper.find(ui.field)
+
+    expect(o.prop('style').maxHeight).toBe('50vh')
   })
 })
 

--- a/src/components/ScrollLock/README.md
+++ b/src/components/ScrollLock/README.md
@@ -14,6 +14,11 @@ ScrollLock is an event handling component which prevents scrolling past the top 
 ```
 
 
+### Use in Firefox
+
+ScrollLocking has been disabled for Firefox. Firefox does not seem to handle the combination of the `onWheel` event combined with `event.preventDefault` in a smooth way. Disabling for Firefox applies to this component, as well as the `scrollLockX` and `scrollLockY` functions that this component uses.
+
+
 ## Props
 
 | Prop | Type | Description |

--- a/src/components/ScrollLock/index.js
+++ b/src/components/ScrollLock/index.js
@@ -1,5 +1,6 @@
 import React, {PureComponent as Component} from 'react'
 import PropTypes from 'prop-types'
+import { isFirefox } from '../../utilities/browser'
 import { noop } from '../../utilities/other'
 
 export const propTypes = {
@@ -50,7 +51,11 @@ function handleWheelEvent (event, direction, stopPropagation) {
   }
 }
 
-function scrollLockX (event, stopPropagation) {
+export function scrollLockX (event, stopPropagation) {
+  // Disabled for Firefox
+  /* istanbul ignore if */
+  // Can't test this function in JSDOM
+  if (isFirefox()) return
   const { deltaX } = event
   const scrollNode = event.currentTarget
   const { clientWidth, scrollWidth, scrollLeft } = scrollNode
@@ -68,7 +73,11 @@ function scrollLockX (event, stopPropagation) {
   }
 }
 
-function scrollLockY (event, stopPropagation) {
+export function scrollLockY (event, stopPropagation) {
+  // Disabled for Firefox
+  /* istanbul ignore if */
+  // Can't test this function in JSDOM
+  if (isFirefox()) return
   const scrollNode = event.currentTarget
   const { clientHeight, scrollHeight, scrollTop } = scrollNode
   const { deltaY } = event

--- a/src/utilities/browser.js
+++ b/src/utilities/browser.js
@@ -1,0 +1,13 @@
+/* istanbul ignore next */
+// Can't write tests for this in JSDOM.
+// Can't create fixture for JSDOM's built-in Navigator instance.
+export const isBrowser = (browser) => {
+  /* istanbul ignore next */
+  if (!navigator) return false
+  return (navigator.userAgent.toLowerCase().indexOf(browser) > -1)
+}
+
+export const isEdge = /* istanbul ignore next */ () => isBrowser('edge')
+export const isChrome = /* istanbul ignore next */ () => isBrowser('chrome')
+export const isFirefox = /* istanbul ignore next */ () => isBrowser('firefox')
+export const isSafari = /* istanbul ignore next */ () => isBrowser('safari')

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -1,4 +1,5 @@
 import * as animationUtils from './animation'
+import * as browserUtils from './browser'
 import * as classNamesUtils from './classNames'
 import * as componentUtils from './component'
 import * as colorUtils from './color'
@@ -15,6 +16,7 @@ import * as stringsUtils from './strings'
 import * as typesUtils from './types'
 
 export const animation = animationUtils
+export const browser = browserUtils
 export const classNames = classNamesUtils
 export const color = colorUtils
 export const component = componentUtils
@@ -32,6 +34,7 @@ export const types = typesUtils
 
 export default {
   animation,
+  browser,
   classNames,
   component,
   color,

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -107,6 +107,7 @@ class StatefulComponent extends React.Component {
                   <Input
                     autoFocus
                     multiline={3}
+                    maxHeight={140}
                     onChange={this.handleOnInputChange}
                     value={value}
                   />


### PR DESCRIPTION
## Input: Allow scrolling + implement scroll-lock

![screen recording 2018-02-27 at 12 55 pm](https://user-images.githubusercontent.com/2322354/36750509-b41d5a62-1bcb-11e8-8878-cf1c08d1214b.gif)

This update fixes multiline scrollable Inputs to allow them to scroll
if they are used within a ScrollLock'ed component.

These Input components (actually textareas) have their own Scroll-locking
mechanism.

Lastly, scroll-locking has been disabled for Firefox, due to some strange
interaction issues with FF.