### PR TITLE
Message: Chat: Allow for HTML rendering

### DIFF
--- a/src/components/Message/Bubble.js
+++ b/src/components/Message/Bubble.js
@@ -12,6 +12,7 @@ const contextTypes = providerContextTypes
 
 const Bubble = (props, context) => {
   const {
+    body,
     children,
     className,
     from,
@@ -45,11 +46,20 @@ const Bubble = (props, context) => {
 
   const childrenMarkup = React.Children.map(children, child => {
     return isWord(child) || isNativeSpanType(child) ? (
-      <Text wordWrap>
-        {child}
-      </Text>
+      <span className='c-MessageBubble__body'>
+        <Text wordWrap>
+          {child}
+        </Text>
+      </span>
     ) : child
   })
+
+  const bodyMarkup = body ? (
+    <span
+      className='c-MessageBubble__body'
+      dangerouslySetInnerHTML={{__html: body}}
+    />
+  ) : childrenMarkup
 
   const titleMarkup = title ? (
     <Heading className='c-MessageBubble__title' size='small'>
@@ -61,7 +71,7 @@ const Bubble = (props, context) => {
     <div className='c-MessageBubble__typing'>
       <LoadingDots />
     </div>
-  ) : childrenMarkup
+  ) : bodyMarkup
 
   return (
     <div className={componentClassName} {...rest}>

--- a/src/components/Message/Chat.js
+++ b/src/components/Message/Chat.js
@@ -8,6 +8,7 @@ export const propTypes = bubbleTypes
 
 const Chat = props => {
   const {
+    body,
     children,
     className,
     read,
@@ -31,6 +32,8 @@ const Chat = props => {
   )
 
   const chatProps = {
+    body,
+    children,
     from,
     ltr,
     rtl,
@@ -54,9 +57,7 @@ const Chat = props => {
         title={title}
         typing={typing}
         type={type}
-      >
-        {children}
-      </Bubble>
+      />
     </ChatBlock>
   )
 }

--- a/src/components/Message/ChatBlock.js
+++ b/src/components/Message/ChatBlock.js
@@ -13,6 +13,7 @@ const contextTypes = providerContextTypes
 
 const ChatBlock = (props, context) => {
   const {
+    body,
     children,
     className,
     ltr,

--- a/src/components/Message/Media.js
+++ b/src/components/Message/Media.js
@@ -14,6 +14,7 @@ export const propTypes = Object.assign({}, bubbleTypes, {
 
 const Media = props => {
   const {
+    body,
     children,
     className,
     caption,
@@ -44,23 +45,25 @@ const Media = props => {
   ) : null
 
   const mediaMarkup = imageUrl ? (
-    <Image
-      block
-      className='c-MessageMedia__media'
-      src={imageUrl}
-      shape='rounded'
-    />
+    <div className='c-MessageMedia__media'>
+      <Image
+        block
+        className='c-MessageMedia__mediaImage'
+        src={imageUrl}
+        shape='rounded'
+      />
+    </div>
   ) : null
 
   const mediaContainerMarkup = imageUrl ? (
     <div className='c-MessageMedia__media-container'>
-      <Modal trigger={mediaMarkup} scrollFade={false}>
-        <Modal.Content>
-          <div>
+      <Modal trigger={mediaMarkup}>
+        <Modal.Body scrollFade={false} isSeamless>
+          <Modal.Content>
             {mediaMarkup}
-          </div>
-          {captionMarkup}
-        </Modal.Content>
+            {captionMarkup}
+          </Modal.Content>
+        </Modal.Body>
       </Modal>
     </div>
   ) : null

--- a/src/components/Message/propTypes.js
+++ b/src/components/Message/propTypes.js
@@ -30,6 +30,7 @@ export const chatTypes = Object.assign({}, messageTypes, {
 })
 
 export const bubbleTypes = Object.assign({}, chatTypes, {
+  body: PropTypes.string,
   isNote: PropTypes.bool,
   primary: PropTypes.bool,
   title: PropTypes.string,

--- a/src/components/Message/tests/Bubble.test.js
+++ b/src/components/Message/tests/Bubble.test.js
@@ -4,8 +4,12 @@ import Bubble from '../Bubble'
 import { Heading, LoadingDots, Text } from '../../'
 import { baseComponentTest } from '../../../tests/helpers/components'
 
+const cx = 'c-MessageBubble'
 const baseComponentOptions = {
-  className: 'c-MessageBubble'
+  className: cx
+}
+const ui = {
+  body: `.${cx}__body`
 }
 
 baseComponentTest(Bubble, baseComponentOptions)
@@ -92,6 +96,40 @@ describe('Content', () => {
 
     expect(o.length).toBe(0)
     expect(wrapper.html()).toContain('Mugatu')
+  })
+
+  test('Renders body if defined', () => {
+    const wrapper = shallow(
+      <Bubble body='Mugatu' />
+    )
+    const o = wrapper.find(ui.body)
+
+    expect(o.length).toBe(1)
+    expect(wrapper.html()).toContain('Mugatu')
+  })
+
+  test('Renders body instead of children, if defined', () => {
+    const wrapper = shallow(
+      <Bubble body='Mugatu'>
+        Zoolander
+      </Bubble>
+    )
+    const o = wrapper.find(ui.body)
+
+    expect(o.length).toBe(1)
+    expect(wrapper.html()).toContain('Mugatu')
+    expect(wrapper.html()).not.toContain('Zoolander')
+  })
+
+  test('Renders body as HTML', () => {
+    const html = '<div>Mugatu<br /></div>'
+    const wrapper = shallow(
+      <Bubble body={html} />
+    )
+    const o = wrapper.find(ui.body)
+
+    expect(o.length).toBe(1)
+    expect(wrapper.html()).toContain(html)
   })
 })
 

--- a/src/components/Message/tests/Chat.test.js
+++ b/src/components/Message/tests/Chat.test.js
@@ -45,6 +45,7 @@ describe('Bubble', () => {
   test('Passes correct props to Bubble', () => {
     const wrapper = shallow(
       <Chat
+        body='body'
         from
         isNote
         ltr
@@ -58,6 +59,7 @@ describe('Bubble', () => {
     )
     const props = wrapper.find(Bubble).node.props
 
+    expect(props.body).toBeTruthy()
     expect(props.from).toBeTruthy()
     expect(props.isNote).toBeTruthy()
     expect(props.ltr).toBeTruthy()

--- a/src/components/Modal/Body.js
+++ b/src/components/Modal/Body.js
@@ -5,6 +5,7 @@ import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 
 export const propTypes = {
+  isSeamless: PropTypes.bool,
   onScroll: PropTypes.func,
   scrollable: PropTypes.bool,
   scrollableRef: PropTypes.func,
@@ -12,6 +13,7 @@ export const propTypes = {
 }
 
 const defaultProps = {
+  isSeamless: false,
   onScroll: noop,
   scrollable: true,
   scrollableRef: noop,
@@ -46,6 +48,7 @@ class Body extends Component {
     const {
       className,
       children,
+      isSeamless,
       onScroll,
       scrollable,
       scrollFade,
@@ -55,6 +58,7 @@ class Body extends Component {
 
     const componentClassName = classNames(
       'c-ModalBody',
+      isSeamless && 'is-seamless',
       scrollable ? 'is-scrollable' : 'is-not-scrollable',
       className
     )
@@ -62,6 +66,7 @@ class Body extends Component {
     const childrenContent = scrollable ? (
       <Scrollable
         className='c-ModalBody__scrollable'
+        contentClassName='c-ModalBody__scrollableContent'
         fade={scrollFade}
         rounded
         onScroll={onScroll}

--- a/src/components/Modal/docs/Body.md
+++ b/src/components/Modal/docs/Body.md
@@ -1,6 +1,6 @@
 # Body
 
-A Modal.Body component contains content that appears within a [Modal](./Modal.md). 
+A Modal.Body component contains content that appears within a [Modal](./Modal.md).
 
 
 ## Example
@@ -19,6 +19,7 @@ A Modal.Body component contains content that appears within a [Modal](./Modal.md
 | Prop | Type | Description |
 | --- | --- | --- |
 | className | `string` | Custom class names to be added to the component. |
+| isSeamless | `bool` | Applies seamless styles to the component. |
 | onScroll | `function` | Callback function when inner Scrollable is scrolled. |
 | scrollFade | `bool` | Enables the upper fade-to-white styles. Default `true`. |
 | scrollableRef | `function` | Retrieves the scrollable node. |

--- a/src/components/Modal/tests/Body.test.js
+++ b/src/components/Modal/tests/Body.test.js
@@ -112,3 +112,17 @@ describe('Context', () => {
     expect(spy.mock.calls[0][0]).toBeTruthy()
   })
 })
+
+describe('Styles', () => {
+  test('Does not have seamless styles by default', () => {
+    const wrapper = shallow(<Body />)
+
+    expect(wrapper.hasClass('is-seamless')).not.toBeTruthy()
+  })
+
+  test('Applies isSeamless styles, if applied', () => {
+    const wrapper = shallow(<Body isSeamless />)
+
+    expect(wrapper.hasClass('is-seamless')).toBeTruthy()
+  })
+})

--- a/src/components/Scrollable/README.md
+++ b/src/components/Scrollable/README.md
@@ -20,6 +20,7 @@ A Scrollable component is light-weight wrapper that enables scrolling for conten
 | --- | --- | --- |
 | backgroundColor | `string` | Background color for the fade elements. |
 | className | `string` | Custom class names to be added to the component. |
+| contentClassName | `string` | Custom class names for the component's content DOM node. |
 | fade | `bool` | Adds a "fade-to-white" visual experience while scrolling. Appears at the top. |
 | fadeBottom | `bool` | Adds a "fade-to-white" visual experience while scrolling. Appears at the bottom. |
 | onScroll | `function` | Callback function when component is scrolled. |

--- a/src/components/Scrollable/index.js
+++ b/src/components/Scrollable/index.js
@@ -8,6 +8,7 @@ import { noop } from '../../utilities/other'
 export const propTypes = {
   backgroundColor: PropTypes.string,
   className: PropTypes.string,
+  contentClassName: PropTypes.string,
   fade: PropTypes.bool,
   fadeBottom: PropTypes.bool,
   onScroll: PropTypes.func,
@@ -87,6 +88,7 @@ class Scrollable extends Component {
       backgroundColor,
       children,
       className,
+      contentClassName,
       fade,
       fadeBottom,
       onRef,
@@ -104,6 +106,11 @@ class Scrollable extends Component {
       fade && 'has-fade',
       rounded && 'is-rounded',
       className
+    )
+
+    const componentContentClassName = classNames(
+      'c-Scrollable__content',
+      contentClassName
     )
 
     const faderTopMarkup = (
@@ -134,7 +141,7 @@ class Scrollable extends Component {
         {faderTopMarkup}
         <ScrollLock isDisabled={!isScrollLocked}>
           <div
-            className='c-Scrollable__content'
+            className={componentContentClassName}
             onScroll={handleOnScroll}
             ref={node => {
               this.containerNode = node

--- a/src/components/Scrollable/tests/Scrollable.test.js
+++ b/src/components/Scrollable/tests/Scrollable.test.js
@@ -3,6 +3,10 @@ import { mount, shallow } from 'enzyme'
 import Scrollable from '..'
 import wait from '../../../tests/helpers/wait'
 
+const ui = {
+  content: '.c-Scrollable__content'
+}
+
 describe('ClassName', () => {
   test('Has default className', () => {
     const wrapper = shallow(<Scrollable />)
@@ -91,6 +95,30 @@ describe('Fade', () => {
       expect(o.faderNodeBottom.style.transform).toContain('scaleY')
       done()
     })
+  })
+})
+
+describe('Content', () => {
+  test('Renders content within the content node', () => {
+    const wrapper = shallow(
+      <Scrollable>
+        <div className='mugatu'>Mugatu</div>
+      </Scrollable>
+    )
+    const o = wrapper.find(ui.content)
+
+    expect(o.length).toBe(1)
+    expect(o.html()).toContain('mugatu')
+    expect(o.html()).toContain('Mugatu')
+  })
+
+  test('Can provide content with custom className', () => {
+    const wrapper = shallow(
+      <Scrollable contentClassName='mugatu' />
+    )
+    const o = wrapper.find(ui.content)
+
+    expect(o.hasClass('mugatu')).toBeTruthy()
   })
 })
 

--- a/src/styles/components/Modal/ModalBody.scss
+++ b/src/styles/components/Modal/ModalBody.scss
@@ -1,18 +1,26 @@
+@import "pack/seed-this/__index";
+
 .c-ModalBody {
   @import "../../resets/base";
+  $block: this();
   display: flex;
   flex: 1;
   height: 100%;
   max-width: 100%;
   min-height: 0;
 
-  &__scrollable {
-    & > .c-Scrollable__content {
-      padding: 20px;
-    }
+  &__scrollableContent {
+    padding: 20px;
   }
 
+  // Modifiers
   &.is-not-scrollable {
     padding: 20px;
+  }
+
+  &.is-seamless {
+    #{$block}__scrollableContent {
+      padding: 0;
+    }
   }
 }

--- a/stories/Message.js
+++ b/stories/Message.js
@@ -105,19 +105,23 @@ stories.add('action', () => (
   </Message>
 ))
 
-stories.add('chat', () => (
-  <Message to avatar={<Avatar name='Buddy' />}>
-    <Message.Chat read timestamp='9:41am'>
-      :sob:
-      <br />
-      omgomgomg
-      {1}
-    </Message.Chat>
-    <Message.Chat read timestamp='9:41am'>
-      <strong>*Frantically running through North pole*</strong>
-    </Message.Chat>
-  </Message>
-))
+stories.add('chat', () => {
+  const htmlBody = `
+    :sob:
+    <br />
+    <br />
+    omgomgomg
+    <br />
+  `
+  return (
+    <Message to avatar={<Avatar name='Buddy' />}>
+      <Message.Chat read timestamp='9:41am' body={htmlBody} />
+      <Message.Chat read timestamp='9:41am'>
+        <strong>*Frantically running through North pole*</strong>
+      </Message.Chat>
+    </Message>
+  )
+})
 
 stories.add('content', () => (
   <Message to avatar={<Avatar name='Buddy' />}>


### PR DESCRIPTION
## Message: Chat: Allow for HTML rendering 👾 

This update enhances the `<Message.Chat />` component to be able to render
HTML by passing HTML string into a new `body` prop. In a scenario where
there is both a `body` and `children` prop defined, `body` will render
instead of `children`.

`<Message.Media>` received some light UI adjustments to account for the
new(ish) Modal structure that was introduced. This change touched a bit of
`Modal.Body` as well as `Scrollable`.

Documentation and tests have been added.