### PR TITLE
Avatar: Adjust UI for outerBorderColor

### DIFF
--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -21,6 +21,7 @@ An Avatar component displays a user's avatar image, or their initials if an imag
 | light | `bool` | Applies a "light" style to the component. |
 | initials | `string` | Custom initials to display. |
 | name | `string` | Name of the user. Required. |
+| outerBorderColor | `string` | Color for the Avatar's outer border. |
 | shape | `string` | Shape of the avatar. |
 | size | `string` | Size of the avatar. |
 | title | `string` | Text for the image `alt` and `title` attributes. |

--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -16,6 +16,8 @@ export const propTypes = {
   initials: PropTypes.string,
   light: PropTypes.bool,
   name: PropTypes.string.isRequired,
+  outerBorderColor: PropTypes.string,
+  showStatusBorderColor: PropTypes.bool,
   shape: shapeTypes,
   size: standardSizeTypes,
   statusIcon: PropTypes.string,
@@ -25,6 +27,7 @@ export const propTypes = {
 const defaultProps = {
   light: false,
   name: '',
+  showStatusBorderColor: false,
   size: 'md',
   shape: 'circle'
 }
@@ -55,6 +58,8 @@ class Avatar extends Component {
       name,
       light,
       initials,
+      outerBorderColor,
+      showStatusBorderColor,
       size,
       shape,
       status,
@@ -67,8 +72,10 @@ class Avatar extends Component {
 
     const componentClassName = classNames(
       'c-Avatar',
+      borderColor && 'has-borderColor',
       hasImage && 'has-image',
       light && 'is-light',
+      outerBorderColor && 'has-outerBorderColor',
       shape && `is-${shape}`,
       size && `is-${size}`,
       status && `is-${status}`,
@@ -76,7 +83,6 @@ class Avatar extends Component {
     )
 
     const imageStyle = hasImage ? { backgroundImage: `url('${image}')` } : null
-
     const text = count || initials || nameToInitials(name)
 
     const contentMarkup = hasImage
@@ -94,9 +100,10 @@ class Avatar extends Component {
         {text}
       </div>
 
-    let styles = borderColor ? {
-      border: '2px solid',
-      borderColor
+    let styles = (borderColor || outerBorderColor) ? {
+      border: borderColor ? '2px solid' : undefined,
+      borderColor,
+      boxShadow: outerBorderColor ? `0 0 0 2px ${outerBorderColor}` : undefined
     } : {}
 
     hasImage && Object.assign(styles, {
@@ -107,7 +114,12 @@ class Avatar extends Component {
 
     const statusMarkup = status ? (
       <div className='c-Avatar__status'>
-        <StatusDot status={status} icon={statusIcon} />
+        <StatusDot
+          icon={statusIcon}
+          outerBorderColor={showStatusBorderColor ? borderColor : undefined}
+          size={size === 'sm' ? 'sm' : 'md'}
+          status={status}
+        />
       </div>
     ) : null
 

--- a/src/components/Avatar/tests/Avatar.test.js
+++ b/src/components/Avatar/tests/Avatar.test.js
@@ -152,6 +152,55 @@ describe('Border color', () => {
 
     expect(style).not.toBeTruthy()
   })
+
+  test('Adds a style class to the component', () => {
+    const wrapper = shallow(<Avatar name='Buddy' borderColor='red' />)
+
+    expect(wrapper.hasClass('has-borderColor')).toBeTruthy()
+  })
+
+  test('Does not pass borderColor as outerBorderColor to StatusDot, by default', () => {
+    const wrapper = shallow(
+      <Avatar name='Buddy' borderColor='red' status='online' />
+    )
+    const o = wrapper.find(StatusDot)
+
+    expect(o.prop('outerBorderColor')).not.toBe('red')
+  })
+
+  test('Passes borderColor as outerBorderColor to StatusDot, if specified', () => {
+    const wrapper = shallow(
+      <Avatar name='Buddy' borderColor='red' status='online' showStatusBorderColor />
+    )
+    const o = wrapper.find(StatusDot)
+
+    expect(o.prop('outerBorderColor')).toBe('red')
+  })
+})
+
+describe('Outer border color', () => {
+  test('Does not apply outerBorderColor by default', () => {
+    const wrapper = shallow(<Avatar name='Buddy' />)
+    const crop = wrapper.find(classNames.crop)
+    const style = crop.props().style
+
+    expect(style).not.toBeTruthy()
+  })
+
+  test('Can apply outerBorderColor', () => {
+    const wrapper = shallow(<Avatar name='Buddy' outerBorderColor='green' />)
+    const crop = wrapper.find(classNames.crop)
+    const style = crop.props().style
+
+    expect(style).toBeTruthy()
+    expect(style.boxShadow).toContain('green')
+  })
+
+  test('Adds a style class to the component', () => {
+    const wrapper = shallow(<Avatar name='Buddy' outerBorderColor='red' />)
+
+    expect(wrapper.hasClass('has-outerBorderColor')).toBeTruthy()
+  })
 })
 
 describe('Size', () => {
@@ -180,6 +229,16 @@ describe('StatusDot', () => {
     expect(wrapper.hasClass('is-online'))
     expect(statusMarkup.length).toBe(1)
     expect(o.length).toBe(1)
+  })
+
+  test('Adjust the size of StatusDot based on size of Avatar', () => {
+    const wrapper = shallow(<Avatar status='online' size='md' />)
+
+    expect(wrapper.find(StatusDot).prop('size')).toBe('md')
+
+    wrapper.setProps({size: 'sm'})
+
+    expect(wrapper.find(StatusDot).prop('size')).toBe('sm')
   })
 
   test('Renders an icon in StatusDot, if defined', () => {

--- a/src/styles/components/Avatar.scss
+++ b/src/styles/components/Avatar.scss
@@ -6,6 +6,7 @@
   @import "../configs/color";
   @import "../resets/base";
   $block: this();
+  $bdrWidth: 2px;
   $sizes: (
     lg: (
       size: 52px,
@@ -92,6 +93,12 @@
       height: $sz;
       font-size: _get($values, font-size);
       width: $sz;
+
+      &.has-outerBorderColor {
+        $sz: _get($values, size) + ($bdrWidth * 2);
+        height: $sz;
+        width: $sz;
+      }
     }
   }
 

--- a/stories/Avatar/index.js
+++ b/stories/Avatar/index.js
@@ -117,7 +117,14 @@ stories.add('sizes', () => (
 ))
 
 stories.add('border', () => (
-  <div>
-    <Avatar name={fixture.name} size='lg' borderColor='red' />
+  <div style={{ background: 'orangered', padding: 20 }}>
+    <Avatar
+      borderColor='orangered'
+      outerBorderColor='white'
+      name={fixture.name}
+      showStatusBorderColor
+      size='lg'
+      status='online'
+    />
   </div>
 ))


### PR DESCRIPTION
## Avatar: Adjust UI for outerBorderColor 🦊 

![screen shot 2018-03-01 at 11 11 16 am](https://user-images.githubusercontent.com/2322354/36855498-a5879662-1d41-11e8-995b-45b53754adfe.jpg)

This update enhances the Avatar component by adjusting the styles for
`outerBorderColor` and `borderColor`. It also coordinates the the Avatar's
`StatusDot` size with the Avatar's size.