### PR TITLE
Button: Add XS and Outline styles

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 import RouteWrapper from '../RouteWrapper'
-import { standardSizeTypes, stateTypes } from '../../constants/propTypes'
+import { stateTypes } from '../../constants/propTypes'
 
 export const propTypes = {
   accessibilityLabel: PropTypes.string,
@@ -17,7 +17,13 @@ export const propTypes = {
   outline: PropTypes.bool,
   plain: PropTypes.bool,
   primary: PropTypes.bool,
-  size: standardSizeTypes,
+  size: PropTypes.oneOf([
+    'lg',
+    'md',
+    'sm',
+    'xs',
+    ''
+  ]),
   state: stateTypes,
   submit: PropTypes.bool,
   theme: PropTypes.string

--- a/src/components/Drop/index.js
+++ b/src/components/Drop/index.js
@@ -90,6 +90,14 @@ export const DropComponent = (/* istanbul ignore next */ options = defaultOption
   Drop.propTypes = propTypes
   Drop.defaultProps = defaultProps
 
+  const componentName = (
+    ComposedComponent.displayName ||
+    ComposedComponent.name ||
+    /* istanbul ignore next */
+    'Component'
+  )
+  Drop.displayName = `withDrop(${componentName})`
+
   return Drop
 }
 

--- a/src/components/Drop/tests/Drop.test.js
+++ b/src/components/Drop/tests/Drop.test.js
@@ -209,3 +209,51 @@ describe('isOpen', () => {
       })
   })
 })
+
+describe('displayName', () => {
+  test('Uses a ComposedComponent.name', () => {
+    const Derek = () => (
+      <div />
+    )
+    const WrappedComponent = Drop()(Derek)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+
+  test('Uses a ComposedComponent.displayName', () => {
+    const Composed = () => (
+      <div />
+    )
+    Composed.displayName = 'Derek'
+    const WrappedComponent = Drop()(Composed)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+
+  test('Works with React.Component', () => {
+    class Derek extends React.Component {
+      render () {
+        return (<div />)
+      }
+    }
+    const WrappedComponent = Drop()(Derek)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+
+  test('Works with React.Component.displayName', () => {
+    class Composed extends React.Component {
+      render () {
+        return (<div />)
+      }
+    }
+    Composed.displayName = 'Derek'
+    const WrappedComponent = Drop()(Composed)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+})

--- a/src/components/HoverWrapper/index.js
+++ b/src/components/HoverWrapper/index.js
@@ -61,7 +61,14 @@ const HoverWrapper = ComposedComponent => {
   WrappedComponent.propTypes = propTypes
   WrappedComponent.defaultProps = defaultProps
   WrappedComponent.contextTypes = ComposedComponent.contextTypes
-  WrappedComponent.displayName = ComposedComponent.displayName
+
+  const componentName = (
+    ComposedComponent.displayName ||
+    ComposedComponent.name ||
+    /* istanbul ignore next */
+    'Component'
+  )
+  WrappedComponent.displayName = `withHover(${componentName})`
 
   return WrappedComponent
 }

--- a/src/components/HoverWrapper/tests/HoverWrapper.test.js
+++ b/src/components/HoverWrapper/tests/HoverWrapper.test.js
@@ -93,8 +93,55 @@ describe('Props', () => {
       />
     )
 
-    expect(wrapper.props()['aria-role']).toBeTruthy()
     expect(wrapper.props()['data-attr']).toBeTruthy()
     expect(wrapper.props().style.background).toBe('red')
+  })
+})
+
+describe('displayName', () => {
+  test('Uses a ComposedComponent.name', () => {
+    const Derek = () => (
+      <div />
+    )
+    const WrappedComponent = HoverWrapper(Derek)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+
+  test('Uses a ComposedComponent.displayName', () => {
+    const Composed = () => (
+      <div />
+    )
+    Composed.displayName = 'Derek'
+    const WrappedComponent = HoverWrapper(Composed)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+
+  test('Works with React.Component', () => {
+    class Derek extends React.Component {
+      render () {
+        return (<div />)
+      }
+    }
+    const WrappedComponent = HoverWrapper(Derek)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+
+  test('Works with React.Component.displayName', () => {
+    class Composed extends React.Component {
+      render () {
+        return (<div />)
+      }
+    }
+    Composed.displayName = 'Derek'
+    const WrappedComponent = HoverWrapper(Composed)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
   })
 })

--- a/src/components/PortalWrapper/index.js
+++ b/src/components/PortalWrapper/index.js
@@ -312,7 +312,14 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
   PortalWrapper.propTypes = propTypes
   PortalWrapper.defaultProps = defaultProps
   PortalWrapper.contextTypes = contextTypes
-  PortalWrapper.displayName = 'PortalWrapper'
+
+  const componentName = (
+    ComposedComponent.displayName ||
+    ComposedComponent.name ||
+    /* istanbul ignore next */
+    'Component'
+  )
+  PortalWrapper.displayName = `withPortal(${componentName})`
 
   return PortalWrapper
 }

--- a/src/components/PortalWrapper/tests/PortalWrapper.test.js
+++ b/src/components/PortalWrapper/tests/PortalWrapper.test.js
@@ -412,3 +412,51 @@ describe('Esc keypress', () => {
     }, 20)
   })
 })
+
+describe('displayName', () => {
+  test('Uses a ComposedComponent.name', () => {
+    const Derek = () => (
+      <div />
+    )
+    const WrappedComponent = PortalWrapper()(Derek)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+
+  test('Uses a ComposedComponent.displayName', () => {
+    const Composed = () => (
+      <div />
+    )
+    Composed.displayName = 'Derek'
+    const WrappedComponent = PortalWrapper()(Composed)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+
+  test('Works with React.Component', () => {
+    class Derek extends React.Component {
+      render () {
+        return (<div />)
+      }
+    }
+    const WrappedComponent = PortalWrapper()(Derek)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+
+  test('Works with React.Component.displayName', () => {
+    class Composed extends React.Component {
+      render () {
+        return (<div />)
+      }
+    }
+    Composed.displayName = 'Derek'
+    const WrappedComponent = PortalWrapper()(Composed)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+})

--- a/src/components/RouteWrapper/index.js
+++ b/src/components/RouteWrapper/index.js
@@ -43,6 +43,15 @@ const RouteWrapper = (WrappedComponent) => {
     start: PropTypes.func,
     to: PropTypes.string
   }
+
+  const componentName = (
+    WrappedComponent.displayName ||
+    WrappedComponent.name ||
+    /* istanbul ignore next */
+    'Component'
+  )
+  Component.displayName = `withRoute(${componentName})`
+
   return Component
 }
 

--- a/src/components/RouteWrapper/tests/RouteWrapper.test.js
+++ b/src/components/RouteWrapper/tests/RouteWrapper.test.js
@@ -69,3 +69,51 @@ describe('Route fetching', () => {
     errorSpy.mockRestore()
   })
 })
+
+describe('displayName', () => {
+  test('Uses a ComposedComponent.name', () => {
+    const Derek = () => (
+      <div />
+    )
+    const WrappedComponent = RouteWrapper(Derek)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+
+  test('Uses a ComposedComponent.displayName', () => {
+    const Composed = () => (
+      <div />
+    )
+    Composed.displayName = 'Derek'
+    const WrappedComponent = RouteWrapper(Composed)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+
+  test('Works with React.Component', () => {
+    class Derek extends React.Component {
+      render () {
+        return (<div />)
+      }
+    }
+    const WrappedComponent = RouteWrapper(Derek)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+
+  test('Works with React.Component.displayName', () => {
+    class Composed extends React.Component {
+      render () {
+        return (<div />)
+      }
+    }
+    Composed.displayName = 'Derek'
+    const WrappedComponent = RouteWrapper(Composed)
+
+    expect(WrappedComponent.displayName).toContain('with')
+    expect(WrappedComponent.displayName).toContain('Derek')
+  })
+})

--- a/src/styles/components/Button.scss
+++ b/src/styles/components/Button.scss
@@ -11,6 +11,47 @@ button.#{$seed-button-namespace} {
 
 .c-Button {
   @import "../configs/color";
+
+  &:before {
+    border-radius: 2px;
+    bottom: 0;
+    content: "";
+    display: none;
+    left: 0;
+    opacity: 0.3;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  &--outline {
+    border-color: currentColor;
+    background-color: transparent;
+    box-shadow: 0 0 0 1px currentColor inset;
+    position: relative;
+    &:hover,
+    &:active,
+    &:focus,
+    &:focus:active {
+      border-color: currentColor;
+      background-color: transparent;
+      box-shadow: 0 0 0 1px currentColor inset;
+    }
+    &:focus,
+    &:focus:active {
+      &:before {
+        box-shadow: 0 0 0 3px currentColor;
+        display: block;
+      }
+    }
+    &:focus:active {
+      &:before {
+        opacity: 0.45;
+      }
+    }
+  }
+
   $themes: (
     editing: (
       _generate-states: false,

--- a/src/styles/configs/_seed-control.scss
+++ b/src/styles/configs/_seed-control.scss
@@ -1,4 +1,9 @@
 $seed-control-sizes: (
+  xs: (
+    font-size: 13px,
+    height: 22px,
+    padding: 0 0.5em,
+  ),
   sm: (
     font-size: 13px,
     height: 32px,

--- a/stories/Button.js
+++ b/stories/Button.js
@@ -11,14 +11,24 @@ stories.add('types', () => (
     <Button>Regular</Button>
     <Button primary>Primary</Button>
     <Button plain>Plain</Button>
+    <Button outline>Outline Button</Button>
   </div>
 ))
 
 stories.add('sizes', () => (
   <div>
-    <Button size='lg'>Large</Button>
-    <Button size='md'>Medium</Button>
-    <Button size='sm'>Small</Button>
+    <div>
+      <Button size='lg'>Large</Button>
+      <Button size='md'>Medium</Button>
+      <Button size='sm'>Small</Button>
+      <Button size='xs'>Extra Small</Button>
+    </div>
+    <div>
+      <Button size='lg' outline>Large</Button>
+      <Button size='md' outline>Medium</Button>
+      <Button size='sm' outline>Small</Button>
+      <Button size='xs' outline>Extra Small</Button>
+    </div>
   </div>
 ))
 
@@ -32,7 +42,7 @@ stories.add('states', () => (
 
 stories.add('disabled', () => (
   <div>
-    <Button disabled>Can't touch this!</Button>
+    <Button disabled>Cant touch this!</Button>
   </div>
 ))
 


### PR DESCRIPTION
## Button: Add XS and Outline styles 🖌 

![screen recording 2018-03-01 at 11 49 am](https://user-images.githubusercontent.com/2322354/36863059-a5ea9842-1d56-11e8-9554-3176e7265390.gif)

This update enhances the Button component styles by adding a new `xs` size,
as well as `outline` styles.

The `outline` style uses `currentColor` for it's coloring, which allows the user to
easily adjust it using inline styles or CSS style rules.

![screen shot 2018-03-01 at 11 55 38 am](https://user-images.githubusercontent.com/2322354/36863064-ab58d136-1d56-11e8-932c-93f2d165560a.jpg)

This update also provides HOC/Wrapper components with updated `displayName`,
following the convention of `withWrapperComponentName(ComposedComponent)`.