### PR TITLE
Smoothscroll and other fixes

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -100,6 +100,8 @@ class Modal extends Component {
   componentDidMount () {
     this.positionCloseNode()
     this.focusModalCard()
+    /* istanbul ignore next */
+    setTimeout(this.positionCloseNode, this.props.modalAnimationDuration)
   }
 
   componentWillUnmount () {

--- a/src/styles/components/Avatar.scss
+++ b/src/styles/components/Avatar.scss
@@ -62,6 +62,9 @@
     color: white;
     line-height: 1;
     text-transform: uppercase;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
   }
 
   &__status {

--- a/src/styles/components/Message/Bubble.scss
+++ b/src/styles/components/Message/Bubble.scss
@@ -21,6 +21,10 @@
   max-width: 500px;
   text-align: left;
 
+  &__body {
+    word-break: break-word;
+  }
+
   &__title {
     margin-bottom: 2px;
   }

--- a/src/utilities/smoothScroll.js
+++ b/src/utilities/smoothScroll.js
@@ -1,6 +1,11 @@
 import { isNodeElement } from './node'
-import { easeInOutCubic } from './easing'
 import { requestAnimationFrame } from './other'
+
+// Source:
+// https://gist.github.com/gre/1650294
+const easeInOutCubic = (t) => {
+  return t < 0.5 ? 4 * t * t * t : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1
+}
 
 // Source
 // https://jsfiddle.net/s61x7c4e/


### PR DESCRIPTION
## Smoothscroll and other fixes 🔌 

This update contains 4 fixes:

1. The `smoothScrollTo` util function works again. It was previously
broken due to the ease function being removed during the Animation rework.
2. `Avatar` names are no longer user-selectable
3. `Message.Bubble` has word-wrap support.
4. `Modal` repositions CloseNode (again) after the animation sequence timing