### PR TITLE
Message: Media and Attachments enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",
       "!src/tests/helpers/**/*.{js,jsx}",
+      "!src/utilities/browser.{js,jsx}",
       "!src/utilities/smoothScroll.{js,jsx}",
       "!src/utilities/index.{js,jsx}",
       "!src/utilities/log.{js,jsx}",

--- a/src/components/Message/Action.js
+++ b/src/components/Message/Action.js
@@ -12,6 +12,7 @@ const Action = (props, context) => {
     children,
     className,
     from,
+    icon,
     ltr,
     rtl,
     to,

--- a/src/components/Message/Attachment.js
+++ b/src/components/Message/Attachment.js
@@ -1,0 +1,78 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Link from '../Link'
+import Text from '../Text'
+import Chat from './Chat'
+import classNames from '../../utilities/classNames'
+import { noop } from '../../utilities/other'
+import { bubbleTypes, providerContextTypes } from './propTypes'
+
+export const propTypes = Object.assign({}, bubbleTypes, {
+  filename: PropTypes.string,
+  download: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  onClick: PropTypes.func
+})
+
+const defaultProps = {
+  download: true,
+  onClick: noop
+}
+
+const contextTypes = providerContextTypes
+
+const Attachment = (props, context) => {
+  const {
+    body,
+    children,
+    className,
+    download,
+    filename,
+    onClick,
+    size,
+    url,
+    type,
+    ...rest
+  } = props
+  const {theme} = context
+
+  const componentClassName = classNames(
+    'c-MessageAttachment',
+    theme && `is-theme-${theme}`,
+    className
+  )
+
+  const title = download ? `Download ${filename}` : null
+
+  const filenameMarkup = url ? (
+    <Link
+      className='c-MessageAttachment__link'
+      download={download}
+      href={url}
+      title={title}
+    >
+      {filename}
+    </Link>
+  ) : (
+    <Text className='c-MessageAttachment__text'>
+      {filename}
+    </Text>
+  )
+
+  return (
+    <Chat
+      {...rest}
+      bubbleClassName='c-MessageMedia__bubble'
+      className={componentClassName}
+      icon='attachment'
+      size='sm'
+    >
+      {filenameMarkup}
+    </Chat>
+  )
+}
+
+Attachment.propTypes = propTypes
+Attachment.defaultProps = defaultProps
+Attachment.contextTypes = contextTypes
+
+export default Attachment

--- a/src/components/Message/Bubble.js
+++ b/src/components/Message/Bubble.js
@@ -1,6 +1,8 @@
 import React from 'react'
+import Flexy from '../Flexy'
 import Heading from '../Heading'
 import LoadingDots from '../LoadingDots'
+import Icon from '../Icon'
 import Text from '../Text'
 import classNames from '../../utilities/classNames'
 import { isWord } from '../../utilities/strings'
@@ -16,6 +18,7 @@ const Bubble = (props, context) => {
     children,
     className,
     from,
+    icon,
     isNote,
     ltr,
     primary,
@@ -69,6 +72,17 @@ const Bubble = (props, context) => {
     </div>
   ) : null
 
+  const iconMarkup = icon ? (
+    <Flexy.Item className='c-MessageBubble__iconWrapper'>
+      <Icon
+        className='c-MessageBubble__icon'
+        name={icon}
+        size='20'
+        shade='extraMuted'
+      />
+    </Flexy.Item>
+  ) : null
+
   const titleMarkup = title ? (
     <Heading className='c-MessageBubble__title' size='small'>
       {title}
@@ -81,11 +95,20 @@ const Bubble = (props, context) => {
       dangerouslySetInnerHTML={{__html: body}}
     />
   ) : childrenMarkup
-  const contentMarkup = typing ? (
+  const innerContentMarkup = typing ? (
     <div className='c-MessageBubble__typing'>
       <LoadingDots />
     </div>
   ) : bodyMarkup
+
+  const contentMarkup = (
+    <Flexy className='c-MessageBubble__content' align='top' gap='xs'>
+      {iconMarkup}
+      <Flexy.Block className='c-MessageBubble__bodyWrapper'>
+        {innerContentMarkup}
+      </Flexy.Block>
+    </Flexy>
+  )
 
   return (
     <div className={componentClassName} {...rest}>

--- a/src/components/Message/Caption.js
+++ b/src/components/Message/Caption.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Text from '../Text'
+import classNames from '../../utilities/classNames'
+import {providerContextTypes} from './propTypes'
+
+const propTypes = {
+  wordWrap: PropTypes.bool
+}
+const defaultProps = {
+  wordWrap: true
+}
+const contextTypes = providerContextTypes
+
+const Caption = (props, context) => {
+  const {
+    className,
+    children,
+    wordWrap,
+    ...rest
+  } = props
+  const {theme} = context
+  const isThemeEmbed = theme === 'embed'
+
+  const componentClassName = classNames(
+    'c-MessageCaption',
+    theme && `is-theme-${theme}`,
+    className
+  )
+
+  const textSize = isThemeEmbed ? '11' : '13'
+
+  return (
+    <div className={componentClassName} {...rest}>
+      <Text
+        className='c-MessageCaption__text'
+        size={textSize}
+        shade='faint'
+        wordWrap={wordWrap}
+      >
+        {children}
+      </Text>
+    </div>
+  )
+}
+
+Caption.propTypes = propTypes
+Caption.defaultProps = defaultProps
+Caption.contextTypes = contextTypes
+Caption.displayName = 'MessageCaption'
+
+export default Caption

--- a/src/components/Message/Chat.js
+++ b/src/components/Message/Chat.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Bubble from './Bubble'
+import Caption from './Caption'
 import ChatBlock from './ChatBlock'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
@@ -9,6 +10,7 @@ import { bubbleTypes } from './propTypes'
 export const propTypes = {
   ...bubbleTypes,
   bubbleClassName: PropTypes.string,
+  caption: PropTypes.string,
   onBubbleClick: PropTypes.func
 }
 
@@ -20,10 +22,12 @@ const Chat = props => {
   const {
     body,
     bubbleClassName,
+    caption,
     children,
     className,
     read,
     from,
+    icon,
     isNote,
     ltr,
     onBubbleClick,
@@ -47,12 +51,17 @@ const Chat = props => {
     body,
     children,
     from,
+    icon,
     ltr,
     rtl,
     timestamp,
     to,
     type
   }
+
+  const captionMarkup = caption ? (
+    <Caption>{caption}</Caption>
+  ) : null
 
   return (
     <ChatBlock
@@ -72,6 +81,7 @@ const Chat = props => {
         typing={typing}
         type={type}
       />
+      {captionMarkup}
     </ChatBlock>
   )
 }

--- a/src/components/Message/ChatBlock.js
+++ b/src/components/Message/ChatBlock.js
@@ -16,6 +16,7 @@ const ChatBlock = (props, context) => {
     body,
     children,
     className,
+    icon,
     ltr,
     rtl,
     read,
@@ -46,8 +47,9 @@ const ChatBlock = (props, context) => {
   ) : null
 
   const childrenMarkup = React.Children.map(children, child => {
-    return (child.type === Action || child.type === Bubble)
+    return (child && (child.type === Action || child.type === Bubble))
       ? React.cloneElement(child, {
+        icon,
         from,
         ltr,
         rtl,

--- a/src/components/Message/Media.js
+++ b/src/components/Message/Media.js
@@ -1,94 +1,109 @@
-import React from 'react'
+import React, {PureComponent as Component} from 'react'
 import PropTypes from 'prop-types'
 import Image from '../Image'
 import Modal from '../Modal'
-import Text from '../Text'
 import Chat from './Chat'
+import Caption from './Caption'
 import classNames from '../../utilities/classNames'
-import { bubbleTypes } from './propTypes'
+import { noop } from '../../utilities/other'
+import { bubbleTypes, providerContextTypes } from './propTypes'
 
 export const propTypes = Object.assign({}, bubbleTypes, {
   caption: PropTypes.string,
-  imageUrl: PropTypes.string
+  imageAlt: PropTypes.string,
+  imageUrl: PropTypes.string,
+  onMediaClick: PropTypes.func,
+  openMediaInModal: PropTypes.bool
 })
 
-const Media = props => {
-  const {
-    body,
-    children,
-    className,
-    caption,
-    from,
-    imageUrl,
-    isNote,
-    ltr,
-    primary,
-    read,
-    rtl,
-    size,
-    timestamp,
-    title,
-    to,
-    type,
-    ...rest
-  } = props
+const defaultProps = {
+  onMediaClick: noop,
+  openMediaInModal: true
+}
 
-  const componentClassName = classNames(
-    'c-MessageMedia',
-    className
-  )
+const contextTypes = providerContextTypes
 
-  const captionMarkup = caption ? (
-    <div className='c-MessageMedia__caption'>
-      <Text muted size='13'>{caption}</Text>
-    </div>
-  ) : null
+class Media extends Component {
+  render () {
+    const {
+      body,
+      children,
+      className,
+      caption,
+      imageUrl,
+      imageAlt,
+      onMediaClick,
+      openMediaInModal,
+      type,
+      ...rest
+    } = this.props
 
-  const mediaMarkup = imageUrl ? (
-    <div className='c-MessageMedia__media'>
-      <Image
-        block
-        className='c-MessageMedia__mediaImage'
-        src={imageUrl}
-        shape='rounded'
-      />
-    </div>
-  ) : null
+    const {theme} = this.context
 
-  const mediaContainerMarkup = imageUrl ? (
-    <div className='c-MessageMedia__media-container'>
-      <Modal trigger={mediaMarkup}>
-        <Modal.Body scrollFade={false} isSeamless>
-          <Modal.Content>
-            {mediaMarkup}
-            {captionMarkup}
-          </Modal.Content>
-        </Modal.Body>
-      </Modal>
-    </div>
-  ) : null
+    const isThemeEmbed = theme === 'embed'
+    const maybeOpenMediaInModal = !isThemeEmbed && openMediaInModal
 
-  return (
-    <Chat
-      className={componentClassName}
-      from={from}
-      isNote={isNote}
-      ltr={ltr}
-      primary={primary}
-      read={read}
-      rtl={rtl}
-      size='sm'
-      timestamp={timestamp}
-      title={title}
-      to={to}
-      {...rest}
-    >
-      {mediaContainerMarkup}
-      {captionMarkup}
-    </Chat>
-  )
+    const componentClassName = classNames(
+      'c-MessageMedia',
+      className
+    )
+
+    const mediaMarkup = imageUrl ? (
+      <div className='c-MessageMedia__media'>
+        <Image
+          alt={imageAlt || null}
+          block
+          className='c-MessageMedia__mediaImage'
+          onClick={onMediaClick}
+          src={imageUrl}
+          title={imageAlt || null}
+          shape='rounded'
+        />
+      </div>
+    ) : null
+
+    const captionMarkup = (!isThemeEmbed && caption) ? (
+      <div className='c-MessageMedia__caption'>
+        <Caption>
+          {caption}
+        </Caption>
+      </div>
+    ) : null
+
+    const mediaContainerMarkup = imageUrl ? maybeOpenMediaInModal ? (
+      <div className='c-MessageMedia__mediaContainer'>
+        <Modal trigger={mediaMarkup}>
+          <Modal.Body scrollFade={false} isSeamless>
+            <Modal.Content>
+              {mediaMarkup}
+              {captionMarkup}
+            </Modal.Content>
+          </Modal.Body>
+        </Modal>
+      </div>
+    ) : (
+      <div className='c-MessageMedia__mediaContainer'>
+        {mediaMarkup}
+      </div>
+    ) : null
+
+    return (
+      <Chat
+        {...rest}
+        bubbleClassName='c-MessageMedia__bubble'
+        caption={isThemeEmbed ? caption : undefined}
+        className={componentClassName}
+        size='sm'
+      >
+        {mediaContainerMarkup}
+        {captionMarkup}
+      </Chat>
+    )
+  }
 }
 
 Media.propTypes = propTypes
+Media.defaultProps = defaultProps
+Media.contextTypes = contextTypes
 
 export default Media

--- a/src/components/Message/Message.js
+++ b/src/components/Message/Message.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types'
 import Flexy from '../Flexy'
 import Text from '../Text'
 import Action from './Action'
+import Attachment from './Attachment'
 import Bubble from './Bubble'
+import Caption from './Caption'
 import Chat from './Chat'
 import Content from './Content'
 import Media from './Media'
@@ -55,7 +57,14 @@ const Message = (props, context) => {
   )
 
   const isChatType = child => {
-    const chatTypes = [Action, Chat, Content, Media, Question]
+    const chatTypes = [
+      Action,
+      Attachment,
+      Chat,
+      Content,
+      Media,
+      Question
+    ]
     return chatTypes.some(type => {
       return typeof child.type === 'function' && child.type === type
     })
@@ -116,7 +125,9 @@ Message.propTypes = propTypes
 Message.defaultProps = defaultProps
 Message.contextTypes = contextTypes
 Message.Action = Action
+Message.Attachment = Attachment
 Message.Bubble = Bubble
+Message.Caption = Caption
 Message.Chat = Chat
 Message.Content = Content
 Message.Media = Media

--- a/src/components/Message/README.md
+++ b/src/components/Message/README.md
@@ -13,7 +13,9 @@ Message components provides the UI to display content within a Chat context.
 Message provides a collection of smaller components:
 
 * [Action](./docs/Action.md)
+* [Attachment](./docs/Attachment.md)
 * [Bubble](./docs/Bubble.md)
+* [Caption](./docs/Caption.md)
 * [Chat](./docs/Chat.md)
 * [ChatBlock](./docs/ChatBlock.md)
 * [Content](./docs/Content.md)

--- a/src/components/Message/docs/Attachment.md
+++ b/src/components/Message/docs/Attachment.md
@@ -1,16 +1,16 @@
-# Media
+# Attachment
 
-A Media component provides the UI to render media-based content within a [Message](./Message.md).
+A Attachment component provides the UI to render caption text within a [Message](./Message.md). This component is typically used within other Message sub-components.
 
 
 ## Example
 
 ```jsx
 <Message from avatar={<Avatar name='Arctic Puffin' />}>
-  <Message.Chat read timestamp='9:41am'>
-    Hey Buddy!
-  </Message.Chat>
-  <Message.Media imageUrl='...' caption='image.jpg' timestamp='9:41am' read />
+  <Message.Attachment
+    filename='image.png'
+    url='https://.../image.png'
+  />
 </Message>
 ```
 
@@ -19,16 +19,15 @@ A Media component provides the UI to render media-based content within a [Messag
 
 | Prop | Type | Description |
 | --- | --- | --- |
-| caption | `string` | Description of the media. |
 | className | `string` | Custom class names to be added to the component. |
+| download | `bool` | Determines if the file can be downloaded on click. Default `true`. |
+| filename | `string` | The name of the file. |
 | from | `node`/`bool` | Provides author information and applies "From" styles. |
-| imageAlt | `string` | Alt/title of the media image. |
-| imageUrl | `string` | URL of the media image. |
-| onMediaClick | `func` | Callback when the media image is clicked. |
-| openMediaInModal | `bool` | Opens the media image in a Modal when clicked. Default `true`. |
+| onClick | `func` | Callback when the file is clicked. |
 | ltr | `bool` | Applies left-to-right text styles. |
 | ltr | `bool` | Applies left-to-right text styles. |
 | read | `bool` | Determines if the Message is read. |
 | rtl | `bool` | Applies right-to-left text styles. |
 | timestamp | `string` | Timestamp for the Message. |
 | to | `node`/`bool` | Provides author information and applies "To" styles. |
+| url | `string` | The URL of the file. |

--- a/src/components/Message/docs/Caption.md
+++ b/src/components/Message/docs/Caption.md
@@ -1,0 +1,20 @@
+# Caption
+
+A Caption component provides the UI to render caption text within a [Message](./Message.md). This component is typically used within other Message sub-components.
+
+
+## Example
+
+```jsx
+<Message.Caption>
+  Captions
+</Message.Caption>
+```
+
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| className | `string` | Custom class names to be added to the component. |
+| wordWrap | `bool` | Breaks longer text content. Default `true`. |

--- a/src/components/Message/docs/Chat.md
+++ b/src/components/Message/docs/Chat.md
@@ -25,10 +25,12 @@ A Chat component provides the UI for the primary content within a [Message](./Me
 | Prop | Type | Description |
 | --- | --- | --- |
 | bubbleClassName | `string` | Custom class names for the child [Bubble](./Bubble.md) component. |
+| caption | `string` | Renders a [Caption](./Caption.md). |
 | className | `string` | Custom class names to be added to the component. |
 | from | `node`/`bool` | Provides author information and applies "From" styles. |
 | isNote | `bool` | Applies "note" styles. |
 | ltr | `bool` | Applies left-to-right text styles. |
+| onBubbleClick | `func` | Callback when the Bubble is clicked. |
 | primary | `bool` | Applies "primary" styles. |
 | read | `bool` | Determines if the Message is read. |
 | rtl | `bool` | Applies right-to-left text styles. |

--- a/src/components/Message/propTypes.js
+++ b/src/components/Message/propTypes.js
@@ -32,6 +32,7 @@ export const chatTypes = Object.assign({}, messageTypes, {
 
 export const bubbleTypes = Object.assign({}, chatTypes, {
   body: PropTypes.string,
+  icon: PropTypes.string,
   isNote: PropTypes.bool,
   primary: PropTypes.bool,
   title: PropTypes.string,

--- a/src/components/Message/tests/Attachment.test.js
+++ b/src/components/Message/tests/Attachment.test.js
@@ -1,0 +1,86 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Attachment from '../Attachment'
+
+const cx = 'c-MessageAttachment'
+
+const ui = {
+  link: `.${cx}__link`,
+  text: `.${cx}__text`
+}
+
+describe('ClassNames', () => {
+  test('Has default className', () => {
+    const wrapper = shallow(<Attachment />)
+    const o = wrapper.find(`.${cx}`)
+
+    expect(o.length).toBeTruthy()
+  })
+
+  test('Accepts custom classNames', () => {
+    const wrapper = shallow(<Attachment className='mugatu' />)
+    const o = wrapper.find(`.${cx}`)
+
+    expect(o.hasClass('mugatu')).toBeTruthy()
+  })
+})
+
+describe('Context', () => {
+  test('Adds className based on context.theme', () => {
+    const wrapper = shallow(
+      <Attachment />
+    , {context: {theme: 'embed'}})
+
+    expect(wrapper.hasClass('is-theme-embed')).toBe(true)
+  })
+})
+
+describe('Content', () => {
+  test('Renders content within Text, if url not defined', () => {
+    const wrapper = shallow(<Attachment filename='file.png' />)
+    const t = wrapper.find(ui.text)
+    const l = wrapper.find(ui.link)
+
+    expect(t.length).toBeTruthy()
+    expect(t.html()).toContain('file.png')
+    expect(l.length).not.toBeTruthy()
+  })
+
+  test('Renders content within Link, if url is defined', () => {
+    const wrapper = shallow(<Attachment filename='file.png' url='url' />)
+    const t = wrapper.find(ui.text)
+    const l = wrapper.find(ui.link)
+
+    expect(t.length).not.toBeTruthy()
+    expect(l.length).toBeTruthy()
+    expect(l.html()).toContain('file.png')
+  })
+})
+
+describe('Download', () => {
+  test('Provides download functionality, by default', () => {
+    const wrapper = shallow(<Attachment filename='file.png' url='url' />)
+    const o = wrapper.find(ui.link)
+
+    expect(o.prop('download')).toBeTruthy()
+    expect(o.html()).toContain('download')
+  })
+
+  test('Download can be disabled', () => {
+    const wrapper = shallow(
+      <Attachment filename='file.png' url='url' download={false} />
+    )
+    const o = wrapper.find(ui.link)
+
+    expect(o.prop('download')).not.toBeTruthy()
+    expect(o.html()).not.toContain('download')
+  })
+
+  test('Provides download link with title', () => {
+    const wrapper = shallow(<Attachment filename='file.png' url='url' />)
+    const o = wrapper.find(ui.link)
+
+    expect(o.prop('title')).toBeTruthy()
+    expect(o.prop('title')).toContain('file.png')
+  })
+})

--- a/src/components/Message/tests/Bubble.test.js
+++ b/src/components/Message/tests/Bubble.test.js
@@ -11,7 +11,10 @@ const baseComponentOptions = {
 }
 const ui = {
   body: `.${cx}__body`,
-  from: `.${cx}__from`
+  bodyWrapper: `.${cx}__bodyWrapper`,
+  from: `.${cx}__from`,
+  iconWrapper: `.${cx}__iconWrapper`,
+  icon: `.${cx}__icon`
 }
 
 baseComponentTest(Bubble, baseComponentOptions)
@@ -235,5 +238,30 @@ describe('From', () => {
 
     expect(o.length).toBe(1)
     expect(o.html()).toContain('Mugatu')
+  })
+})
+
+describe('Icon', () => {
+  test('Does not render an icon by default', () => {
+    const wrapper = mount(
+      <Bubble body='derek' />
+    )
+    const o = wrapper.find(ui.icon)
+    const w = wrapper.find(ui.iconWrapper)
+
+    expect(o.length).toBe(0)
+    expect(w.length).toBe(0)
+  })
+
+  test('Renders an icon, if specified', () => {
+    const wrapper = shallow(
+      <Bubble body='derek' icon='attachment' />
+    )
+    const o = wrapper.find(ui.icon)
+    const w = wrapper.find(ui.iconWrapper)
+
+    expect(o.length).toBe(1)
+    expect(w.length).toBe(1)
+    expect(o.prop('name')).toBe('attachment')
   })
 })

--- a/src/components/Message/tests/Caption.test.js
+++ b/src/components/Message/tests/Caption.test.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Caption from '../Caption'
+
+const cx = 'c-MessageCaption'
+
+const ui = {
+  text: `.${cx}__text`
+}
+
+describe('ClassNames', () => {
+  test('Has default className', () => {
+    const wrapper = shallow(<Caption />)
+    const o = wrapper.find(`.${cx}`)
+
+    expect(o.length).toBeTruthy()
+  })
+
+  test('Accepts custom classNames', () => {
+    const wrapper = shallow(<Caption className='mugatu' />)
+    const o = wrapper.find(`.${cx}`)
+
+    expect(o.hasClass('mugatu')).toBeTruthy()
+  })
+})
+
+describe('Context', () => {
+  test('Adds className based on context.theme', () => {
+    const wrapper = shallow(
+      <Caption />
+    , {context: {theme: 'embed'}})
+
+    expect(wrapper.hasClass('is-theme-embed')).toBe(true)
+  })
+})
+
+describe('Text', () => {
+  test('Does not have reduced text size by default', () => {
+    const wrapper = shallow(<Caption>hello</Caption>)
+    const o = wrapper.find(ui.text)
+
+    expect(o.prop('size')).toBe('13')
+  })
+
+  test('Reduces text size for embed themed Captions', () => {
+    const wrapper = shallow(
+      <Caption>hello</Caption>
+    , {context: {theme: 'embed'}})
+    const o = wrapper.find(ui.text)
+
+    expect(o.prop('size')).toBe('11')
+  })
+
+  test('Applies wordWrap by default', () => {
+    const wrapper = shallow(
+      <Caption>hello</Caption>
+    , {context: {theme: 'embed'}})
+    const o = wrapper.find(ui.text)
+
+    expect(o.prop('wordWrap')).toBe(true)
+  })
+
+  test('wordWrap can be disabled', () => {
+    const wrapper = shallow(
+      <Caption wordWrap={false}>hello</Caption>
+    , {context: {theme: 'embed'}})
+    const o = wrapper.find(ui.text)
+
+    expect(o.prop('wordWrap')).toBe(false)
+  })
+})

--- a/src/components/Message/tests/Chat.test.js
+++ b/src/components/Message/tests/Chat.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme'
 import Bubble from '../Bubble'
 import ChatBlock from '../ChatBlock'
 import Chat from '../Chat'
+import Caption from '../Caption'
 
 const cx = 'c-MessageChat'
 
@@ -106,5 +107,22 @@ describe('ChatBlock', () => {
     expect(props.ltr).toBeTruthy()
     expect(props.rtl).toBeTruthy()
     expect(props.timestamp).toBeTruthy()
+  })
+})
+
+describe('Caption', () => {
+  test('Does not render a Caption by default', () => {
+    const wrapper = shallow(<Chat />)
+    const o = wrapper.find(Caption)
+
+    expect(o.length).not.toBeTruthy()
+  })
+
+  test('Renders a caption, if one is provided', () => {
+    const wrapper = shallow(<Chat caption='Derek' />)
+    const o = wrapper.find(Caption)
+
+    expect(o.length).toBeTruthy()
+    expect(o.prop('children')).toBe('Derek')
   })
 })

--- a/src/components/Message/tests/Media.test.js
+++ b/src/components/Message/tests/Media.test.js
@@ -1,10 +1,15 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import Chat from '../Chat'
 import Media from '../Media'
+import Message from '../Message'
 import { Image, Modal, Text } from '../../'
 
 const cx = 'c-MessageMedia'
+const ui = {
+  caption: `.${cx}__caption`,
+  mediaContainer: `.${cx}__mediaContainer`
+}
 
 describe('ClassNames', () => {
   test('Has default className', () => {
@@ -67,18 +72,41 @@ describe('Chat', () => {
 
 describe('Caption', () => {
   test('Does not render a caption by default', () => {
-    const wrapper = shallow(<Media />)
-    const o = wrapper.find(`.${cx}__caption`)
+    const wrapper = mount(<Media />)
+    const o = wrapper.find(ui.caption)
 
     expect(o.length).not.toBeTruthy()
   })
 
   test('Renders a caption, if defined', () => {
-    const wrapper = shallow(<Media caption='mugatu' />)
-    const o = wrapper.find(`.${cx}__caption`)
+    const wrapper = mount(<Media caption='mugatu' />)
+    const o = wrapper.find(ui.caption)
 
     expect(o.length).toBeTruthy()
     expect(o.find(Text).length).toBeTruthy()
+  })
+
+  test('Does not render caption, if theme is embed', () => {
+    const wrapper = mount(
+      <Message.Provider theme='embed'>
+        <Media caption='mugatu' />
+      </Message.Provider>
+    )
+    const o = wrapper.find(ui.caption)
+
+    expect(o.length).not.toBeTruthy()
+  })
+
+  test('Passes caption to Chat component, if theme is embed', () => {
+    const wrapper = mount(
+      <Message.Provider theme='embed'>
+        <Media caption='mugatu' />
+      </Message.Provider>
+    )
+    const o = wrapper.find(Chat)
+
+    expect(o.length).toBeTruthy()
+    expect(o.prop('caption')).toBe('mugatu')
   })
 })
 
@@ -107,6 +135,69 @@ describe('Image', () => {
     const o = m.find(Image)
 
     expect(m.length).toBeTruthy()
+    expect(o.length).toBeTruthy()
+  })
+
+  test('onMediaClick callback is fired when image is clicked', () => {
+    const spy = jest.fn()
+    const url = './mugatu.png'
+    const wrapper = shallow(<Media imageUrl={url} onMediaClick={spy} />)
+    const o = wrapper.find(Image)
+
+    o.simulate('click')
+
+    expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('Modal', () => {
+  test('Media renders into a modal by default', () => {
+    const url = './mugatu.png'
+    const wrapper = shallow(<Media imageUrl={url} />)
+    const c = wrapper.find(ui.mediaContainer)
+    const m = c.find(Modal)
+    const o = m.find(Image)
+
+    expect(m.length).toBeTruthy()
+    expect(o.length).toBeTruthy()
+  })
+
+  test('Does not render if imageUrl is not defined', () => {
+    const wrapper = shallow(<Media />)
+    const c = wrapper.find(ui.mediaContainer)
+    const m = wrapper.find(Modal)
+
+    expect(c.length).not.toBeTruthy()
+    expect(m.length).not.toBeTruthy()
+  })
+
+  test('Media does not render into a Modal, if specified', () => {
+    const url = './mugatu.png'
+    const wrapper = shallow(
+      <Media imageUrl={url} openMediaInModal={false} />
+    )
+    const c = wrapper.find(ui.mediaContainer)
+    const m = c.find(Modal)
+    const o = c.find(Image)
+
+    expect(c.length).toBeTruthy()
+    expect(m.length).not.toBeTruthy()
+    expect(o.length).toBeTruthy()
+  })
+
+  test('Modal does not render, if theme is embed, even if specified', () => {
+    const url = './mugatu.png'
+    const wrapper = mount(
+      <Message.Provider theme='embed'>
+        <Media imageUrl={url} openMediaInModal />
+      </Message.Provider>
+    )
+    const c = wrapper.find(ui.mediaContainer)
+    const m = c.find(Modal)
+    const o = c.find(Image)
+
+    expect(c.length).toBeTruthy()
+    expect(m.length).not.toBeTruthy()
     expect(o.length).toBeTruthy()
   })
 })

--- a/src/styles/components/Image.scss
+++ b/src/styles/components/Image.scss
@@ -9,6 +9,6 @@
   }
 
   &.is-rounded {
-    border-radius: 2px;
+    border-radius: 4px;
   }
 }

--- a/src/styles/components/Message/Bubble.scss
+++ b/src/styles/components/Message/Bubble.scss
@@ -100,5 +100,6 @@
   // Themes
   &.is-theme-embed {
     padding: 12px 15px;
+    max-width: 100%;
   }
 }

--- a/src/styles/components/Message/Media.scss
+++ b/src/styles/components/Message/Media.scss
@@ -3,16 +3,44 @@
 .c-MessageMedia {
   @import "../../resets/base";
   $block: this();
+  margin-bottom: 10px;
+  margin-top: 10px;
 
   &__caption {
     padding: 8px;
   }
 
-  &__media-container {
+  &__mediaContainer {
     padding-bottom: 4px;
 
     #{$block}__media {
       cursor: pointer;
+    }
+  }
+
+  // Themes
+  &.is-theme-embed {
+    #{$block}__bubble {
+      background-color: white;
+      border: none;
+      border-radius: 8px !important;
+      box-shadow: #{
+        0 0 0 1px rgba(black, 0.16) inset,
+        0 2px 3px rgba(black, 0.08),
+        };
+      padding: 3px;
+      transition: all 200ms linear;
+
+      &:hover {
+        box-shadow: #{
+          0 0 0 1px rgba(black, 0.216) inset,
+          0 3px 12px rgba(black, 0.08),
+          };
+      }
+    }
+
+    #{$block}__mediaContainer {
+      padding-bottom: 0;
     }
   }
 }

--- a/src/utilities/browser.js
+++ b/src/utilities/browser.js
@@ -2,12 +2,11 @@
 // Can't write tests for this in JSDOM.
 // Can't create fixture for JSDOM's built-in Navigator instance.
 export const isBrowser = (browser) => {
-  /* istanbul ignore next */
   if (!navigator) return false
   return (navigator.userAgent.toLowerCase().indexOf(browser) > -1)
 }
 
-export const isEdge = /* istanbul ignore next */ () => isBrowser('edge')
-export const isChrome = /* istanbul ignore next */ () => isBrowser('chrome')
-export const isFirefox = /* istanbul ignore next */ () => isBrowser('firefox')
-export const isSafari = /* istanbul ignore next */ () => isBrowser('safari')
+export const isEdge = () => isBrowser('edge')
+export const isChrome = () => isBrowser('chrome')
+export const isFirefox = () => isBrowser('firefox')
+export const isSafari = () => isBrowser('safari')

--- a/src/utilities/types.js
+++ b/src/utilities/types.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export const isComponentOneOfType = (component, types) => {
-  if (!Array.isArray(types) && typeof types !== 'string') return false
+  if (!component || (!Array.isArray(types) && typeof types !== 'string')) return false
   const isArray = Array.isArray(types)
 
   return (

--- a/stories/EmbedChat/index.js
+++ b/stories/EmbedChat/index.js
@@ -28,6 +28,10 @@ stories.add('default', () => {
           <Message.Chat>
             Can I get an extension?
           </Message.Chat>
+          <Message.Media imageUrl='https://img.buzzfeed.com/buzzfeed-static/static/2014-12/5/11/enhanced/webdr06/longform-original-7538-1417798667-22.jpg?downsize=715:*&output-format=auto&output-quality=auto' caption='image.jpg' />
+          <Message.Chat>
+            Can I get an extension?
+          </Message.Chat>
         </Message>
 
         <Message>
@@ -51,6 +55,10 @@ stories.add('default', () => {
           <Message.Chat>
             Yeah of course! I've gone and added that to your account.
           </Message.Chat>
+          <Message.Attachment
+            filename='puffin.png'
+            url='https://img.buzzfeed.com/buzzfeed-static/static/2014-12/5/11/enhanced/webdr06/longform-original-7538-1417798667-22.jpg?downsize=715:*&output-format=auto&output-quality=auto'
+          />
         </Message>
       </Message.Provider>
     </div>

--- a/stories/Message.js
+++ b/stories/Message.js
@@ -139,12 +139,18 @@ stories.add('content', () => (
 ))
 
 stories.add('media', () => (
-  <Message from avatar={<Avatar name='Arctic Puffin' />}>
-    <Message.Chat read timestamp='9:41am'>
-      Hey Buddy!
-    </Message.Chat>
-    <Message.Media imageUrl='https://img.buzzfeed.com/buzzfeed-static/static/2014-12/5/11/enhanced/webdr06/longform-original-7538-1417798667-22.jpg?downsize=715:*&output-format=auto&output-quality=auto' caption='image.jpg' timestamp='9:41am' read />
-  </Message>
+  <Message.Provider theme='embed'>
+    <Message from avatar={<Avatar name='Arctic Puffin' />}>
+      <Message.Chat>
+        Hey Buddy!
+      </Message.Chat>
+      <Message.Media imageUrl='https://img.buzzfeed.com/buzzfeed-static/static/2014-12/5/11/enhanced/webdr06/longform-original-7538-1417798667-22.jpg?downsize=715:*&output-format=auto&output-quality=auto' caption='image.jpg' />
+    </Message>
+
+    <Message to avatar={<Avatar name='Arctic Puffin' />}>
+      <Message.Media imageUrl='https://img.buzzfeed.com/buzzfeed-static/static/2014-12/5/11/enhanced/webdr06/longform-original-7538-1417798667-22.jpg?downsize=715:*&output-format=auto&output-quality=auto' caption='image.jpg' />
+    </Message>
+  </Message.Provider>
 ))
 
 stories.add('note', () => (


### PR DESCRIPTION
## Message: Media and Attachments enhancements 🖇 

![screen shot 2018-03-15 at 1 16 32 pm](https://user-images.githubusercontent.com/2322354/37480188-f791a3d0-2854-11e8-9499-da4f154ae32c.jpg)

This update enhances the `Message.Media` sub-component, as well as adds
a new `Message.Attachment` sub-component.

`Message.Media` had some UI adjustments as well as added flexibility.
You can now choose whether clicking the media image will automatically
open a Modal preview, as well as tap into an `onClick` callback.

`Message.Attachment` was added to better handle file attachments within
a Chat context.

Related Message sub-components, like `Message.Chat`, were adjusted to
faciliate these changes.