### PR TITLE
Make LineItems support dangerously-set HTML `body`s

### DIFF
--- a/src/components/ChatTranscript/LineItem.js
+++ b/src/components/ChatTranscript/LineItem.js
@@ -43,7 +43,7 @@ const LineItem = props => {
     </span>
   ) : null
 
-  const contentMarkup = body || children
+  const contentMarkup = (<span dangerouslySetInnerHTML={{__html: body}} />) || children
 
   return (
     <div className={componentClassName} {...rest}>

--- a/src/components/ChatTranscript/LineItem.js
+++ b/src/components/ChatTranscript/LineItem.js
@@ -43,7 +43,7 @@ const LineItem = props => {
     </span>
   ) : null
 
-  const contentMarkup = (<span dangerouslySetInnerHTML={{__html: body}} />) || children
+  const contentMarkup = body ? (<span dangerouslySetInnerHTML={{__html: body}} />) : children
 
   return (
     <div className={componentClassName} {...rest}>

--- a/src/components/ChatTranscript/tests/LineItem.test.js
+++ b/src/components/ChatTranscript/tests/LineItem.test.js
@@ -30,6 +30,12 @@ describe('Children', () => {
 
     expect(el.text()).toContain('Hello')
   })
+
+  test('Renders dangerously-set body HTML', () => {
+    const body = '<h1 class="dangerous">Dangerous!</h1>'
+    const wrapper = mount(<LineItem body={body} />)
+    expect(wrapper.html()).toContain(body)
+  })
 })
 
 describe('CreatedAt', () => {


### PR DESCRIPTION
ChatTranscript `LineItem` bodies contain HTML. This PR makes the `LineItem` support dangerously-set HTML in the `body`.  