### PR TITLE
Inline: Fix right margins

### DIFF
--- a/src/styles/components/Inline/Inline.scss
+++ b/src/styles/components/Inline/Inline.scss
@@ -28,7 +28,6 @@
   @each $size, $value in $spacing {
     &.is-#{$size} {
       margin-bottom: -($value);
-      margin-right: -($value);
 
       &:last-child {
         margin-bottom: -($value);


### PR DESCRIPTION
## Inline: Fix right margins 🤜 

This update removes the right negative margins from the `Inline` component,
which appeared to be causing issues for certain use-cases.

Thanks to @brettjonesdev for spotting this one!