### PR TITLE
Message:Attachment - No URL styles

### DIFF
--- a/src/components/Message/Attachment.js
+++ b/src/components/Message/Attachment.js
@@ -48,8 +48,13 @@ const Attachment = (props, context) => {
 
   const componentClassName = classNames(
     'c-MessageAttachment',
+    !url && 'has-noUrl',
     theme && `is-theme-${theme}`,
     className
+  )
+  const textClassName = classNames(
+    'c-MessageAttachment__text',
+    !url && 'has-noUrl'
   )
 
   const title = download ? `Download ${filename}` : null
@@ -64,7 +69,7 @@ const Attachment = (props, context) => {
       {filename}
     </Link>
   ) : (
-    <Text className='c-MessageAttachment__text'>
+    <Text className={textClassName}>
       {filename}
     </Text>
   )

--- a/src/components/Message/tests/Attachment.test.js
+++ b/src/components/Message/tests/Attachment.test.js
@@ -56,6 +56,14 @@ describe('Content', () => {
     expect(l.length).toBeTruthy()
     expect(l.html()).toContain('file.png')
   })
+
+  test('Renders text with has-noUrl styles, if url is not defined', () => {
+    const wrapper = shallow(<Attachment filename='file.png' />)
+    const t = wrapper.find(ui.text)
+
+    expect(wrapper.hasClass('has-noUrl')).toBeTruthy()
+    expect(t.hasClass('has-noUrl')).toBeTruthy()
+  })
 })
 
 describe('Download', () => {

--- a/src/styles/components/Message/Attachment.scss
+++ b/src/styles/components/Message/Attachment.scss
@@ -1,0 +1,9 @@
+.c-MessageAttachment {
+  @import "../../resets/base";
+
+  &__text {
+    &.has-noUrl {
+      opacity: 0.4;
+    }
+  }
+}

--- a/src/styles/components/Message/__index.scss
+++ b/src/styles/components/Message/__index.scss
@@ -1,4 +1,5 @@
 @import "./Action";
+@import "./Attachment";
 @import "./Bubble";
 @import "./Chat";
 @import "./ChatBlock";

--- a/stories/Message/attachment.js
+++ b/stories/Message/attachment.js
@@ -31,6 +31,9 @@ stories.add('states', () => (
         isUploading
         url={imageUrl}
       />
+      <Message.Attachment
+        filename='no-url.png'
+      />
     </Message>
   </Message.Provider>
 ))


### PR DESCRIPTION
## Message:Attachment - No URL styles

![screen shot 2018-03-28 at 2 29 38 pm](https://user-images.githubusercontent.com/2322354/38048865-ab5c5ac4-3294-11e8-9d23-8545e1fe499d.jpg)


This update enhances the `Message.Attachment` component to render a muted
style if a `url` prop is not provided.