### PR TITLE
Message.Attachment: Truncate filenames

### DIFF
--- a/src/components/Message/Attachment.js
+++ b/src/components/Message/Attachment.js
@@ -66,10 +66,12 @@ const Attachment = (props, context) => {
       href={url}
       title={title}
     >
-      {filename}
+      <Text truncate className='c-MessageAttachment__linkText'>
+        {filename}
+      </Text>
     </Link>
   ) : (
-    <Text className={textClassName}>
+    <Text className={textClassName} truncate>
       {filename}
     </Text>
   )

--- a/src/components/Message/tests/Attachment.test.js
+++ b/src/components/Message/tests/Attachment.test.js
@@ -7,6 +7,7 @@ const cx = 'c-MessageAttachment'
 
 const ui = {
   link: `.${cx}__link`,
+  linkText: `.${cx}__linkText`,
   text: `.${cx}__text`
 }
 
@@ -57,12 +58,27 @@ describe('Content', () => {
     expect(l.html()).toContain('file.png')
   })
 
+  test('Renders truncated text within link', () => {
+    const wrapper = shallow(<Attachment filename='file.png' url='url' />)
+    const t = wrapper.find(ui.linkText)
+
+    expect(t.html()).toContain('file.png')
+    expect(t.prop('truncate')).toEqual(true)
+  })
+
   test('Renders text with has-noUrl styles, if url is not defined', () => {
     const wrapper = shallow(<Attachment filename='file.png' />)
     const t = wrapper.find(ui.text)
 
     expect(wrapper.hasClass('has-noUrl')).toBeTruthy()
     expect(t.hasClass('has-noUrl')).toBeTruthy()
+  })
+
+  test('Renders truncated text within non-link', () => {
+    const wrapper = shallow(<Attachment filename='file.png' />)
+    const t = wrapper.find(ui.text)
+
+    expect(t.prop('truncate')).toEqual(true)
   })
 })
 


### PR DESCRIPTION
## Message.Attachment: Truncate filenames

![screen shot 2018-04-05 at 10 09 22 am](https://user-images.githubusercontent.com/2322354/38371012-74010162-38b9-11e8-8f14-6ebc2b236b1b.jpg)


This update fixes the filename rendering within the `<Message.Attachment>`
component to truncate the text, via the `truncate` prop made available
by an inner `<Text>` component.