### PR TITLE
Message: Media - Provide an `onLoad` callback

### DIFF
--- a/src/components/Message/Media.js
+++ b/src/components/Message/Media.js
@@ -19,11 +19,13 @@ export const propTypes = Object.assign({}, bubbleTypes, {
   imageUrl: PropTypes.string,
   isUploading: PropTypes.bool,
   onMediaClick: PropTypes.func,
+  onMediaLoad: PropTypes.func,
   openMediaInModal: PropTypes.bool
 })
 
 const defaultProps = {
   onMediaClick: noop,
+  onMediaLoad: noop,
   openMediaInModal: true,
   isUploading: false
 }
@@ -41,6 +43,7 @@ class Media extends Component {
       imageAlt,
       isUploading,
       onMediaClick,
+      onMediaLoad,
       openMediaInModal,
       type,
       ...rest
@@ -63,6 +66,7 @@ class Media extends Component {
           block
           className='c-MessageMedia__mediaImage'
           onClick={onMediaClick}
+          onLoad={onMediaLoad}
           src={imageUrl}
           title={imageAlt || null}
           shape='rounded'

--- a/src/components/Message/docs/Media.md
+++ b/src/components/Message/docs/Media.md
@@ -27,8 +27,8 @@ A Media component provides the UI to render media-based content within a [Messag
 | imageAlt | `string` | Alt/title of the media image. |
 | imageUrl | `string` | URL of the media image. |
 | isUploading | `bool` | Renders the uploading spinner UI. Default `false`. |
-
 | onMediaClick | `func` | Callback when the media image is clicked. |
+| onMediaLoad | `func` | Callback when the media image is loaded. |
 | openMediaInModal | `bool` | Opens the media image in a Modal when clicked. Default `true`. |
 | ltr | `bool` | Applies left-to-right text styles. |
 | ltr | `bool` | Applies left-to-right text styles. |

--- a/src/components/Message/tests/Media.test.js
+++ b/src/components/Message/tests/Media.test.js
@@ -148,6 +148,17 @@ describe('Image', () => {
 
     expect(spy).toHaveBeenCalled()
   })
+
+  test('onMediaLoad callback is fired when image is loaded', () => {
+    const spy = jest.fn()
+    const url = './mugatu.png'
+    const wrapper = shallow(<Media imageUrl={url} onMediaLoad={spy} />)
+    const o = wrapper.find(Image)
+
+    o.simulate('load')
+
+    expect(spy).toHaveBeenCalled()
+  })
 })
 
 describe('Modal', () => {

--- a/stories/Message/media.js
+++ b/stories/Message/media.js
@@ -4,6 +4,7 @@ import { Avatar, Message } from '../../src/index.js'
 
 const stories = storiesOf('Message/Media', module)
 const imageUrl = 'https://img.buzzfeed.com/buzzfeed-static/static/2014-12/5/11/enhanced/webdr06/longform-original-7538-1417798667-22.jpg?downsize=715:*&output-format=auto&output-quality=auto'
+const onMediaLoad = (event) => console.log(event.target)
 
 stories.add('default', () => (
   <Message.Provider theme='embed'>
@@ -11,7 +12,7 @@ stories.add('default', () => (
       <Message.Chat>
         Hey Buddy!
       </Message.Chat>
-      <Message.Media imageUrl={imageUrl} caption='image.jpg' />
+      <Message.Media imageUrl={imageUrl} caption='image.jpg' onMediaLoad={onMediaLoad} />
     </Message>
 
     <Message to avatar={<Avatar name='Arctic Puffin' />}>


### PR DESCRIPTION
This update enhances `Message.Media` to provide an `onLoad` callback when
the internal `<Image>` is loaded.