### PR TITLE
Message: Attachment - Allow onClick callback

### DIFF
--- a/src/components/Message/Attachment.js
+++ b/src/components/Message/Attachment.js
@@ -64,6 +64,7 @@ const Attachment = (props, context) => {
       className='c-MessageAttachment__link'
       download={download}
       href={url}
+      onClick={onClick}
       title={title}
     >
       <Text truncate className='c-MessageAttachment__linkText'>

--- a/src/components/Message/tests/Attachment.test.js
+++ b/src/components/Message/tests/Attachment.test.js
@@ -110,6 +110,30 @@ describe('Download', () => {
   })
 })
 
+describe('onClick', () => {
+  test('Callback fires when link is clicked', () => {
+    const spy = jest.fn()
+    const wrapper = shallow(
+      <Attachment filename='file.png' url='url' onClick={spy} />
+    )
+    const o = wrapper.find(ui.link)
+    o.simulate('click')
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('Callback is not passed to text (non-link)', () => {
+    const spy = jest.fn()
+    const wrapper = shallow(
+      <Attachment filename='file.png' onClick={spy} />
+    )
+    const o = wrapper.find(ui.text)
+    o.simulate('click')
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+})
+
 describe('Uploading', () => {
   test('Does not render uploading spinner by default', () => {
     const wrapper = shallow(


### PR DESCRIPTION
## Message: Attachment - Allow onClick callback

This update fixes the `Message.Attachment` to allow for an `onClick` callback
when the attachment link is clicked.