### PR TITLE
Message.Attachment: Open downloadable links in new tab

### DIFF
--- a/src/components/Message/Attachment.js
+++ b/src/components/Message/Attachment.js
@@ -17,12 +17,14 @@ export const propTypes = Object.assign({}, bubbleTypes, {
   download: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   isUploading: PropTypes.bool,
   onClick: PropTypes.func,
+  openDownloadInNewTab: PropTypes.bool,
   uploadingMessage: PropTypes.string
 })
 
 const defaultProps = {
   download: true,
   onClick: noop,
+  openDownloadInNewTab: true,
   isUploading: false,
   uploadingMessage: 'Uploading…'
 }
@@ -38,6 +40,7 @@ const Attachment = (props, context) => {
     filename,
     isUploading,
     onClick,
+    openDownloadInNewTab,
     size,
     uploadingMessage,
     url,
@@ -64,6 +67,7 @@ const Attachment = (props, context) => {
       className='c-MessageAttachment__link'
       download={download}
       href={url}
+      target={openDownloadInNewTab ? '_blank' : null}
       title={title}
     >
       <Text truncate className='c-MessageAttachment__linkText'>

--- a/src/components/Message/docs/Attachment.md
+++ b/src/components/Message/docs/Attachment.md
@@ -25,13 +25,14 @@ An Attachment component provides the UI to render caption text within a [Message
 | errorMessage | `string` | Customizes the error caption. |
 | filename | `string` | The name of the file. |
 | from | `node`/`bool` | Provides author information and applies "From" styles. |
-| onClick | `func` | Callback when the file is clicked. |
 | isUploading | `bool` | Renders the uploading spinner UI. Default `false`. |
-| uploadingMessage | `string` | Customizes the uploading message text. |
 | ltr | `bool` | Applies left-to-right text styles. |
 | ltr | `bool` | Applies left-to-right text styles. |
+| onClick | `func` | Callback when the file is clicked. |
+| openDownloadInNewTab | `bool` | Opens downloadable links in new tab. Default `true`. |
 | read | `bool` | Determines if the Message is read. |
 | rtl | `bool` | Applies right-to-left text styles. |
 | timestamp | `string` | Timestamp for the Message. |
 | to | `node`/`bool` | Provides author information and applies "To" styles. |
+| uploadingMessage | `string` | Customizes the uploading message text. |
 | url | `string` | The URL of the file. |

--- a/src/components/Message/tests/Attachment.test.js
+++ b/src/components/Message/tests/Attachment.test.js
@@ -108,6 +108,30 @@ describe('Download', () => {
     expect(o.prop('title')).toBeTruthy()
     expect(o.prop('title')).toContain('file.png')
   })
+
+  test('Provides download link with title', () => {
+    const wrapper = shallow(<Attachment filename='file.png' url='url' />)
+    const o = wrapper.find(ui.link)
+
+    expect(o.prop('title')).toBeTruthy()
+    expect(o.prop('title')).toContain('file.png')
+  })
+
+  test('Links should open in new tab, by default', () => {
+    const wrapper = shallow(<Attachment filename='file.png' url='url' />)
+    const o = wrapper.find(ui.link)
+
+    expect(o.prop('target')).toBe('_blank')
+  })
+
+  test('Links should not open in new tab, if specified', () => {
+    const wrapper = shallow(
+      <Attachment filename='file.png' url='url' openDownloadInNewTab={false} />
+    )
+    const o = wrapper.find(ui.link)
+
+    expect(o.prop('target')).not.toBe('_blank')
+  })
 })
 
 describe('Uploading', () => {


### PR DESCRIPTION
## Message.Attachment: Open downloadable links in new tab ⬇️ 

This update enhances the `Message.Attachment` to open download links
in new tabs when clicked. This better handles non-downloadable file types
like `.html` or `.mp4` or `.mp3`.