### PR TITLE
Attachment: Download should open in new window

### DIFF
--- a/src/components/Attachment/docs/Attachment.md
+++ b/src/components/Attachment/docs/Attachment.md
@@ -15,6 +15,7 @@ An Attachment component provides UI for file attachments, typically found in [Ch
 | Prop | Type | Description |
 | --- | --- | --- |
 | className | `string` | Custom class names to be added to the component. |
+| download | `bool`/`string` | Enables file downloaded. Allowed by default if `url` is provided. |
 | id | `number`/`string` | The id of the attachment. |
 | imageUrl | `string` | The URL of the an image attachment to render. |
 | mime | `string` | The file type of the attachment. |
@@ -22,6 +23,7 @@ An Attachment component provides UI for file attachments, typically found in [Ch
 | onClick | `function` | The callback when the component is clicked. |
 | onRemoveClick | `function` | The callback when the component's [CloseButton](../../CloseButton) UI is clicked. |
 | size | `string` | The size of the attachment. |
+| target | `string` | Determines the link target. Set to `_blank` by default if `url` is provided. |
 | truncateLimit | `number` | The amount of characters to truncate the file name. |
 | type | `string` | The type of UI for the component. |
 | url | `string` | The URL of the attachment. |

--- a/src/components/Attachment/index.js
+++ b/src/components/Attachment/index.js
@@ -10,6 +10,7 @@ import { noop } from '../../utilities/other'
 import { providerContextTypes } from './propTypes'
 
 export const propTypes = {
+  download: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   imageUrl: PropTypes.string,
   mime: PropTypes.string,
@@ -17,6 +18,7 @@ export const propTypes = {
   onClick: PropTypes.func,
   onRemoveClick: PropTypes.func,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  target: PropTypes.string,
   truncateLimit: PropTypes.number,
   type: PropTypes.oneOf([
     'action',
@@ -40,6 +42,7 @@ const Attachment = (props, context) => {
   const {
     children,
     className,
+    download,
     id,
     imageUrl,
     mime,
@@ -47,6 +50,7 @@ const Attachment = (props, context) => {
     onClick,
     onRemoveClick,
     size,
+    target,
     truncateLimit,
     type,
     url,
@@ -115,11 +119,17 @@ const Attachment = (props, context) => {
     />
   ) : null
 
+  const downloadProps = {
+    download: download !== undefined ? download : (url ? true : null),
+    target: target !== undefined ? target : (url ? '_blank' : null)
+  }
+
   return (
     <a
       className={componentClassName}
       href={url}
       onClick={handleOnClick}
+      {...downloadProps}
       {...rest}
     >
       {contentMarkup}

--- a/src/components/Attachment/tests/Attachment.test.js
+++ b/src/components/Attachment/tests/Attachment.test.js
@@ -226,3 +226,35 @@ describe('CloseButton', () => {
     expect(spy.mock.calls[0][1].id).toBe('1')
   })
 })
+
+describe('Download', () => {
+  test('Autofills download attributes if url is provided', () => {
+    const wrapper = shallow(<Attachment url='file.pdf' />)
+    const link = wrapper.find('a')
+
+    expect(link.prop('download')).toBe(true)
+    expect(link.prop('target')).toBe('_blank')
+  })
+
+  test('Does not provide valid download attributes if url is not provided', () => {
+    const wrapper = shallow(<Attachment />)
+    const link = wrapper.find('a')
+
+    expect(link.prop('download')).toBeFalsy()
+    expect(link.prop('target')).toBeFalsy()
+  })
+
+  test('Does not swallow props.download if url is provided', () => {
+    const wrapper = shallow(<Attachment url='file.pdf' download={false} />)
+    const link = wrapper.find('a')
+
+    expect(link.prop('download')).toBe(false)
+  })
+
+  test('Does not swallow props.target if url is provided', () => {
+    const wrapper = shallow(<Attachment url='file.pdf' target='_self' />)
+    const link = wrapper.find('a')
+
+    expect(link.prop('target')).toBe('_self')
+  })
+})

--- a/stories/Attachment/index.js
+++ b/stories/Attachment/index.js
@@ -6,12 +6,12 @@ const stories = storiesOf('Attachment', module)
 
 stories.add('default', () => {
   return (
-    <Attachment name='parrot.png' size='5kb' />
+    <Attachment name='parrot.png' size='5kb' url='https://github.com/helpscout/blue/raw/master/images/Blue.png' />
   )
 })
 
 stories.add('long file name', () => {
   return (
-    <Attachment name='parrot-with-a-super-long-name.png' size='5kb' />
+    <Attachment name='parrot-with-a-super-long-name.png' size='5kb' url='https://github.com/helpscout/blue/raw/master/images/Blue.png' />
   )
 })


### PR DESCRIPTION
## Attachment: Download should open in new window

This update enhances the `<Attachment>` component to automatically fill
the `download` and `target` HTML link attributes if a `url` is provided.
This allows for the attachment to reliably download/open in a new tab.

Download handling is custom for every browser. For Chrome's case, it
favours simply loading the file in a new tab.

To customize the behaviour, you can provide your own `download`,
`target` attributes, which will override the auto-generated ones.

Example:

**Usage**

```jsx
<Attachment link='https://github.com/helpscout/blue/raw/master/images/Blue.png' />
```

**Result**

```html
<a
  class="c-Attachment is-link" 
  href="https://github.com/helpscout/blue/raw/master/images/Blue.png"
  download=""
  target="_blank"
>
  ...
</a>
```

CC'ing @brettjonesdev  :)