### PR TITLE
Only render avatar images that are fully loaded

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -34,22 +34,36 @@ const defaultProps = {
   shape: 'circle'
 }
 
+export const IMAGE_STATES = {
+  loading: 'loading',
+  loaded: 'loaded',
+  failed: 'failed'
+}
+
 class Avatar extends Component {
   constructor (props) {
     super(props)
 
     this.state = {
-      // Assume image will load so that we only re-render on error
-      imageLoaded: true
+      // Assume image is loading so that we only re-render on error
+      imageLoaded: IMAGE_STATES.loading
     }
     this.onImageLoadedError = this.onImageLoadedError.bind(this)
+    this.onImageLoadedSuccess = this.onImageLoadedSuccess.bind(this)
   }
 
   onImageLoadedError () {
     this.setState({
-      imageLoaded: false
+      imageLoaded: IMAGE_STATES.failed
     })
     this.props.onError && this.props.onError()
+  }
+
+  onImageLoadedSuccess () {
+    this.setState({
+      imageLoaded: IMAGE_STATES.loaded
+    })
+    this.props.onLoad && this.props.onLoad()
   }
 
   render () {
@@ -72,7 +86,8 @@ class Avatar extends Component {
     } = this.props
 
     const { imageLoaded } = this.state
-    const hasImage = image && imageLoaded
+    const hasImage = image && [IMAGE_STATES.loading, IMAGE_STATES.loaded].indexOf(imageLoaded) >= 0
+    const isImageLoaded = image && imageLoaded === IMAGE_STATES.loaded
 
     const componentClassName = classNames(
       'c-Avatar',
@@ -86,7 +101,7 @@ class Avatar extends Component {
       className
     )
 
-    const imageStyle = hasImage ? { backgroundImage: `url('${image}')` } : null
+    const imageStyle = isImageLoaded ? { backgroundImage: `url('${image}')` } : null
     const text = count || initials || nameToInitials(name)
 
     const contentMarkup = hasImage
@@ -96,7 +111,7 @@ class Avatar extends Component {
             <VisuallyHidden>
               {name}
             </VisuallyHidden>
-            <img alt='' onError={this.onImageLoadedError} onLoad={onLoad} src={image} style={{display: 'none'}} />
+            <img alt='' onError={this.onImageLoadedError} onLoad={this.onImageLoadedSuccess} src={image} style={{display: 'none'}} />
           </div>
         </div>
       )

--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -16,6 +16,8 @@ export const propTypes = {
   initials: PropTypes.string,
   light: PropTypes.bool,
   name: PropTypes.string.isRequired,
+  onLoad: PropTypes.func,
+  onError: PropTypes.func,
   outerBorderColor: PropTypes.string,
   showStatusBorderColor: PropTypes.bool,
   shape: shapeTypes,
@@ -47,6 +49,7 @@ class Avatar extends Component {
     this.setState({
       imageLoaded: false
     })
+    this.props.onError && this.props.onError()
   }
 
   render () {
@@ -58,6 +61,7 @@ class Avatar extends Component {
       name,
       light,
       initials,
+      onLoad,
       outerBorderColor,
       showStatusBorderColor,
       size,
@@ -92,7 +96,7 @@ class Avatar extends Component {
             <VisuallyHidden>
               {name}
             </VisuallyHidden>
-            <img alt='' onError={this.onImageLoadedError} src={image} style={{display: 'none'}} />
+            <img alt='' onError={this.onImageLoadedError} onLoad={onLoad} src={image} style={{display: 'none'}} />
           </div>
         </div>
       )

--- a/src/components/Avatar/tests/Avatar.test.js
+++ b/src/components/Avatar/tests/Avatar.test.js
@@ -248,3 +248,23 @@ describe('StatusDot', () => {
     expect(o.props().icon).toBe('tick')
   })
 })
+
+describe('onError', () => {
+  test('onError handler gets called when there is an error loading the avatar image', () => {
+    const spy = jest.fn()
+    const wrapper = shallow(<Avatar name='Buddy' image='buddy.jpg' onError={spy} />)
+    const img = wrapper.find('img').first()
+    img.simulate('error')
+    expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('onLoad', () => {
+  test('onLoad handler gets called when the avatar image loads', () => {
+    const spy = jest.fn()
+    const wrapper = shallow(<Avatar name='Buddy' image='buddy.jpg' onLoad={spy} />)
+    const img = wrapper.find('img').first()
+    img.simulate('load')
+    expect(spy).toHaveBeenCalled()
+  })
+})

--- a/src/components/Avatar/tests/Avatar.test.js
+++ b/src/components/Avatar/tests/Avatar.test.js
@@ -69,12 +69,20 @@ describe('Image', () => {
     expect(crop.prop('style').backgroundColor).toEqual('transparent')
   })
 
-  test('Render image if image prop is specified', () => {
+  test('Do not render image if image prop is specified but image is loading', () => {
     const src = 'buddy.jpg'
     const wrapper = mount(<Avatar name='Buddy the Elf' image={src} />)
     const image = wrapper.find(classNames.image)
 
     expect(image.exists()).toBeTruthy()
+    expect(image.prop('style')).toBe(null) // Style prop does not get set.
+  })
+
+  test('Render image if image prop is specified and image has finished loading', () => {
+    const src = 'buddy.jpg'
+    const wrapper = mount(<Avatar name='Buddy the Elf' image={src} />)
+    const image = wrapper.find(classNames.image)
+    wrapper.find('img').first().simulate('load')
     expect(image.prop('style').backgroundImage).toContain(src)
   })
 


### PR DESCRIPTION
To make the avatar loading experience smoother, avatars images should only be rendered once they are fully loaded.

This PR implements a change such that the `background-image` property is not set on the Avatar until the image has fully loaded. This prevents partially loaded images from rendering in the Avatar. 

New hooks for onLoad and onError have been added so that consumers of the Avatar component can hook into these events for any custom logic.