### PR TITLE
Guard against invalid values in the nameToInitials strings util

### DIFF
--- a/src/utilities/strings.js
+++ b/src/utilities/strings.js
@@ -3,7 +3,16 @@ export const isString = (string) => {
 }
 
 export const nameToInitials = (name = '') => {
-  if (!name || !name.length) return ''
+  // Returning early if undefined to avoid casting undefined to "undefined"
+  if (!name) {
+    return ''
+  }
+
+  // Trim trailing whitespace
+  name = (name + '').trim()
+  if (!name.length) {
+    return ''
+  }
 
   const words = name.split(' ')
     .map(w => w[0])

--- a/src/utilities/strings.js
+++ b/src/utilities/strings.js
@@ -15,6 +15,7 @@ export const nameToInitials = (name = '') => {
   }
 
   const words = name.split(' ')
+    .filter(w => w !== '')
     .map(w => w[0])
     .map(w => w.toUpperCase())
 

--- a/src/utilities/tests/strings.test.js
+++ b/src/utilities/tests/strings.test.js
@@ -32,6 +32,26 @@ describe('nameToInitials', () => {
   test('Returns empty string if no args are passed', () => {
     expect(nameToInitials()).toBe('')
   })
+
+  test('Returns empty string if undefined is passed', () => {
+    expect(nameToInitials(undefined)).toBe('')
+  })
+
+  test('Returns empty string if an empty string is passed', () => {
+    expect(nameToInitials('')).toBe('')
+  })
+
+  test('Returns empty string if just whitespace is passed', () => {
+    expect(nameToInitials(' ')).toBe('')
+  })
+
+  test('Returns initials string if name is passed', () => {
+    expect(nameToInitials('Tom Graham')).toBe('TG')
+  })
+
+  test('Returns initials string if name is passed with trailing whitespace', () => {
+    expect(nameToInitials('Tom Graham ')).toBe('TG')
+  })
 })
 
 describe('isWord', () => {

--- a/src/utilities/tests/strings.test.js
+++ b/src/utilities/tests/strings.test.js
@@ -49,6 +49,14 @@ describe('nameToInitials', () => {
     expect(nameToInitials('Tom Graham')).toBe('TG')
   })
 
+  test('Returns initials string if name is passed with extra whitespace', () => {
+    expect(nameToInitials('Tom  Graham')).toBe('TG')
+  })
+
+  test('Returns initials string if name is passed with leading whitespace', () => {
+    expect(nameToInitials(' Tom Graham')).toBe('TG')
+  })
+
   test('Returns initials string if name is passed with trailing whitespace', () => {
     expect(nameToInitials('Tom Graham ')).toBe('TG')
   })


### PR DESCRIPTION
We had some bad data turn up in prod, which was causing Agent Chat to throw a JS error and stop working. I haven't been able to fully track down the data, but the error was within the `nameToInitials` util. I could reproduce the error by passing a string with additional whitespace.

Needed for https://github.com/helpscout/hs-app/pull/4885