### PR TITLE
Allow customizing class name on modal wrapper

### DIFF
--- a/src/components/Message/Media.js
+++ b/src/components/Message/Media.js
@@ -18,6 +18,7 @@ export const propTypes = Object.assign({}, bubbleTypes, {
   imageAlt: PropTypes.string,
   imageUrl: PropTypes.string,
   isUploading: PropTypes.bool,
+  modalWrapperClassName: PropTypes.string,
   onMediaClick: PropTypes.func,
   onMediaLoad: PropTypes.func,
   openMediaInModal: PropTypes.bool
@@ -42,6 +43,7 @@ class Media extends Component {
       imageUrl,
       imageAlt,
       isUploading,
+      modalWrapperClassName,
       onMediaClick,
       onMediaLoad,
       openMediaInModal,
@@ -84,7 +86,7 @@ class Media extends Component {
 
     const mediaContainerMarkup = imageUrl ? maybeOpenMediaInModal ? (
       <div className='c-MessageMedia__mediaContainer'>
-        <Modal trigger={mediaMarkup}>
+        <Modal trigger={mediaMarkup} wrapperClassName={modalWrapperClassName}>
           <Modal.Body scrollFade={false} isSeamless>
             <Modal.Content>
               {mediaMarkup}

--- a/src/components/Message/tests/Media.test.js
+++ b/src/components/Message/tests/Media.test.js
@@ -211,6 +211,17 @@ describe('Modal', () => {
     expect(m.length).not.toBeTruthy()
     expect(o.length).toBeTruthy()
   })
+
+  test('Accepts custom wrapperClassName for modal', () => {
+    const url = './mugatu.png'
+    let wrapper = shallow(<Media imageUrl={url} />)
+    let c = wrapper.find(Modal)
+    expect(c.props().wrapperClassName).toEqual(undefined)
+
+    wrapper = shallow(<Media imageUrl={url} modalWrapperClassName='custom' />)
+    c = wrapper.find(Modal)
+    expect(c.props().wrapperClassName).toEqual('custom')
+  })
 })
 
 describe('Uploading', () => {


### PR DESCRIPTION
The Modal component allows a custom class name to be set on the modal's wrapper. This is very useful for integrating Blue components into other user interfaces. 

A consumer of Blue may scope the Blue styles inside a namespace by importing inside a class. For example, `.myScope { @import 'blue.scss' }`. This is useful to allow the styles from Blue to safely be applied inside a region on a page, avoiding potential style conflicts. This breaks down however, for components that use portals since these components end up being rendered outside the intended region and thereby the styles from Blue are not applied. By being able to set a custom wrapper class name on the Modal component (which uses a portal), this issue is alleviated since the component can now render inside the same class name space.

Unfortunately, it was not possible to supply the custom wrapper class name to the Modal component used in the Message.Media component. This PR solves that problem, by allowing a consumer of Blue to set the `modalWrapperClassName` prop on the Message.Media component, and it gets passed through to the inner Modal component.