### PR TITLE
Avatar: Fix StatusDot size for lg

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -135,7 +135,7 @@ class Avatar extends Component {
         <StatusDot
           icon={statusIcon}
           outerBorderColor={showStatusBorderColor ? borderColor : undefined}
-          size='sm'
+          size={size === 'lg' ? 'md' : 'sm'}
           status={status}
         />
       </div>

--- a/src/components/Avatar/tests/Avatar.test.js
+++ b/src/components/Avatar/tests/Avatar.test.js
@@ -239,7 +239,7 @@ describe('StatusDot', () => {
     expect(o.length).toBe(1)
   })
 
-  test('Does not adjust the size of StatusDot based on size of Avatar', () => {
+  test('Does not adjust the size of StatusDot, if the Avatar is md or smaller', () => {
     const wrapper = shallow(<Avatar status='online' size='md' />)
 
     expect(wrapper.find(StatusDot).prop('size')).toBe('sm')
@@ -247,6 +247,12 @@ describe('StatusDot', () => {
     wrapper.setProps({size: 'sm'})
 
     expect(wrapper.find(StatusDot).prop('size')).toBe('sm')
+  })
+
+  test('Adjusts the size of StatusDot if Avatar is lg', () => {
+    const wrapper = shallow(<Avatar status='online' size='lg' />)
+
+    expect(wrapper.find(StatusDot).prop('size')).toBe('md')
   })
 
   test('Renders an icon in StatusDot, if defined', () => {


### PR DESCRIPTION
## Avatar: Fix StatusDot size for lg

![screen shot 2018-04-24 at 12 10 41 pm](https://user-images.githubusercontent.com/2322354/39199932-b4c292fc-47b8-11e8-8838-cd2fcc1e7c47.jpg)

This update fixes the StatusDot size when used within an Avatar. The
size needs to be `md` if the Avatar is set to have a size of `lg`.