### PR TITLE
Fix: Update Fancy for Edge/IE support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@helpscout/fancy": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-0.6.6.tgz",
-      "integrity": "sha512-rZ8mk5oKb/I76VFVw9OdcWPEQcA8elcL95UpivDiXIjr7OmQtk+FSGJLvqMwPtdEIuBPg3IagXnlH6h4HvZNNA==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-0.6.7.tgz",
+      "integrity": "sha512-5Zb57kJ2K4xtnsihJvZwqsck5gc7+A/0oQKBjhXzvOGE+miAyuYQJiWbaS2kueG6j6X1jJasHSMYqkWti0ZB7A==",
       "requires": {
         "stylis": "3.5.0"
       }
@@ -4363,7 +4363,7 @@
         "qs": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg=",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^15"
   },
   "dependencies": {
-    "@helpscout/fancy": "0.6.6",
+    "@helpscout/fancy": "0.6.7",
     "@shopify/javascript-utilities": "2.0.0",
     "closest": "0.0.1",
     "emoji-mart": "^1.0.1",


### PR DESCRIPTION
## Fix: Update Fancy for Edge/IE support

This update bumps Fancy to v0.6.7, which uses `appendChild` vs `append` for
proper IE/Edge support.