### PR TITLE
Update Fancy to v0.6.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@helpscout/fancy": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-0.6.7.tgz",
-      "integrity": "sha512-5Zb57kJ2K4xtnsihJvZwqsck5gc7+A/0oQKBjhXzvOGE+miAyuYQJiWbaS2kueG6j6X1jJasHSMYqkWti0ZB7A==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-0.6.8.tgz",
+      "integrity": "sha512-lJVkv8vAla6uGit/irppdWk9KGIqFbhDG5doNrgLV4V+rAp7g17uMk2oSAQEbFLtFlXPyMgW+ItvbOvJPsr9+g==",
       "requires": {
         "stylis": "3.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^15"
   },
   "dependencies": {
-    "@helpscout/fancy": "0.6.7",
+    "@helpscout/fancy": "0.6.8",
     "@shopify/javascript-utilities": "2.0.0",
     "closest": "0.0.1",
     "emoji-mart": "^1.0.1",


### PR DESCRIPTION
## Update Fancy to v0.6.8

This update bumps [Fancy to v0.6.8](https://github.com/helpscout/fancy/releases/tag/v0.6.8), which fixes the async render cycles
of components with hashed style names.