### PR TITLE
Add line breaks to content in the chat transcript

### DIFF
--- a/src/components/ChatTranscript/LineItem.js
+++ b/src/components/ChatTranscript/LineItem.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Text from '../Text'
 import classNames from '../../utilities/classNames'
+import { newlineToHTML } from '../../utilities/strings'
 
 export const propTypes = {
   body: PropTypes.string,
@@ -43,7 +44,7 @@ const LineItem = props => {
     </span>
   ) : null
 
-  const contentMarkup = body ? (<span dangerouslySetInnerHTML={{__html: body}} />) : children
+  const contentMarkup = body ? (<span dangerouslySetInnerHTML={{__html: newlineToHTML(body)}} />) : children
 
   return (
     <div className={componentClassName} {...rest}>

--- a/src/components/ChatTranscript/tests/LineItem.test.js
+++ b/src/components/ChatTranscript/tests/LineItem.test.js
@@ -36,6 +36,12 @@ describe('Children', () => {
     const wrapper = mount(<LineItem body={body} />)
     expect(wrapper.html()).toContain(body)
   })
+
+  test('Converts newlines to line break elements', () => {
+    const body = 'Hello\n\nGoodbye'
+    const wrapper = mount(<LineItem body={body} />)
+    expect(wrapper.html()).toContain('Hello<br><br>Goodbye')
+  })
 })
 
 describe('CreatedAt', () => {

--- a/src/utilities/strings.js
+++ b/src/utilities/strings.js
@@ -64,3 +64,8 @@ export const stripUrlPrefix = url => {
   if (!isString(url)) return url
   return url.replace(/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)/g, '')
 }
+
+export const newlineToHTML = string => {
+  return string.trim()
+    .replace(/\r?\n/g, '<br>')
+}

--- a/src/utilities/tests/strings.test.js
+++ b/src/utilities/tests/strings.test.js
@@ -151,3 +151,20 @@ describe('stripUrlPrefix', () => {
     expect(stripUrlPrefix('http://www.site.com')).toBe('site.com')
   })
 })
+
+describe('newlineToHTML', () => {
+  test('Returns string, untouched, if there are no newlines', () => {
+    const string = 'word1 word2'
+    expect(newlineToHTML(string)).toEqual(string)
+  })
+
+  test('Replaces newline with <br /> tag', () => {
+    const string = 'word1\nword2'
+    expect(newlineToHTML(string)).toEqual('word1<br />word2')
+  })
+
+  test('Replaces multiple newline with multiple <br /> tag', () => {
+    const string = 'word1\nword2\nword3'
+    expect(newlineToHTML(string)).toEqual('word1<br />word2<br />word3')
+  })
+})

--- a/src/utilities/tests/strings.test.js
+++ b/src/utilities/tests/strings.test.js
@@ -2,6 +2,7 @@ import {
   isString,
   isWord,
   nameToInitials,
+  newlineToHTML,
   wordHasSpaces,
   stripUrlPrefix,
   truncateMiddle
@@ -160,11 +161,11 @@ describe('newlineToHTML', () => {
 
   test('Replaces newline with <br /> tag', () => {
     const string = 'word1\nword2'
-    expect(newlineToHTML(string)).toEqual('word1<br />word2')
+    expect(newlineToHTML(string)).toEqual('word1<br>word2')
   })
 
   test('Replaces multiple newline with multiple <br /> tag', () => {
     const string = 'word1\nword2\nword3'
-    expect(newlineToHTML(string)).toEqual('word1<br />word2<br />word3')
+    expect(newlineToHTML(string)).toEqual('word1<br>word2<br>word3')
   })
 })

--- a/stories/ChatTranscript/index.js
+++ b/stories/ChatTranscript/index.js
@@ -81,7 +81,7 @@ stories.add('types', () => {
   return (
     <ChatTranscript>
       <ChatTranscript.Item
-        body='Something happened (This is a line_item)'
+        body="Something\nhappened (This is a line_item)"
         type='line_item'
         createdAt='10:45pm'
         timestamp='Monday, 10:45pm'

--- a/stories/ChatTranscript/index.js
+++ b/stories/ChatTranscript/index.js
@@ -81,7 +81,7 @@ stories.add('types', () => {
   return (
     <ChatTranscript>
       <ChatTranscript.Item
-        body="Something\nhappened (This is a line_item)"
+        body='Something\nhappened (This is a line_item)'
         type='line_item'
         createdAt='10:45pm'
         timestamp='Monday, 10:45pm'


### PR DESCRIPTION
https://trello.com/c/HBqD6W7A/307-chat-transcript-linebreaks-are-ignored

Adds a new `newlineToHTML` string utility that converts newlines to HTML line breaks. This is used within the chat transcript to convert the newlines in the chat message body.