### PR TITLE
AttachmentList: Wrap items instead of Overflow

### DIFF
--- a/src/components/AttachmentList/index.js
+++ b/src/components/AttachmentList/index.js
@@ -75,9 +75,7 @@ const AttachmentList = (props, context) => {
     ) : null
 
   const contentMarkup = isThemePreview ? (
-    <Overflow className="c-AttachmentList__content">
-      <div className="c-AttachmentList__overflowContent">{childrenMarkup}</div>
-    </Overflow>
+    <div className="c-AttachmentList__content">{childrenMarkup}</div>
   ) : (
     <Inline className="c-AttachmentList__content c-AttachmentList__inlineList">
       <Inline.Item>

--- a/src/components/AttachmentList/tests/AttachmentList.test.js
+++ b/src/components/AttachmentList/tests/AttachmentList.test.js
@@ -1,11 +1,10 @@
 import React from 'react'
 import { mount, shallow } from 'enzyme'
 import AttachmentList from '../index'
-import { Attachment, Icon, Overflow } from '../../index'
+import { Attachment, Icon } from '../../index'
 
 const ui = {
   content: '.c-AttachmentList__content',
-  overflowContent: '.c-AttachmentList__overflowContent',
   list: {
     item: '.c-AttachmentList__inlineListItem',
     download: '.c-AttachmentList__inlineListItemDownloadAll',
@@ -154,35 +153,5 @@ describe('Theme', () => {
 
     expect(o.length).toBe(1)
     expect(o.hasClass('is-theme-preview')).toBeTruthy()
-  })
-})
-
-describe('Overflow', () => {
-  test('Does not render by default', () => {
-    const wrapper = mount(<AttachmentList />)
-    const c = wrapper.find(ui.content)
-    const o = wrapper.find(Overflow)
-
-    expect(c.length).toBe(1)
-    expect(o.length).toBe(0)
-  })
-
-  test('Renders content in Overflow, if theme is preview', () => {
-    const wrapper = mount(
-      <Attachment.Provider theme="preview">
-        <AttachmentList>
-          <Attachment />
-        </AttachmentList>
-      </Attachment.Provider>
-    )
-    const c = wrapper.find(ui.content)
-    const o = wrapper.find(Overflow)
-    const oc = wrapper.find(ui.overflowContent)
-    const a = oc.find(Attachment)
-
-    expect(c.length).toBe(1)
-    expect(o.length).toBe(1)
-    expect(oc.length).toBe(1)
-    expect(a.length).toBe(1)
   })
 })

--- a/src/styles/components/AttachmentList.scss
+++ b/src/styles/components/AttachmentList.scss
@@ -1,13 +1,6 @@
-@import "pack/seed-this/__index";
+@import 'pack/seed-this/__index';
 
 .c-AttachmentList {
-  @import "../resets/base";
+  @import '../resets/base';
   $block: this();
-
-  // Themes
-  &.is-theme-preview {
-    #{$block}__inlineListItem {
-      padding-top: 10px;
-    }
-  }
 }


### PR DESCRIPTION
## AttachmentList: Wrap items instead of Overflow

![screen shot 2018-05-30 at 4 45 48 pm](https://user-images.githubusercontent.com/2322354/40746912-afbce612-6429-11e8-9f8a-d3842a97b89f.jpg)

This update adjusts the AttachmentList to ensure that items that overflow
are wrapped, instead of being contained within an Overflow component.