### PR TITLE
Input: Multiline: Improve scroll mechanism

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -5,7 +5,6 @@ import Resizer from './Resizer'
 import Static from './Static'
 import HelpText from '../HelpText'
 import Label from '../Label'
-import KeypressListener from '../KeypressListener'
 import { scrollLockY } from '../ScrollLock'
 import Keys from '../../constants/Keys'
 import classNames from '../../utilities/classNames'
@@ -81,7 +80,6 @@ class Input extends Component {
     this.inputNode = null
     this.handleOnChange = this.handleOnChange.bind(this)
     this.handleOnInputFocus = this.handleOnInputFocus.bind(this)
-    this.handleOnEnter = this.handleOnEnter.bind(this)
     this.handleOnWheel = this.handleOnWheel.bind(this)
     this.handleExpandingResize = this.handleExpandingResize.bind(this)
   }
@@ -134,7 +132,8 @@ class Input extends Component {
 
   scrollToBottom() {
     /* istanbul ignore next */
-    if (!this.inputNode || !this.inputNode.scrollTo) return
+    if (!this.props.multiline || !this.inputNode || !this.inputNode.scrollTo)
+      return
     /* istanbul ignore next */
     /**
      * Skipping this test, due to lack of JSDOM DOM property support.
@@ -150,15 +149,11 @@ class Input extends Component {
     }
   }
 
-  handleOnEnter() {
-    if (!this.props.multiline) return
-    this.scrollToBottom()
-  }
-
   handleOnChange(e) {
     const value = e.currentTarget.value
     this.setState({ value })
     this.props.onChange(value)
+    this.scrollToBottom()
   }
 
   handleOnInputFocus(e) {
@@ -254,7 +249,7 @@ class Input extends Component {
     const resizer =
       multiline != null ? (
         <Resizer
-          contents={value || placeholder}
+          contents={value}
           currentHeight={height}
           minimumLines={typeof multiline === 'number' ? multiline : 1}
           offsetAmount={offsetAmount}
@@ -313,18 +308,6 @@ class Input extends Component {
 
     return (
       <div className="c-InputWrapper" style={styleProp}>
-        <KeypressListener
-          keyCode={Keys.ENTER}
-          handler={this.handleOnEnter}
-          noModifier
-          type="keyup"
-        />
-        <KeypressListener
-          keyCode={Keys.ENTER}
-          handler={this.handleOnEnter}
-          modifier="shift"
-          type="keyup"
-        />
         {labelMarkup}
         {hintTextMarkup}
         <div className={componentClassName}>

--- a/src/components/Input/tests/Input.test.js
+++ b/src/components/Input/tests/Input.test.js
@@ -522,23 +522,3 @@ describe('isFocused', () => {
     }, 40)
   })
 })
-
-describe('Enter keypress', () => {
-  test('Attempts to scroll to botton on enter keypress, if multiline', () => {
-    const spy = jest.spyOn(Input.prototype, 'scrollToBottom')
-    const wrapper = mount(<Input multiline />)
-    wrapper.instance().handleOnEnter()
-
-    expect(spy).toHaveBeenCalled()
-    spy.mockRestore()
-  })
-
-  test('Does not to scroll to botton on enter keypress, if not multiline', () => {
-    const spy = jest.spyOn(Input.prototype, 'scrollToBottom')
-    const wrapper = mount(<Input />)
-    wrapper.instance().handleOnEnter()
-
-    expect(spy).not.toHaveBeenCalled()
-    spy.mockRestore()
-  })
-})


### PR DESCRIPTION
## Input: Multiline: Improve scroll mechanism

![screen recording 2018-05-31 at 12 16 pm](https://user-images.githubusercontent.com/2322354/40794406-0b6cf2b0-64cd-11e8-905f-3445d57cf558.gif)

This update improves the scrolling mechanism that attempts to scroll to the
ideal reading position of a multi-line input.

The scrolling mechanism calculates on every character change, but only kicks
in if the textarea line number is the last line number.