### PR TITLE
Update to Fancy v1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@helpscout/fancy": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-0.7.0.tgz",
-      "integrity": "sha512-6YpL7IS3ZqKzY75osYM96rQ9Am/HpBQz3IQtQXBz8swbj0JT/cKmtAhZKfCudhFcDOpvj0nGqeW3om7JvHaXKQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-1.0.3.tgz",
+      "integrity": "sha512-vmH3n7CjwRW3lvSNty2WVSPVyGeB6BJV8vdZzhEDL4jeeQJ6OxzYNofQ3EG0e+pu7l3ZeOQADMRSratrggOOJA==",
       "requires": {
         "stylis": "3.5.0"
       }
@@ -31,7 +31,7 @@
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha1-hNt+nrVTHfGKjF4L+25EnlXmVLI=",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
         "samsam": "1.3.0"
@@ -11432,7 +11432,7 @@
     "just-extend": {
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha1-7G55QQ/5FORyZSq/oOYDwD1g6QU=",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
       "dev": true
     },
     "karma": {
@@ -12101,7 +12101,7 @@
     "lolex": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
-      "integrity": "sha1-nAh6aexEDjnT95Z2fPGyzcQ9XqU=",
+      "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
       "dev": true
     },
     "longest": {
@@ -12541,7 +12541,7 @@
     "nise": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.3.tgz",
-      "integrity": "sha1-wXqFAGaood/rN/kh2gJEGvxKgro=",
+      "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "^2.0.0",
@@ -18251,7 +18251,7 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "sane": {
@@ -19025,7 +19025,7 @@
     "sinon": {
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.0.10.tgz",
-      "integrity": "sha1-ooKzanR1ZkyfmHGRCOVUaQcSkCM=",
+      "integrity": "sha512-+YT7Mjr8BpNndQqUUydO/daggF4yuOAnsVjo+5Ayx3mLLUqojfkXhDkho4HB5VgfnZYSdhxVDPbfJ2EBXFMSvA==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "^2.0.0",
@@ -19052,7 +19052,7 @@
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-dom": "^15"
   },
   "dependencies": {
-    "@helpscout/fancy": "0.7.0",
+    "@helpscout/fancy": "1.0.3",
     "closest": "0.0.1",
     "emoji-mart": "^1.0.1",
     "lodash.camelcase": "4.3.0",

--- a/src/components/Emoticon/index.js
+++ b/src/components/Emoticon/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import fancy from '@helpscout/fancy'
 import EMOTICONS from './emoticons'
 import css from './styles/Emoticon.css'
+import styled from '../styled'
 import classNames from '../../utilities/classNames'
 import { sizeTypes } from './propTypes'
 
@@ -17,6 +17,7 @@ const Component = props => {
     title,
     size,
     styles,
+    theme,
     ...rest
   } = props
 
@@ -43,7 +44,7 @@ const Component = props => {
   )
 }
 
-const Emoticon = fancy(css)(Component)
+const Emoticon = styled(Component)(css)
 
 Emoticon.propTypes = {
   center: PropTypes.bool,

--- a/src/components/Emoticon/styles/Emoticon.css.js
+++ b/src/components/Emoticon/styles/Emoticon.css.js
@@ -41,10 +41,10 @@ const css = `
     }
   }
 
-  &__pathHead {
+  .c-Emoticon__pathHead {
     fill: ${colors.off.head};
   }
-  &__pathFace {
+  .c-Emoticon__pathFace {
     fill: ${colors.off.face};
   }
 

--- a/src/components/styled/README.md
+++ b/src/components/styled/README.md
@@ -1,0 +1,7 @@
+# styled
+
+This is an adapter for [Fancy](https://github.com/helpscout/fancy), which provides some flexibility for how Fancy is consumed within Blue.
+
+As a bonus, it makes migrating away from Fancy easier, if we ever choose to swap Fancy out with another CSS-in-JS equivalent (with a similar API).
+
+See [Fancy's documentation](https://github.com/helpscout/fancy) for more details.

--- a/src/components/styled/__tests__/styled.test.js
+++ b/src/components/styled/__tests__/styled.test.js
@@ -1,0 +1,84 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import styled, { ThemeProvider } from '../index'
+
+const resetStyles = () => {
+  document.head.innerHTML = ''
+  styled.StyleSheet.__dangerouslyResetStyleSheet()
+}
+
+const getCSS = el => window.getComputedStyle(el)
+
+describe('styled integration', () => {
+  afterEach(() => {
+    resetStyles()
+  })
+
+  describe('Components', () => {
+    test('Can create a primitive component', () => {
+      const Ron = styled.div`
+        color: red;
+        padding: 20px;
+      `
+      const wrapper = mount(<Ron />)
+      const el = wrapper.find('div').node
+
+      setTimeout(() => {
+        expect(getCSS(el).color).toBe('red')
+        expect(getCSS(el).padding).toBe('20px')
+      })
+    })
+
+    test('Can style an existing component', () => {
+      const Base = props => <div {...props} />
+
+      const Ron = styled(Base)`
+        color: red;
+        padding: 20px;
+      `
+      const wrapper = mount(<Ron />)
+      const el = wrapper.find('div').node
+
+      setTimeout(() => {
+        expect(getCSS(el).color).toBe('red')
+        expect(getCSS(el).padding).toBe('20px')
+      })
+    })
+
+    test('Supports css interpolationg with props', () => {
+      const Ron = styled.div`
+        color: red;
+        padding: ${props => `${props['data-padding']}px;`};
+      `
+      const wrapper = mount(<Ron data-padding={108} />)
+      const el = wrapper.find('div').node
+
+      setTimeout(() => {
+        expect(getCSS(el).color).toBe('red')
+        expect(getCSS(el).padding).toBe('108px')
+      })
+    })
+  })
+
+  describe('Theming', () => {
+    test('ThemeProvider can pass data down to styled components', () => {
+      const Ron = styled.div`
+        color: ${props => (props.theme === 'dark' ? 'black' : 'white')};
+        padding: 20px;
+      `
+      const wrapper = mount(
+        <div>
+          <ThemeProvider theme="dark">
+            <Ron />
+          </ThemeProvider>
+        </div>
+      )
+      const el = wrapper.find('div').node
+
+      setTimeout(() => {
+        expect(getCSS(el).color).toBe('black')
+        expect(getCSS(el).padding).toBe('20px')
+      })
+    })
+  })
+})

--- a/src/components/styled/index.js
+++ b/src/components/styled/index.js
@@ -1,0 +1,7 @@
+import styled, { ThemeProvider } from '@helpscout/fancy'
+
+const Style = styled.Style
+
+export default styled
+
+export { Style, ThemeProvider }


### PR DESCRIPTION
## Update to Fancy v1.0
This update upgrades [Fancy](https://github.com/helpscout/fancy/releases/tag/v1.0.0) to v1, which has support for Theming with a new
styled-component-like API.

Fancy will be used throughout Blue via a `styled` adapter for added
flexibility.

Integration tests have been added to ensure basic functionality.

At the moment, Fancy is only being used for the Emoticon component. Here's
a screenshot of it rendering on Microsoft Edge.

![screen shot 2018-05-31 at 5 18 14 pm](https://user-images.githubusercontent.com/2322354/40808975-fa6f8aa2-64f6-11e8-80c9-131291e0e5ca.jpg)
