### PR TITLE
Fancy: Update build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@helpscout/fancy": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-1.0.3.tgz",
-      "integrity": "sha512-vmH3n7CjwRW3lvSNty2WVSPVyGeB6BJV8vdZzhEDL4jeeQJ6OxzYNofQ3EG0e+pu7l3ZeOQADMRSratrggOOJA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-1.0.5.tgz",
+      "integrity": "sha512-WMo8e0NiynOtgRgt6+HGKpAhMnb0vFSFf1nHC8761gBwwS/DFByx4MQZIwrzW8ErTpzEA33F5Ie/Tf0vW/E37g==",
       "requires": {
         "stylis": "3.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-dom": "^15"
   },
   "dependencies": {
-    "@helpscout/fancy": "1.0.3",
+    "@helpscout/fancy": "1.0.5",
     "closest": "0.0.1",
     "emoji-mart": "^1.0.1",
     "lodash.camelcase": "4.3.0",


### PR DESCRIPTION
## Fancy: Update build

This update bumps Fancy to v1.0.5, which includes minor bug fixes, but more
importantly, a consumable build for friendly Webpack (uglify) bundling.