### PR TITLE
Tooltip: Word-wrap

### DIFF
--- a/src/components/Tooltip/styles/TooltipPopper.css.js
+++ b/src/components/Tooltip/styles/TooltipPopper.css.js
@@ -10,6 +10,7 @@ const css = `
   font-size: 12px;
   max-width: 300px;
   padding: 6px 8px;
+  word-break: break-word;
 }
 `
 

--- a/stories/Tooltip.js
+++ b/stories/Tooltip.js
@@ -38,10 +38,10 @@ stories.add('default', () => (
     <br />
     <Tooltip
       triggerOn="click"
-      title="Lots and lots and lots of words"
-      placement="top-end"
+      title="lotsssssssssofffffffffwordddddddddddddddddsssssssssssssssssssssssss"
+      placement="top-start"
     >
-      Top Right
+      Top Left, lots of words
     </Tooltip>
   </div>
 ))


### PR DESCRIPTION
## Tooltip: Word-wrap

![screen shot 2018-06-05 at 10 50 23 am](https://user-images.githubusercontent.com/2322354/40983853-823ccf84-68ae-11e8-925d-f688463544c3.jpg)

This update adds word-wrapping for Tooltip content.