### PR TITLE
Split Time component from Timestamp to allow just rendering time without wrapper

### DIFF
--- a/src/components/Timestamp/Time.js
+++ b/src/components/Timestamp/Time.js
@@ -1,0 +1,90 @@
+import React, { Component } from 'react'
+import { calculateTimeoutPeriod } from '../../utilities/timestamp'
+import PropTypes from 'prop-types'
+
+export const propTypes = {
+  formatter: PropTypes.func,
+  live: PropTypes.bool,
+}
+
+const defaultProps = {
+  formatter: timestamp => timestamp,
+  live: false,
+}
+
+class Time extends Component {
+  constructor(props) {
+    super(props)
+
+    this.timeoutId = undefined
+    this._isMounted = false
+  }
+
+  componentDidMount() {
+    const { live } = this.props
+    this._isMounted = true
+
+    if (live) {
+      // Start the tick
+      this.tick(true)
+    }
+  }
+
+  componentDidUpdate(lastProps) {
+    const { live: lastLive, timestamp: lastTimestamp } = lastProps
+    const { live, timestamp } = this.props
+
+    if (live !== lastLive || timestamp !== lastTimestamp) {
+      if (!live && this.timeoutId) {
+        // Clear the timeout if now not live
+        clearTimeout(this.timeoutId)
+        this.timeoutId = undefined
+      }
+
+      // Tick to update the timestamp
+      this.tick()
+    }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false
+
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId)
+      this.timeoutId = undefined
+    }
+  }
+
+  tick(refresh) {
+    const { live, timestamp } = this.props
+
+    if (!this._isMounted || !live) {
+      return
+    }
+
+    const period = calculateTimeoutPeriod(timestamp)
+
+    if (period > 0) {
+      this.timeoutId = setTimeout(this.tick.bind(this), period)
+    }
+
+    if (!refresh) {
+      this.forceUpdate()
+    }
+  }
+
+  render() {
+    const { className, formatter, timestamp } = this.props
+
+    return (
+      <time className={className} dateTime={timestamp}>
+        {formatter(timestamp)}
+      </time>
+    )
+  }
+}
+
+Time.propTypes = propTypes
+Time.defaultProps = defaultProps
+
+export default Time

--- a/src/components/Timestamp/index.js
+++ b/src/components/Timestamp/index.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react'
 import classNames from '../../utilities/classNames'
-import { calculateTimeoutPeriod } from '../../utilities/timestamp'
 import PropTypes from 'prop-types'
 import Flexy from '../Flexy'
 import Icon from '../Icon'
 import Text from '../Text'
+import Time from './Time'
 
 export const propTypes = {
   formatter: PropTypes.func,
@@ -15,73 +15,11 @@ export const propTypes = {
 }
 
 const defaultProps = {
-  formatter: timestamp => timestamp,
-  live: false,
   read: false,
   timestamp: '9:41am',
 }
 
 class Timestamp extends Component {
-  constructor(props) {
-    super(props)
-
-    this.timeoutId = undefined
-    this._isMounted = false
-  }
-
-  componentDidMount() {
-    const { live } = this.props
-    this._isMounted = true
-
-    if (live) {
-      // Start the tick
-      this.tick(true)
-    }
-  }
-
-  componentDidUpdate(lastProps) {
-    const { live: lastLive, timestamp: lastTimestamp } = lastProps
-    const { live, timestamp } = this.props
-
-    if (live !== lastLive || timestamp !== lastTimestamp) {
-      if (!live && this.timeoutId) {
-        // Clear the timeout if now not live
-        clearTimeout(this.timeoutId)
-        this.timeoutId = undefined
-      }
-
-      // Tick to update the timestamp
-      this.tick()
-    }
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false
-
-    if (this.timeoutId) {
-      clearTimeout(this.timeoutId)
-      this.timeoutId = undefined
-    }
-  }
-
-  tick(refresh) {
-    const { live, timestamp } = this.props
-
-    if (!this._isMounted || !live) {
-      return
-    }
-
-    const period = calculateTimeoutPeriod(timestamp)
-
-    if (period > 0) {
-      this.timeoutId = setTimeout(this.tick.bind(this), period)
-    }
-
-    if (!refresh) {
-      this.forceUpdate()
-    }
-  }
-
   render() {
     const {
       children,
@@ -109,7 +47,7 @@ class Timestamp extends Component {
         <Flexy gap="xs" just="left">
           <Flexy.Item>
             <Text size="12" faint disableSelect noWrap>
-              <time dateTime={timestamp}>{formatter(timestamp)}</time>
+              <Time formatter={formatter} live={live} timestamp={timestamp} />
             </Text>
           </Flexy.Item>
           <Flexy.Item>{readMarkup}</Flexy.Item>
@@ -121,5 +59,6 @@ class Timestamp extends Component {
 
 Timestamp.propTypes = propTypes
 Timestamp.defaultProps = defaultProps
+Timestamp.Time = Time
 
 export default Timestamp

--- a/src/components/Timestamp/tests/Timestamp.test.js
+++ b/src/components/Timestamp/tests/Timestamp.test.js
@@ -31,7 +31,7 @@ describe('Content', () => {
   test('Wraps timestamp in a Text component', () => {
     const wrapper = shallow(<Timestamp timestamp="noon" />)
     const o = wrapper.find(Text)
-    const t = o.find('time')
+    const t = o.find(Timestamp.Time)
 
     expect(o.length).toBeTruthy()
     expect(t).toBeTruthy()

--- a/src/utilities/tests/timestamp.test.js
+++ b/src/utilities/tests/timestamp.test.js
@@ -15,11 +15,11 @@ describe('calculateTimeoutPeriod', () => {
     expect(calculateTimeoutPeriod(timestamp)).toEqual(60 * 60 * 1000)
   })
 
-  test('returns a minute (in ms) when the difference is more than an minute', () => {
+  test('returns 15 seconds (in ms) when the difference is more than an minute', () => {
     const timestamp = new Date()
     timestamp.setTime(Date.now() - 60 * 3 * 1000)
 
-    expect(calculateTimeoutPeriod(timestamp)).toEqual(60 * 1000)
+    expect(calculateTimeoutPeriod(timestamp)).toEqual(15 * 1000)
   })
 
   test('returns a second (in ms) when the difference is less than an minute', () => {

--- a/src/utilities/timestamp.js
+++ b/src/utilities/timestamp.js
@@ -14,8 +14,9 @@ export const calculateTimeoutPeriod = timestamp => {
   }
 
   if (diff < HOUR) {
-    // Once every minute
-    return 1000 * MINUTE
+    // Once every 15 seconds
+    // NB: Not every minute as we had problems with multiple timestamp components updating on different intervals
+    return 1000 * 15
   }
 
   if (diff < DAY) {

--- a/stories/Timestamp.js
+++ b/stories/Timestamp.js
@@ -23,3 +23,11 @@ stories.add('formatter', () => (
     formatter={customFormatter}
   />
 ))
+
+stories.add('Time', () => (
+  <Timestamp.Time
+    timestamp={new Date().toISOString()}
+    live
+    formatter={customFormatter}
+  />
+))


### PR DESCRIPTION
I needed a live updating `time` element that wasn't wrapped in the usual way that `Timestamp` does. It needed to be inline and inherit the styles from the container. To achieve this I split out the logic for the live updating timestamp into a `Time` component that could be used independently of `Timestamp` as `Timestamp.Time`.

The `calculateTimeoutPeriod` function is used to determine the interval to use for updating the live timestamp. When the difference is more than one minute we only updated every minute. This was causing some display issues when we had multiple components that were rendered at different times. One might say "3 min ago" and the other "4 min ago" as the intervals are out of sync. To alleviate some of this I updated the interval to be every 15 seconds rather than every 1 minute.