### PR TITLE
Input: ScrollLock and cursor focus

### DIFF
--- a/src/components/Alert/tests/Alert.test.js
+++ b/src/components/Alert/tests/Alert.test.js
@@ -73,7 +73,7 @@ describe('Dismissing', () => {
     const o = wrapper.find(Collapsible)
 
     expect(o.length).toBeTruthy()
-    expect(o.node.props.isOpen).toBeTruthy()
+    expect(o.getNode().props.isOpen).toBeTruthy()
   })
 
   test('Collapses alert on CloseButton click', () => {
@@ -83,7 +83,7 @@ describe('Dismissing', () => {
 
     b.simulate('click')
 
-    expect(o.node.props.isOpen).not.toBeTruthy()
+    expect(o.getNode().props.isOpen).not.toBeTruthy()
   })
 })
 
@@ -147,7 +147,7 @@ describe('Badge', () => {
 
     expect(d.length).toBeTruthy()
     expect(o.length).toBeTruthy()
-    expect(o.node.props.children).toBe('Badge')
+    expect(o.getNode().props.children).toBe('Badge')
     expect(wrapper.hasClass('has-badge')).toBeTruthy()
   })
 })
@@ -167,7 +167,7 @@ describe('Icon', () => {
 
     expect(d.length).toBeTruthy()
     expect(o.length).toBeTruthy()
-    expect(o.node.props.name).toBe('alert')
+    expect(o.getNode().props.name).toBe('alert')
     expect(wrapper.hasClass('has-icon')).toBeTruthy()
   })
 })

--- a/src/components/Button/tests/Button.test.js
+++ b/src/components/Button/tests/Button.test.js
@@ -157,7 +157,7 @@ describe('RouteWrapper', () => {
   test('`to` router navigation is skipped on ctrl+click', done => {
     const route = '/some/route/'
     const wrapper = wrap(<Button to={route}>Gator</Button>, options)
-    expect(wrapper.node.type).toBe('button')
+    expect(wrapper.getNode().type).toBe('button')
     clickEvent.ctrlKey = true
     wrapper.simulate('click', clickEvent)
     expect(preventDefault).not.toHaveBeenCalled()
@@ -170,7 +170,7 @@ describe('RouteWrapper', () => {
   test('`to` router navigation is skipped on cmd+click', done => {
     const route = '/some/route/'
     const wrapper = wrap(<Button to={route}>Gator</Button>, options)
-    expect(wrapper.node.type).toBe('button')
+    expect(wrapper.getNode().type).toBe('button')
     clickEvent.metaKey = true
     wrapper.simulate('click', clickEvent)
     expect(preventDefault).not.toHaveBeenCalled()
@@ -189,7 +189,7 @@ describe('RouteWrapper', () => {
       </Button>,
       options
     )
-    expect(wrapper.node.type).toBe('button')
+    expect(wrapper.getNode().type).toBe('button')
     wrapper.simulate('click', clickEvent)
     expect(preventDefault).toHaveBeenCalled()
     setTimeout(() => {

--- a/src/components/Card/tests/Card.Block.test.js
+++ b/src/components/Card/tests/Card.Block.test.js
@@ -78,7 +78,7 @@ describe('Scrollable', () => {
     const wrapper = shallow(<CardBlock scrollable onScroll={spy} />)
     const o = wrapper.find(Scrollable)
 
-    o.node.props.onScroll()
+    o.getNode().props.onScroll()
 
     expect(spy).toHaveBeenCalled()
   })

--- a/src/components/Card/tests/Card.test.js
+++ b/src/components/Card/tests/Card.test.js
@@ -34,7 +34,7 @@ describe('Block', () => {
     const o = wrapper.find(Card.Block)
 
     expect(o.length).toBe(1)
-    expect(o.node.props.children).toBe('MegaMind')
+    expect(o.getNode().props.children).toBe('MegaMind')
   })
 
   test('Can render a multiple Card.Block', () => {
@@ -87,8 +87,8 @@ describe('Link', () => {
     const o = wrapper.find(Link)
 
     expect(o.length).toBe(1)
-    expect(o.node.props.block).toBeTruthy()
-    expect(o.node.props.href).toBe(link)
+    expect(o.getNode().props.block).toBeTruthy()
+    expect(o.getNode().props.href).toBe(link)
   })
 
   test('Renders a Link component if to is defined', () => {
@@ -96,14 +96,14 @@ describe('Link', () => {
     const o = wrapper.find(Link)
 
     expect(o.length).toBe(1)
-    expect(o.node.props.block).toBeTruthy()
-    expect(o.node.props.to).toBe(link)
+    expect(o.getNode().props.block).toBeTruthy()
+    expect(o.getNode().props.to).toBe(link)
   })
 
   test('Renders a Link component with target="_blank"', () => {
     const wrapper = shallow(<Card href={link} external />)
     const o = wrapper.find(Link)
-    const p = o.node.props
+    const p = o.getNode().props
 
     expect(o.length).toBe(1)
     expect(p.block).toBeTruthy()
@@ -122,7 +122,7 @@ describe('Link', () => {
     const o = wrapper.find(Link)
 
     expect(o.length).toBe(1)
-    expect(o.node.props.children.type).toBe(Card.Block)
+    expect(o.getNode().props.children.type).toBe(Card.Block)
     expect(b.length).toBe(1)
     expect(b.node.props.children).toBe('MegaMind')
   })
@@ -191,13 +191,13 @@ describe('Selector', () => {
   test('Renders a div selector by default', () => {
     const wrapper = shallow(<Card />)
 
-    expect(wrapper.node.type).toBe('div')
+    expect(wrapper.getNode().type).toBe('div')
   })
 
   test('Renders a custom selector, if specified', () => {
     const wrapper = shallow(<Card selector="span" />)
 
-    expect(wrapper.node.type).toBe('span')
+    expect(wrapper.getNode().type).toBe('span')
   })
 })
 

--- a/src/components/ChoiceGroup/tests/ChoiceGroup.test.js
+++ b/src/components/ChoiceGroup/tests/ChoiceGroup.test.js
@@ -179,7 +179,7 @@ describe('MultiSelect', () => {
     )
     const o = wrapper.find(ChoiceGroup)
 
-    expect(o.node.multiSelect).toBeFalsy()
+    expect(o.getNode().multiSelect).toBeFalsy()
     wrapper.unmount()
   })
 
@@ -193,7 +193,7 @@ describe('MultiSelect', () => {
     )
     const o = wrapper.find(ChoiceGroup)
 
-    expect(o.node.multiSelect).toBeTruthy()
+    expect(o.getNode().multiSelect).toBeTruthy()
     wrapper.unmount()
   })
 
@@ -207,7 +207,7 @@ describe('MultiSelect', () => {
     )
     const o = wrapper.find(ChoiceGroup)
 
-    expect(o.node.multiSelect).not.toBeTruthy()
+    expect(o.getNode().multiSelect).not.toBeTruthy()
     wrapper.unmount()
   })
 })

--- a/src/components/Drop/tests/Positioner.test.js
+++ b/src/components/Drop/tests/Positioner.test.js
@@ -29,7 +29,7 @@ describe('Position', () => {
         <div>Ron B</div>
       </Positioner>
     )
-    const o = wrapper.find('.c-DropPositioner').node.style
+    const o = wrapper.find('.c-DropPositioner').getNode().style
 
     // Can only test display, unfortunately.
     // Cannot test transform style in JSDOM :'(
@@ -51,7 +51,7 @@ describe('Position', () => {
         <div>Ron B</div>
       </Positioner>
     )
-    const o = wrapper.find('.c-DropPositioner').node.style
+    const o = wrapper.find('.c-DropPositioner').getNode().style
 
     expect(o.display).toBe('none')
   })

--- a/src/components/Dropdown/tests/Dropdown.test.js
+++ b/src/components/Dropdown/tests/Dropdown.test.js
@@ -154,7 +154,7 @@ describe('Selected', () => {
       </Dropdown>
     )
     const o = wrapper.find(Dropdown.Item)
-    o.node.handleOnClick({ stopPropagation: () => {} })
+    o.getNode().handleOnClick({ stopPropagation: () => {} })
 
     expect(spy).toHaveBeenCalledWith('Ron')
   })
@@ -248,7 +248,7 @@ describe('Focus', () => {
     o.simulate('focus')
 
     setTimeout(() => {
-      expect(wrapper.node.isFocused).toBeTruthy()
+      expect(wrapper.instance().isFocused).toBeTruthy()
       done()
     }, 1)
   })

--- a/src/components/Dropdown/tests/Item.test.js
+++ b/src/components/Dropdown/tests/Item.test.js
@@ -20,15 +20,6 @@ describe('TabIndex', () => {
   })
 })
 
-describe('Nodes', () => {
-  test('Has a reference to this.node', () => {
-    const wrapper = mount(<Item />)
-    const o = wrapper.node
-
-    expect(o.node).toBeTruthy()
-  })
-})
-
 describe('Styles', () => {
   test('Adds isHover className if applicable', () => {
     const wrapper = shallow(<Item isHover />)
@@ -75,7 +66,7 @@ describe('Sub menu', () => {
         <Menu />
       </Item>
     )
-    const o = wrapper.node
+    const o = wrapper.getNode()
 
     expect(o.menu).toBeTruthy()
   })

--- a/src/components/Dropdown/tests/Menu.test.js
+++ b/src/components/Dropdown/tests/Menu.test.js
@@ -36,7 +36,7 @@ describe('Classname', () => {
 describe('Nodes', () => {
   test('Has a reference to DOM nodes', done => {
     const wrapper = mount(<MenuComponent isOpen />)
-    const o = wrapper.node
+    const o = wrapper.instance()
 
     wait().then(() => {
       expect(o.node).toBeTruthy()
@@ -110,7 +110,7 @@ describe('Items', () => {
         <div className="brick">Brick</div>
       </MenuComponent>
     )
-    const n = wrapper.node
+    const n = wrapper.instance()
     const o = wrapper.find('.brick')
 
     expect(n.items.length).toBe(4)
@@ -338,7 +338,7 @@ describe('Selected', () => {
 describe('Height', () => {
   test('Adjusts height on mount, if Menu will be outside of Viewport', done => {
     const wrapper = mount(<MenuComponent isOpen />)
-    const o = wrapper.node
+    const o = wrapper.getNode()
     const initialHeight = o.height
 
     o.listNode.getBoundingClientRect = () => ({
@@ -363,7 +363,7 @@ describe('Height', () => {
 
   test('Keeps height at null if Menu is within viewport', done => {
     const wrapper = mount(<MenuComponent isOpen />)
-    const o = wrapper.node
+    const o = wrapper.getNode()
 
     o.listNode.getBoundingClientRect = () => ({
       width: 200,
@@ -495,7 +495,7 @@ describe('Keyboard Arrows: Up/Down', () => {
         <Item />
       </MenuComponent>
     )
-    wrapper.node.isFocused = false
+    wrapper.getNode().isFocused = false
 
     simulateKeyPress(Keys.UP_ARROW, 'keydown')
     expect(wrapper.state().focusIndex).toBe(3)
@@ -510,7 +510,7 @@ describe('Keyboard Arrows: Up/Down', () => {
         <Item />
       </MenuComponent>
     )
-    wrapper.node.isFocused = false
+    wrapper.getNode().isFocused = false
 
     simulateKeyPress(Keys.DOWN_ARROW, 'keydown')
     expect(wrapper.state().focusIndex).toBe(3)
@@ -565,7 +565,7 @@ describe('Keyboard Arrows: Left/Right', () => {
         <Item />
       </MenuComponent>
     )
-    wrapper.node.isFocused = false
+    wrapper.getNode().isFocused = false
 
     simulateKeyPress(Keys.LEFT_ARROW, 'keydown')
 
@@ -585,7 +585,7 @@ describe('Keyboard Arrows: Left/Right', () => {
         <Item />
       </MenuComponent>
     )
-    const o = wrapper.node
+    const o = wrapper.getNode()
     const previousHoverIndex = wrapper.state().hoverIndex
 
     simulateKeyPress(Keys.RIGHT_ARROW, 'keydown')
@@ -605,7 +605,7 @@ describe('Keyboard Arrows: Left/Right', () => {
         <Item />
       </MenuComponent>
     )
-    const o = wrapper.node
+    const o = wrapper.getNode()
 
     expect(o.isFocused).toBeTruthy()
 
@@ -625,7 +625,7 @@ describe('Keyboard Arrows: Left/Right', () => {
         <Item />
       </MenuComponent>
     )
-    const o = wrapper.node
+    const o = wrapper.getNode()
 
     expect(o.isFocused).toBeTruthy()
 
@@ -648,7 +648,7 @@ describe('Keyboard Arrows: Left/Right', () => {
         <Item />
       </MenuComponent>
     )
-    wrapper.node.isFocused = false
+    wrapper.getNode().isFocused = false
 
     simulateKeyPress(Keys.LEFT_ARROW, 'keydown')
 
@@ -663,7 +663,7 @@ describe('Open state', () => {
         <Item />
       </MenuComponent>
     )
-    const o = wrapper.node
+    const o = wrapper.getNode()
     wrapper.setProps({ isOpen: true })
 
     expect(o.isFocused).toBe(true)
@@ -704,7 +704,7 @@ describe('Focus', () => {
     simulateKeyPress(Keys.DOWN_ARROW, 'keydown')
 
     expect(wrapper.state().focusIndex).toBe(3)
-    expect(wrapper.node.items[3].node).toBe(document.activeElement)
+    expect(wrapper.getNode().items[3].node).toBe(document.activeElement)
   })
 
   test('Does not focuses item on key down arrow, if menu is unfocused', () => {
@@ -716,14 +716,14 @@ describe('Focus', () => {
         <Item />
       </MenuComponent>
     )
-    const o = wrapper.node
+    const o = wrapper.getNode()
     o.isFocused = false
 
     simulateKeyPress(Keys.DOWN_ARROW, 'keydown')
     simulateKeyPress(Keys.DOWN_ARROW, 'keydown')
     simulateKeyPress(Keys.DOWN_ARROW, 'keydown')
 
-    expect(wrapper.node.items[3].node).not.toBe(document.activeElement)
+    expect(wrapper.getNode().items[3].node).not.toBe(document.activeElement)
   })
 
   test('Removes this.isFocused when item with sub-menu is hovered', () => {
@@ -739,7 +739,7 @@ describe('Focus', () => {
       </MenuComponent>
     )
 
-    expect(wrapper.node.isFocused).toBeTruthy()
+    expect(wrapper.getNode().isFocused).toBeTruthy()
     expect(wrapper.state().focusIndex).not.toBe(3)
     expect(wrapper.state().hoverIndex).not.toBe(3)
 
@@ -751,7 +751,7 @@ describe('Focus', () => {
 
     expect(wrapper.state().focusIndex).toBe(3)
     expect(wrapper.state().hoverIndex).toBe(3)
-    expect(wrapper.node.isFocused).not.toBeTruthy()
+    expect(wrapper.getNode().isFocused).not.toBeTruthy()
   })
 
   test('Resets focus when sub-menu is closed, and if menu is mounted', () => {
@@ -806,8 +806,8 @@ describe('Unmounting', () => {
       </MenuComponent>
     )
 
-    expect(wrapper.node._isMounted).not.toBeFalsy()
+    expect(wrapper.getNode()._isMounted).not.toBeFalsy()
     wrapper.unmount()
-    expect(wrapper.node._isMounted).toBeFalsy()
+    expect(wrapper.getNode()._isMounted).toBeFalsy()
   })
 })

--- a/src/components/Heading/tests/Heading.test.js
+++ b/src/components/Heading/tests/Heading.test.js
@@ -29,13 +29,13 @@ describe('Selector', () => {
   test('Renders a div selector by default', () => {
     const wrapper = shallow(<Heading />)
 
-    expect(wrapper.node.type).toBe('div')
+    expect(wrapper.getNode().type).toBe('div')
   })
 
   test('Renders a custom selector, if specified', () => {
     const wrapper = shallow(<Heading selector="span" />)
 
-    expect(wrapper.node.type).toBe('span')
+    expect(wrapper.getNode().type).toBe('span')
   })
 })
 

--- a/src/components/HelpText/index.js
+++ b/src/components/HelpText/index.js
@@ -11,7 +11,7 @@ type Props = {
   className?: string,
   muted?: boolean,
   size?: Sizes,
-  state?: UIStates,
+  state?: ?UIStates,
 }
 
 const HelpText = (props: Props) => {

--- a/src/components/InfiniteScroller/tests/InfiniteScroller.test.js
+++ b/src/components/InfiniteScroller/tests/InfiniteScroller.test.js
@@ -46,8 +46,8 @@ describe('Node Scope', () => {
         <InfiniteScroller />
       </div>
     )
-    const o = wrapper.find(InfiniteScroller).node
-    const d = wrapper.find('.derlict').node
+    const o = wrapper.find(InfiniteScroller).getNode()
+    const d = wrapper.find('.derlict').getNode()
 
     expect(o.state.nodeScope).toBe(d)
   })
@@ -60,8 +60,8 @@ describe('scrollParent', () => {
         <InfiniteScroller />
       </div>
     )
-    const o = wrapper.find(InfiniteScroller).node
-    const d = wrapper.find('.derlict').node
+    const o = wrapper.find(InfiniteScroller).getNode()
+    const d = wrapper.find('.derlict').getNode()
 
     expect(o.state.nodeScope).toBe(d)
   })
@@ -75,7 +75,7 @@ describe('scrollParent', () => {
         <InfiniteScroller scrollParent={node} />
       </div>
     )
-    const o = wrapper.find(InfiniteScroller).node
+    const o = wrapper.find(InfiniteScroller).getNode()
 
     expect(o.state.nodeScope).toBe(node)
     expect(o.state.nodeScope.id).toBe('hansel')
@@ -112,9 +112,9 @@ describe('scrollParent', () => {
     const wrapper = mount(<CustomModal />)
 
     const o = wrapper.find('.custom-scroller')
-    const n = wrapper.find(InfiniteScroller).node
+    const n = wrapper.find(InfiniteScroller).getNode()
 
-    o.node.dispatchEvent(scrollEvent)
+    o.getNode().dispatchEvent(scrollEvent)
 
     expect(n.state.nodeScope).toBe(o.node)
     expect(spy).toHaveBeenCalled()
@@ -151,9 +151,9 @@ describe('scrollParent', () => {
     const wrapper = mount(<CustomModal />)
 
     const o = wrapper.find('.outer')
-    const n = wrapper.find(InfiniteScroller).node
+    const n = wrapper.find(InfiniteScroller).getNode()
 
-    o.node.dispatchEvent(scrollEvent)
+    o.getNode().dispatchEvent(scrollEvent)
 
     expect(n.state.nodeScope).toBe(o.node)
     expect(spy).toHaveBeenCalled()
@@ -172,7 +172,7 @@ describe('Loading', () => {
     const o = wrapper.find(LoadingDots)
 
     expect(o.length).toBe(1)
-    expect(o.node.props.align).toBe('center')
+    expect(o.getNode().props.align).toBe('center')
   })
 
   test('Can render custom loading markup', () => {
@@ -332,7 +332,7 @@ describe('Integration: Modal', () => {
     )
     const o = wrapper.find('.c-Scrollable__content')
 
-    o.node.dispatchEvent(scrollEvent)
+    o.getNode().dispatchEvent(scrollEvent)
 
     expect(spy).toHaveBeenCalled()
   })

--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -50,6 +50,7 @@ An Input component is an enhanced version of the default HTML `<input>`. Input c
 | readOnly                 | `bool`               | Disable editing of the input.                                             |
 | removeStateStylesOnFocus | `bool`               | Removes the `state` styles on input focus. Default `false`.               |
 | resizable                | `bool`               | Enables resizing for the textarea (only enabled for `multiline`).         |
+| scrollLock               | `bool`               | Enables scrollLock for component. Default `false`.                        |
 | seamless                 | `bool`               | Removes the border around the input.                                      |
 | size                     | `string`             | Determines the size of the input.                                         |
 | state                    | `string`             | Change input to state color.                                              |

--- a/src/components/Input/Resizer.js
+++ b/src/components/Input/Resizer.js
@@ -20,7 +20,7 @@ const REPLACE_REGEX = /[\n&<>]/g
 type Props = {
   className?: string,
   contents: string,
-  currentHeight: number,
+  currentHeight: ?number,
   minimumLines: number,
   offsetAmount: number,
   onResize: (size: number) => void,

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -91,10 +91,20 @@ describe('Events', () => {
     expect(spy).toHaveBeenCalledWith(value)
   })
 
-  test('onWheel callback can be triggered', () => {
+  test('onWheel callback does not trigger for non-multiline inputs', () => {
     const spy = jest.fn()
-    const wrapper = mount(<Input onWheel={spy} />)
+    const wrapper = mount(<Input onWheel={spy} multiline={false} />)
     const input = wrapper.find('input')
+
+    input.simulate('wheel')
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  test('onWheel callback only triggers for multiline + scrollLock enabled inputs', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Input onWheel={spy} multiline={true} scrollLock />)
+    const input = wrapper.find('textarea')
 
     input.simulate('wheel')
 
@@ -103,8 +113,8 @@ describe('Events', () => {
 
   test('onWheel callback stops event from bubbling', () => {
     const spy = jest.fn()
-    const wrapper = mount(<Input />)
-    const input = wrapper.find('input')
+    const wrapper = mount(<Input multiline={true} scrollLock />)
+    const input = wrapper.find('textarea')
 
     input.simulate('wheel', {
       stopPropagation: spy,

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -189,21 +189,21 @@ describe('Multiline', () => {
     const wrapper = shallow(<Input />)
     const o = wrapper.find(ui.field)
 
-    expect(o.node.type).toBe('input')
+    expect(o.getNode().type).toBe('input')
   })
 
   test('Selector becomes a textarea if multiline is defined', () => {
     const wrapper = shallow(<Input multiline />)
     const o = wrapper.find(ui.field)
 
-    expect(o.node.type).toBe('textarea')
+    expect(o.getNode().type).toBe('textarea')
   })
 
   test('Accepts number argument', () => {
     const wrapper = mount(<Input multiline={5} />)
     const o = wrapper.find(ui.field)
 
-    expect(o.node.type).toBe('textarea')
+    expect(o.getNode().type).toBe('textarea')
   })
 
   test('Adds Resizer component if multiline is defined', () => {
@@ -264,6 +264,17 @@ describe('Multiline', () => {
     const o = wrapper.find(ui.field)
 
     expect(o.prop('style').maxHeight).toBe('50vh')
+  })
+
+  test('Does not focus input on resize', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Input multiline={3} maxHeight="50vh" />)
+    const o = wrapper.find(ui.field)
+    o.getNode().onfocus = spy
+
+    wrapper.instance().handleExpandingResize()
+
+    expect(spy).not.toHaveBeenCalled()
   })
 })
 
@@ -478,14 +489,14 @@ describe('inputNode', () => {
   test('Sets inputNode on mount', () => {
     const wrapper = mount(<Input />)
 
-    expect(wrapper.node.inputNode).toBeTruthy()
+    expect(wrapper.getNode().inputNode).toBeTruthy()
   })
 
   test('Unsets inputNode on unmount', () => {
     const wrapper = mount(<Input />)
     wrapper.unmount()
 
-    expect(wrapper.node.inputNode).not.toBeTruthy()
+    expect(wrapper.getNode().inputNode).not.toBeTruthy()
   })
 })
 
@@ -493,7 +504,7 @@ describe('isFocused', () => {
   test('Can focus input using isFocused prop', done => {
     const spy = jest.fn()
     const wrapper = mount(<Input isFocused />)
-    const o = wrapper.node.inputNode
+    const o = wrapper.getNode().inputNode
     o.onfocus = spy
 
     setTimeout(() => {
@@ -505,7 +516,7 @@ describe('isFocused', () => {
   test('Can focus input using custom timeout', done => {
     const spy = jest.fn()
     const wrapper = mount(<Input isFocused forceAutoFocusTimeout={20} />)
-    const o = wrapper.node.inputNode
+    const o = wrapper.getNode().inputNode
     o.onfocus = spy
 
     expect(spy).not.toHaveBeenCalled()
@@ -521,7 +532,7 @@ describe('isFocused', () => {
     const wrapper = mount(
       <Input onFocus={spy} isFocused={false} forceAutoFocusTimeout={20} />
     )
-    const o = wrapper.node.inputNode
+    const o = wrapper.getNode().inputNode
     o.onfocus = spy
 
     wrapper.setProps({ isFocused: true })
@@ -538,7 +549,7 @@ describe('moveCursorToEnd', () => {
     const value = 'ron'
     const wrapper = mount(<Input value="WEE" />)
     wrapper.setState({ value: 'WEE' })
-    wrapper.node.moveCursorToEnd()
-    // console.log(wrapper.node.inputNode.selectionStart)
+    wrapper.getNode().moveCursorToEnd()
+    // console.log(wrapper.getNode().inputNode.selectionStart)
   })
 })

--- a/src/components/Input/__tests__/Resizer.test.js
+++ b/src/components/Input/__tests__/Resizer.test.js
@@ -110,14 +110,14 @@ describe('Styles', () => {
 describe('offsetAmount', () => {
   test('Adds offsetChars, if specified', () => {
     const wrapper = mount(<Resizer offsetAmount={5} />)
-    const chars = wrapper.node.getFinalContents('words')
+    const chars = wrapper.instance().getFinalContents('words')
 
     expect(chars).toContain('RRRRR')
   })
 
   test('Does not add offsetChars, if specified', () => {
     const wrapper = mount(<Resizer offsetAmount={0} />)
-    const chars = wrapper.node.getFinalContents('words')
+    const chars = wrapper.instance().getFinalContents('words')
 
     expect(chars).not.toContain('R')
   })

--- a/src/components/Input/helpers.js
+++ b/src/components/Input/helpers.js
@@ -1,5 +1,4 @@
 // @flow
-
 type InputNode = HTMLInputElement | HTMLTextAreaElement
 
 /**
@@ -8,7 +7,7 @@ type InputNode = HTMLInputElement | HTMLTextAreaElement
  * @param   {InputNode} textarea
  * @returns {number}
  */
-export const getTextAreaLineTotal = (textarea: HTMLTextAreaElement): number => {
+export const getTextAreaLineTotal = (textarea: ?InputNode): number => {
   if (!textarea) return 0
   return textarea.value.split(/\r*\n/).length
 }
@@ -19,9 +18,7 @@ export const getTextAreaLineTotal = (textarea: HTMLTextAreaElement): number => {
  * @param   {InputNode} textarea
  * @returns {number}
  */
-export const getTextAreaLineCurrent = (
-  textarea: HTMLTextAreaElement
-): number => {
+export const getTextAreaLineCurrent = (textarea: ?InputNode): number => {
   if (!textarea) return 0
   return textarea.value.substr(0, textarea.selectionStart).split('\n').length
 }
@@ -32,7 +29,9 @@ export const getTextAreaLineCurrent = (
  *
  * @param   {InputNode} inputNode
  */
-export const moveCursorToEnd = (input: HTMLInputElement) => {
+export const moveCursorToEnd = (input: ?HTMLInputElement) => {
+  // Extra failsafe guard
+  if (!input) return
   if (typeof input.selectionStart === 'number') {
     input.selectionStart = input.selectionEnd = input.value.length
   } else if (typeof input.createTextRange !== 'undefined') {

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -46,8 +46,9 @@ type Props = {
   removeStateStylesOnFocus: boolean,
   resizable: boolean,
   seamless: boolean,
+  scrollLock: boolean,
   size: UISizes,
-  state: UIStates,
+  state?: ?UIStates,
   style: Object,
   suffix: string,
   type: string,
@@ -67,7 +68,7 @@ class Input extends Component<Props, State> {
   static defaultProps = {
     autoFocus: false,
     disabled: false,
-    forceAutoFocusTimeout: 120,
+    forceAutoFocusTimeout: 0,
     inputRef: noop,
     isFocused: false,
     moveCursorToEnd: true,
@@ -80,14 +81,16 @@ class Input extends Component<Props, State> {
     readOnly: false,
     removeStateStylesOnFocus: false,
     resizable: false,
+    scrollLock: false,
     seamless: false,
+    state: '',
     type: 'text',
     value: '',
   }
   static Backdrop = Backdrop
   static Resizer = Resizer
   static Static = Static
-  inputNode: InputNode
+  inputNode: ?InputNode
 
   constructor(props: Props) {
     super()
@@ -182,8 +185,10 @@ class Input extends Component<Props, State> {
     onFocus(event)
   }
 
-  handleOnWheel = (event: Event) => {
-    const { onWheel } = this.props
+  handleOnWheel = (event: WheelEvent) => {
+    const { multiline, onWheel, scrollLock } = this.props
+    if (!multiline || !scrollLock) return
+
     const stopPropagation = true
     scrollLockY(event, stopPropagation)
     onWheel(event)
@@ -235,6 +240,7 @@ class Input extends Component<Props, State> {
       removeStateStylesOnFocus,
       resizable,
       seamless,
+      scrollLock,
       size,
       state: stateProp,
       style: styleProp,

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -196,7 +196,6 @@ class Input extends Component<Props, State> {
 
   handleExpandingResize = (height: number) => {
     this.setState({ height })
-    this.forceAutoFocus()
   }
 
   moveCursorToEnd = () => {

--- a/src/components/Label/index.js
+++ b/src/components/Label/index.js
@@ -10,7 +10,7 @@ type Props = {
   className?: string,
   children?: any,
   for: string,
-  state: UIStates,
+  state?: UIStates,
 }
 
 const Label = (props: Props) => {

--- a/src/components/Link/__tests__/Link.test.js
+++ b/src/components/Link/__tests__/Link.test.js
@@ -148,7 +148,7 @@ describe('RouteWrapper', () => {
       </Link>,
       options
     )
-    expect(wrapper.node.type).toBe('a')
+    expect(wrapper.getNode().type).toBe('a')
     wrapper.simulate('click', clickEvent)
     expect(preventDefault).toHaveBeenCalled()
     setTimeout(() => {

--- a/src/components/List/tests/List.test.js
+++ b/src/components/List/tests/List.test.js
@@ -13,7 +13,7 @@ describe('Defaults', () => {
   test('Renders an ul by default', () => {
     const wrapper = shallow(<List />)
 
-    expect(wrapper.node.type).toBe('ul')
+    expect(wrapper.getNode().type).toBe('ul')
   })
 })
 
@@ -57,7 +57,7 @@ describe('Bullet', () => {
   test('Renders a ol if type is "bullet"', () => {
     const wrapper = shallow(<List type="bullet" />)
 
-    expect(wrapper.node.type).toBe('ul')
+    expect(wrapper.getNode().type).toBe('ul')
     expect(wrapper.hasClass('c-List--bullet')).toBeTruthy()
   })
 })
@@ -66,7 +66,7 @@ describe('Inline', () => {
   test('Renders a ul if type is "inline"', () => {
     const wrapper = shallow(<List type="inline" />)
 
-    expect(wrapper.node.type).toBe('ul')
+    expect(wrapper.getNode().type).toBe('ul')
     expect(wrapper.hasClass('c-List--inline')).toBeTruthy()
   })
 })
@@ -83,7 +83,7 @@ describe('Number', () => {
   test('Renders a ol if type is "number"', () => {
     const wrapper = shallow(<List type="number" />)
 
-    expect(wrapper.node.type).toBe('ol')
+    expect(wrapper.getNode().type).toBe('ol')
     expect(wrapper.hasClass('c-List--number')).toBeTruthy()
   })
 })

--- a/src/components/Message/__tests__/Action.test.js
+++ b/src/components/Message/__tests__/Action.test.js
@@ -43,7 +43,7 @@ describe('ChatBlock', () => {
 
   test('Passes correct props to ChatBlock', () => {
     const wrapper = shallow(<Action from to read ltr rtl timestamp="time" />)
-    const props = wrapper.find(ChatBlock).node.props
+    const props = wrapper.find(ChatBlock).getNode().props
 
     expect(props.from).toBeTruthy()
     expect(props.to).toBeTruthy()
@@ -60,7 +60,7 @@ describe('Content', () => {
     const o = wrapper.find(Text)
 
     expect(o.length).toBeTruthy()
-    expect(o.node.props.children).toBe('Relax')
+    expect(o.getNode().props.children).toBe('Relax')
   })
 })
 

--- a/src/components/Message/__tests__/Bubble.test.js
+++ b/src/components/Message/__tests__/Bubble.test.js
@@ -33,7 +33,7 @@ describe('Title', () => {
 
     expect(o.length).toBe(1)
     expect(o.hasClass('c-MessageBubble__title')).toBeTruthy()
-    expect(o.node.props.children).toContain('Mugatu')
+    expect(o.getNode().props.children).toContain('Mugatu')
   })
 })
 
@@ -67,8 +67,8 @@ describe('Content', () => {
     const o = wrapper.find(Text)
 
     expect(o.length).toBe(1)
-    expect(o.node.props.wordWrap).toBeTruthy()
-    expect(o.node.props.children).toBe('Mugatu')
+    expect(o.getNode().props.wordWrap).toBeTruthy()
+    expect(o.getNode().props.children).toBe('Mugatu')
   })
 
   test('Span-based content is contained with a wordWrapped Text component', () => {

--- a/src/components/Message/__tests__/Chat.test.js
+++ b/src/components/Message/__tests__/Chat.test.js
@@ -46,7 +46,7 @@ describe('Bubble', () => {
     const wrapper = shallow(<Chat>Mugatu</Chat>)
     const o = wrapper.find(Bubble)
 
-    expect(o.node.props.children).toBe('Mugatu')
+    expect(o.getNode().props.children).toBe('Mugatu')
   })
 
   test('Passes correct props to Bubble', () => {
@@ -64,7 +64,7 @@ describe('Bubble', () => {
         typing
       />
     )
-    const props = wrapper.find(Bubble).node.props
+    const props = wrapper.find(Bubble).getNode().props
 
     expect(props.body).toBeTruthy()
     expect(props.from).toBeTruthy()
@@ -96,7 +96,7 @@ describe('ChatBlock', () => {
 
   test('Passes correct props to ChatBlock', () => {
     const wrapper = shallow(<Chat from to read ltr rtl timestamp="time" />)
-    const props = wrapper.find(ChatBlock).node.props
+    const props = wrapper.find(ChatBlock).getNode().props
 
     expect(props.from).toBeTruthy()
     expect(props.to).toBeTruthy()

--- a/src/components/Message/__tests__/ChatBlock.test.js
+++ b/src/components/Message/__tests__/ChatBlock.test.js
@@ -66,7 +66,7 @@ describe('Content', () => {
     const o = wrapper.find(`.${cx}__block`)
 
     expect(o.length).toBeTruthy()
-    expect(o.node.innerHTML).toContain('Mugatu')
+    expect(o.getNode().innerHTML).toContain('Mugatu')
   })
 
   test('Enhances Action child component', () => {

--- a/src/components/Message/__tests__/Content.test.js
+++ b/src/components/Message/__tests__/Content.test.js
@@ -42,7 +42,7 @@ describe('ChatBlock', () => {
 
   test('Passes correct props to ChatBlock', () => {
     const wrapper = shallow(<Content from to read ltr rtl timestamp="time" />)
-    const props = wrapper.find(ChatBlock).node.props
+    const props = wrapper.find(ChatBlock).getNode().props
 
     expect(props.from).toBeTruthy()
     expect(props.to).toBeTruthy()

--- a/src/components/Message/__tests__/Media.test.js
+++ b/src/components/Message/__tests__/Media.test.js
@@ -57,7 +57,7 @@ describe('Chat', () => {
         to
       />
     )
-    const props = wrapper.find(Chat).node.props
+    const props = wrapper.find(Chat).getNode().props
 
     expect(props.from).toBeTruthy()
     expect(props.isNote).toBeTruthy()

--- a/src/components/Message/__tests__/Provider.test.js
+++ b/src/components/Message/__tests__/Provider.test.js
@@ -9,11 +9,11 @@ test('Provides child components with props as context', () => {
       <Message />
     </Provider>
   )
-  let o = wrapper.find(Message).node
+  let o = wrapper.find(Message).getNode()
   expect(o.context.theme).toBe('embed')
 
   wrapper.setProps({ theme: 'admin' })
-  o = wrapper.find(Message).node
+  o = wrapper.find(Message).getNode()
 
   expect(o.context.theme).toBe('admin')
 })

--- a/src/components/Modal/tests/Body.test.js
+++ b/src/components/Modal/tests/Body.test.js
@@ -64,7 +64,7 @@ describe('Scrollable', () => {
 
   test('Can pass scrollableRef to parent', () => {
     const wrapper = mount(<MyComponent />)
-    const n = wrapper.find('.c-Scrollable__content').node
+    const n = wrapper.find('.c-Scrollable__content').getNode()
     const o = wrapper.instance()
 
     expect(o.scrollable).toBe(n)
@@ -75,7 +75,7 @@ describe('Scrollable', () => {
     const wrapper = mount(<MyComponent onScroll={spy} />)
     const o = wrapper.find(Scrollable)
 
-    o.node.props.onScroll()
+    o.getNode().props.onScroll()
 
     expect(spy).toHaveBeenCalled()
   })

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -174,7 +174,7 @@ describe('Route', () => {
 
     wait()
       .then(() => {
-        wrapper.node.history.goBack()
+        wrapper.getNode().history.goBack()
       })
       .then(() => wait(60))
       .then(() => {
@@ -703,7 +703,7 @@ describe('Keyboard: Tab', () => {
         <button className="three">three</button>
       </ModalComponent>
     )
-    const o = wrapper.find('.three').node
+    const o = wrapper.find('.three').getNode()
 
     wrapper.instance().handleOnTab({
       target: o,
@@ -722,7 +722,7 @@ describe('Keyboard: Tab', () => {
         <button className="three">three</button>
       </ModalComponent>
     )
-    const o = wrapper.find('.two').node
+    const o = wrapper.find('.two').getNode()
 
     wrapper.instance().handleOnTab({
       target: o,
@@ -751,7 +751,7 @@ describe('Keyboard: Tab', () => {
         <button className="three">three</button>
       </ModalComponent>
     )
-    const o = wrapper.find('.one').node
+    const o = wrapper.find('.one').getNode()
 
     wrapper.instance().handleOnShiftTab({
       target: o,
@@ -770,7 +770,7 @@ describe('Keyboard: Tab', () => {
         <button className="three">three</button>
       </ModalComponent>
     )
-    const o = wrapper.find('.two').node
+    const o = wrapper.find('.two').getNode()
 
     wrapper.instance().handleOnShiftTab({
       target: o,

--- a/src/components/Notification/tests/Notification.test.js
+++ b/src/components/Notification/tests/Notification.test.js
@@ -160,7 +160,7 @@ describe('setState', () => {
     const wrapper = mount(<Notification />)
     wrapper.unmount()
 
-    expect(wrapper.node._isMounted).toBe(false)
+    expect(wrapper.getNode()._isMounted).toBe(false)
   })
 
   test('Only sets state if mounted', () => {

--- a/src/components/NotificationStack/tests/NotificationStack.test.js
+++ b/src/components/NotificationStack/tests/NotificationStack.test.js
@@ -134,7 +134,7 @@ describe('NotificationID', () => {
       </NotificationStack>
     )
 
-    expect(wrapper.node.firstNotificationId).toBe(23)
+    expect(wrapper.getNode().firstNotificationId).toBe(23)
   })
 
   test('Keeps Notification ID, even if children are removed', () => {
@@ -150,7 +150,7 @@ describe('NotificationID', () => {
       children: [<Notification id={41} />, <Notification id={42} />],
     })
 
-    expect(wrapper.node.firstNotificationId).toBe(23)
+    expect(wrapper.getNode().firstNotificationId).toBe(23)
   })
 
   test('Clears Notification ID onNotificationClick', () => {
@@ -168,7 +168,7 @@ describe('NotificationID', () => {
       .props()
       .onBubbleClick()
 
-    expect(wrapper.node.firstNotificationId).toBeFalsy()
+    expect(wrapper.getNode().firstNotificationId).toBeFalsy()
   })
 })
 

--- a/src/components/Overflow/__tests__/Overflow.test.js
+++ b/src/components/Overflow/__tests__/Overflow.test.js
@@ -139,7 +139,7 @@ describe('adjustHeight', () => {
   test('Method fires on mount', () => {
     const wrapper = mount(<Overflow />)
     const spy = jest.fn()
-    wrapper.node.adjustHeight = spy
+    wrapper.getNode().adjustHeight = spy
 
     wrapper.instance().componentDidMount()
 
@@ -168,7 +168,7 @@ describe('scrollableRef', () => {
 
   test('Can pass scrollableRef to parent', () => {
     const wrapper = mount(<MyComponent />)
-    const n = wrapper.find('.c-Overflow__container').node
+    const n = wrapper.find('.c-Overflow__container').getNode()
     const o = wrapper.instance()
 
     expect(o.scrollable).toBe(n)

--- a/src/components/Pop/__tests__/Pop.test.js
+++ b/src/components/Pop/__tests__/Pop.test.js
@@ -80,11 +80,11 @@ describe('Pop', () => {
         </Pop>
       )
 
-      expect(wrapper.node.node).toBeTruthy()
+      expect(wrapper.getNode().node).toBeTruthy()
 
       wrapper.unmount()
 
-      expect(wrapper.node.node).toBeFalsy()
+      expect(wrapper.getNode().node).toBeFalsy()
     })
   })
 

--- a/src/components/Pop/__tests__/Popper.test.js
+++ b/src/components/Pop/__tests__/Popper.test.js
@@ -36,11 +36,11 @@ describe('Popper', () => {
     test('Nullifies Portal on unmount', () => {
       const wrapper = mount(<Popper />)
 
-      expect(wrapper.node.portal).toBeTruthy()
+      expect(wrapper.getNode().portal).toBeTruthy()
 
       wrapper.unmount()
 
-      expect(wrapper.node.portal).not.toBeTruthy()
+      expect(wrapper.getNode().portal).not.toBeTruthy()
     })
   })
 

--- a/src/components/Pop/__tests__/Reference.test.js
+++ b/src/components/Pop/__tests__/Reference.test.js
@@ -49,7 +49,7 @@ describe('Manager', () => {
       </Manager>
     )
     const man = wrapper.find(Manager)
-    const el = wrapper.find('span').node
+    const el = wrapper.find('span').getNode()
 
     expect(man.node.state.context.referenceNode).toBe(el)
   })

--- a/src/components/PortalWrapper/tests/PortalWrapper.test.js
+++ b/src/components/PortalWrapper/tests/PortalWrapper.test.js
@@ -108,11 +108,11 @@ describe('Manager', () => {
 
     wait()
       .then(() => {
-        o.node.closePortal()
+        o.getNode().closePortal()
       })
       .then(() => wait())
       .then(() => {
-        expect(o.node.state.isOpen).toBe(false)
+        expect(o.getNode().state.isOpen).toBe(false)
         done()
       })
   })
@@ -128,8 +128,8 @@ describe('Manager', () => {
     )
     const o = wrapper.find(TestComponent).first()
 
-    o.node.closePortal()
-    expect(o.node.state.isOpen).toBe(true)
+    o.getNode().closePortal()
+    expect(o.getNode().state.isOpen).toBe(true)
   })
 })
 
@@ -285,7 +285,7 @@ describe('Trigger', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     const trigger = <button>Trigger</button>
     const wrapper = mount(<TestComponent timeout={0} trigger={trigger} />)
-    const o = wrapper.node
+    const o = wrapper.getNode()
 
     expect(o.triggerComponent).toBeTruthy()
     expect(o.triggerNode).toBeTruthy()
@@ -295,7 +295,7 @@ describe('Trigger', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     const trigger = <button>Trigger</button>
     const wrapper = mount(<TestComponent timeout={0} trigger={trigger} />)
-    const o = wrapper.node
+    const o = wrapper.getNode()
 
     wrapper.unmount()
 
@@ -308,7 +308,7 @@ describe('Trigger', () => {
     const trigger = <button>Trigger</button>
     const wrapper = mount(<TestComponent timeout={0} trigger={trigger} />)
     const o = wrapper.find('button')
-    o.node.onfocus = spy
+    o.getNode().onfocus = spy
     wrapper.setProps({ isOpen: false })
 
     setTimeout(() => {
@@ -325,7 +325,7 @@ describe('Trigger', () => {
       <TestComponent timeout={0} trigger={trigger} isOpen />
     )
     const o = wrapper.find('button')
-    o.node.onfocus = spy
+    o.getNode().onfocus = spy
     wrapper.setProps({ isOpen: false })
 
     setTimeout(() => {

--- a/src/components/PreviewCard/__tests__/PreviewCard.test.js
+++ b/src/components/PreviewCard/__tests__/PreviewCard.test.js
@@ -36,7 +36,7 @@ describe('Title', () => {
 
     expect(o.length).toBeTruthy()
     expect(o.hasClass('c-PreviewCard__title')).toBeTruthy()
-    expect(o.node.props.children).toBe('Mugatu')
+    expect(o.getNode().props.children).toBe('Mugatu')
   })
 })
 
@@ -47,6 +47,6 @@ describe('Text', () => {
 
     expect(o.length).toBeTruthy()
     expect(o.hasClass('c-PreviewCard__content')).toBeTruthy()
-    expect(o.node.props.children).toBe('Relax')
+    expect(o.getNode().props.children).toBe('Relax')
   })
 })

--- a/src/components/RouteWrapper/__tests__/RouteWrapper.test.js
+++ b/src/components/RouteWrapper/__tests__/RouteWrapper.test.js
@@ -41,7 +41,7 @@ describe('Route fetching', () => {
     }
     const to = 'some/route'
     const wrapper = wrap(<RouteWrappedPig fetch={fetch} to={to} />, options)
-    expect(wrapper.node.type).toBe('div')
+    expect(wrapper.getNode().type).toBe('div')
     wrapper.simulate('click', clickEvent)
     expect(preventDefault).toHaveBeenCalled()
     setTimeout(() => {
@@ -53,7 +53,7 @@ describe('Route fetching', () => {
   test('Specifying a `to` but no `fetch()` routes correctly', done => {
     const to = 'some/other/route'
     const wrapper = wrap(<RouteWrappedPig to={to} />, options)
-    expect(wrapper.node.type).toBe('div')
+    expect(wrapper.getNode().type).toBe('div')
     wrapper.simulate('click', clickEvent)
     expect(preventDefault).toHaveBeenCalled()
     setTimeout(() => {

--- a/src/components/ScrollLock/index.js
+++ b/src/components/ScrollLock/index.js
@@ -12,13 +12,15 @@ type Props = {
   onWheel: (event: ScrollWheelEvent) => void,
 }
 
-type ScrollWheelEvent = {
-  currentTarget: HTMLDivElement,
-  deltaX: number,
-  deltaY: number,
-  preventDefault: () => void,
-  stopPropagation: () => void,
-}
+type ScrollWheelEvent =
+  | {
+      currentTarget: HTMLDivElement,
+      deltaX: number,
+      deltaY: number,
+      preventDefault: () => void,
+      stopPropagation: () => void,
+    }
+  | WheelEvent
 
 class ScrollLock extends Component<Props> {
   static defaultProps = {

--- a/src/components/Scrollable/tests/Scrollable.test.js
+++ b/src/components/Scrollable/tests/Scrollable.test.js
@@ -163,7 +163,7 @@ describe('scrollableRef', () => {
 
   test('Can pass scrollableRef to parent', () => {
     const wrapper = mount(<MyComponent />)
-    const n = wrapper.find('.c-Scrollable__content').node
+    const n = wrapper.find('.c-Scrollable__content').getNode()
     const o = wrapper.instance()
 
     expect(o.scrollable).toBe(n)

--- a/src/components/Select/tests/Select.test.js
+++ b/src/components/Select/tests/Select.test.js
@@ -410,14 +410,14 @@ describe('selectNode', () => {
   test('Sets selectNode on mount', () => {
     const wrapper = mount(<Select />)
 
-    expect(wrapper.node.selectNode).toBeTruthy()
+    expect(wrapper.getNode().selectNode).toBeTruthy()
   })
 
   test('Unsets selectNode on unmount', () => {
     const wrapper = mount(<Select />)
     wrapper.unmount()
 
-    expect(wrapper.node.selectNode).not.toBeTruthy()
+    expect(wrapper.getNode().selectNode).not.toBeTruthy()
   })
 })
 
@@ -425,7 +425,7 @@ describe('isFocused', () => {
   test('Can focus select using isFocused prop', done => {
     const spy = jest.fn()
     const wrapper = mount(<Select isFocused />)
-    const o = wrapper.node.selectNode
+    const o = wrapper.getNode().selectNode
     o.onfocus = spy
 
     setTimeout(() => {
@@ -437,7 +437,7 @@ describe('isFocused', () => {
   test('Can focus select using custom timeout', done => {
     const spy = jest.fn()
     const wrapper = mount(<Select isFocused forceAutoFocusTimeout={20} />)
-    const o = wrapper.node.selectNode
+    const o = wrapper.getNode().selectNode
     o.onfocus = spy
 
     expect(spy).not.toHaveBeenCalled()
@@ -453,7 +453,7 @@ describe('isFocused', () => {
     const wrapper = mount(
       <Select onFocus={spy} isFocused={false} forceAutoFocusTimeout={20} />
     )
-    const o = wrapper.node.selectNode
+    const o = wrapper.getNode().selectNode
     o.onfocus = spy
 
     wrapper.setProps({ isFocused: true })

--- a/src/components/Sortable/tests/Sortable.test.js
+++ b/src/components/Sortable/tests/Sortable.test.js
@@ -216,7 +216,7 @@ describe('Stateful parent component', () => {
     const items = ['Ron', 'Brick', 'Champ']
     const wrapper = mount(<ParentComponent items={items} />)
     const o = wrapper.find(Sortable)
-    const oldState = o.node.state
+    const oldState = o.getNode().state
 
     expect(wrapper.find('.c-SortableItem').length).toBe(3)
     o.props().onSortEnd()
@@ -224,7 +224,7 @@ describe('Stateful parent component', () => {
     o.props().onSortEnd()
     expect(wrapper.find('.c-SortableItem').length).toBe(5)
 
-    expect(oldState.items).not.toEqual(o.node.state.items)
+    expect(oldState.items).not.toEqual(o.getNode().state.items)
 
     wrapper.unmount()
   })
@@ -234,7 +234,7 @@ describe('Stateful parent component', () => {
     const wrapper = mount(<ParentComponentTwo items={items} />)
     const o = wrapper.find(Sortable)
     const oldWrapperState = wrapper.state()
-    const oldState = o.node.state
+    const oldState = o.getNode().state
 
     expect(wrapper.find('.c-SortableItem').length).toBe(3)
     o.props().onSortEnd()
@@ -245,7 +245,7 @@ describe('Stateful parent component', () => {
     wrapper.setProps({ className: 'news-team' })
 
     expect(oldWrapperState).not.toEqual(wrapper.state())
-    expect(oldState.items).toEqual(o.node.state.items)
+    expect(oldState.items).toEqual(o.getNode().state.items)
 
     wrapper.unmount()
   })
@@ -267,6 +267,6 @@ describe('onSortEnd', () => {
     const wrapper = shallow(<Sortable onSortEnd={spy} />)
     const o = wrapper.find(List)
 
-    expect(o.node.props.onSortEnd).not.toBe(spy)
+    expect(o.getNode().props.onSortEnd).not.toBe(spy)
   })
 })

--- a/src/components/TagList/tests/TagList.test.js
+++ b/src/components/TagList/tests/TagList.test.js
@@ -84,7 +84,7 @@ describe('onRemove', () => {
       </TagList>
     )
     const o = wrapper.find(Tag).first()
-    o.node.handleOnRemove()
+    o.getNode().handleOnRemove()
 
     wait(100).then(() => {
       expect(spy).toHaveBeenCalled()

--- a/src/components/Truncate/__tests__/Truncate.test.js
+++ b/src/components/Truncate/__tests__/Truncate.test.js
@@ -91,14 +91,14 @@ describe('node', () => {
   test('References node on mount', () => {
     const wrapper = mount(<Truncate />)
 
-    expect(wrapper.node.node).toBeTruthy()
+    expect(wrapper.getNode().node).toBeTruthy()
   })
 
   test('Nullifies node on unmount', () => {
     const wrapper = mount(<Truncate />)
     wrapper.unmount()
 
-    expect(wrapper.node.node).not.toBeTruthy()
+    expect(wrapper.getNode().node).not.toBeTruthy()
   })
 })
 
@@ -107,17 +107,17 @@ describe('Truncate: Check', () => {
     const props = { type: 'auto' }
     const wrapper = mount(<Truncate>Words</Truncate>)
 
-    wrapper.node.node = {
+    wrapper.getNode().node = {
       offsetWidth: 100,
       scrollWidth: 1000,
     }
-    expect(wrapper.node.isTruncated(props)).toBe(true)
+    expect(wrapper.getNode().isTruncated(props)).toBe(true)
 
-    wrapper.node.node = {
+    wrapper.getNode().node = {
       offsetWidth: 1000,
       scrollWidth: 100,
     }
-    expect(wrapper.node.isTruncated(props)).toBe(false)
+    expect(wrapper.getNode().isTruncated(props)).toBe(false)
   })
 
   test('Recalculates on appropriate prop change', () => {
@@ -134,9 +134,9 @@ describe('Truncate: Check', () => {
     const wrapper = mount(<Truncate showTooltipOnTruncate>Words</Truncate>)
     wrapper.setState({ isTruncated: false })
     // Stub
-    wrapper.node.isTruncated = () => true
+    wrapper.getNode().isTruncated = () => true
 
-    wrapper.node.handleOnResize()
+    wrapper.getNode().handleOnResize()
 
     expect(wrapper.state().isTruncated).toBe(true)
   })
@@ -148,9 +148,9 @@ describe('Truncate: Check', () => {
     )
     wrapper.setState({ isTruncated: true })
     // Stub
-    wrapper.node.isTruncated = () => true
-    wrapper.node.setState = spy
-    wrapper.node.handleOnResize()
+    wrapper.getNode().isTruncated = () => true
+    wrapper.getNode().setState = spy
+    wrapper.getNode().handleOnResize()
 
     expect(spy).not.toHaveBeenCalled()
   })
@@ -160,15 +160,15 @@ describe('Truncate: Check', () => {
     const wrapper = mount(
       <Truncate showTooltipOnTruncate={false}>Words</Truncate>
     )
-    wrapper.node.setState = spy
-    wrapper.node.handleOnResize()
+    wrapper.getNode().setState = spy
+    wrapper.getNode().handleOnResize()
 
     expect(spy).not.toHaveBeenCalled()
   })
 
   test('Check returns false, if node is somehow not defined', () => {
     const wrapper = mount(<Truncate showTooltipOnTruncate>Words</Truncate>)
-    wrapper.node.node = null
+    wrapper.getNode().node = null
 
     expect(wrapper.state().isTruncated).toBe(false)
   })

--- a/stories/Input.js
+++ b/stories/Input.js
@@ -124,7 +124,14 @@ stories.add('sizes', () => (
   <div>
     <Input autoFocus placeholder="Regular" />
     <br />
-    <Input size="sm" autoFocus placeholder="Small" />
+    <Input size="sm" placeholder="Small" />
+    <br />
+    <Input
+      multiline={3}
+      resizable
+      placeholder="This is a resizable textarea with scrollLock!"
+      maxHeight={150}
+    />
   </div>
 ))
 

--- a/stories/Input.js
+++ b/stories/Input.js
@@ -109,6 +109,17 @@ stories.add('states', () => (
   </div>
 ))
 
+stories.add('scrollock', () => (
+  <Input
+    multiline={3}
+    resizable
+    autoFocus
+    scrollLock
+    placeholder="This is a resizable textarea with scrollLock!"
+    maxHeight={150}
+  />
+))
+
 stories.add('sizes', () => (
   <div>
     <Input autoFocus placeholder="Regular" />

--- a/test/acceptance/components/Modal/Modal.spec.js
+++ b/test/acceptance/components/Modal/Modal.spec.js
@@ -85,7 +85,7 @@ describe('Open/Close', () => {
         expect($('.modal').length).toBe(1)
       })
       .then(() => {
-        wrapper.node.history.goBack()
+        wrapper.getNode().history.goBack()
       })
       .then(() => wait(100))
       .then(() => {
@@ -106,7 +106,7 @@ describe('Open/Close', () => {
       </Router>
     )
 
-    wrapper.node.history.goBack()
+    wrapper.getNode().history.goBack()
 
     wait(100)
       .then(() => {


### PR DESCRIPTION
## Input: ScrollLock and cursor focus ☸️ 

This update improves the UX of the `Input` component by disabling scrollLocking
by default, and only enabling it for `textarea` rendered elements.

It also improves the cursor focus mechanism to only proceed if an Input node
element is provided.