### PR TITLE
Change refApplySubmit to refApplyCallStopTyping

### DIFF
--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -50,7 +50,7 @@ An Input component is an enhanced version of the default HTML `<input>`. Input c
 | placeholder              | `string`             | Placeholder text for the input.                                           |
 | prefix                   | `string`             | Text to appear before the input.                                          |
 | readOnly                 | `bool`               | Disable editing of the input.                                             |
-| refApplySubmit           | `function`           | A function that can be passed from the outside on submit.                 |
+| refApplyCallStopTyping   | `function`           | Exposes `CallStopTyping`, so that it can be called outside itself.        |
 | removeStateStylesOnFocus | `bool`               | Removes the `state` styles on input focus. Default `false`.               |
 | resizable                | `bool`               | Enables resizing for the textarea (only enabled for `multiline`).         |
 | scrollLock               | `bool`               | Enables scrollLock for component. Default `false`.                        |

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -576,7 +576,7 @@ describe('Typing events', () => {
       <Input
         onStartTyping={spies.onStartTyping}
         onStopTyping={spies.onStopTyping}
-        refApplySubmit={fn => (refs.applySubmit = fn)}
+        refApplyCallStopTyping={fn => (refs.applySubmit = fn)}
         typingTimeoutDelay={3000}
         withTypingEvent={true}
       />
@@ -642,7 +642,7 @@ describe('Typing events', () => {
     expect(clearTimeout).toHaveBeenCalledTimes(1)
   })
 
-  test('Should call callStopTyping on refApplySubmit', () => {
+  test('Should call callStopTyping on refApplyCallStopTyping', () => {
     wrapper.find('input').simulate('change')
     expect(spies.callStartTyping).toHaveBeenCalledTimes(1)
     expect(spies.clearTypingTimeout).toHaveBeenCalledTimes(0)

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -49,7 +49,7 @@ type Props = {
   placeholder: string,
   prefix: string,
   readOnly: boolean,
-  refApplySubmit: (event: SubmitEvent) => void,
+  refApplyCallStopTyping: (event: SubmitEvent) => void,
   removeStateStylesOnFocus: boolean,
   resizable: boolean,
   seamless: boolean,
@@ -88,7 +88,7 @@ class Input extends Component<Props, State> {
     onStopTyping: noop,
     onWheel: noop,
     readOnly: false,
-    refApplySubmit: noop,
+    refApplyCallStopTyping: noop,
     removeStateStylesOnFocus: false,
     resizable: false,
     scrollLock: false,
@@ -118,7 +118,7 @@ class Input extends Component<Props, State> {
   componentDidMount() {
     this.maybeForceAutoFocus()
     this.props.withTypingEvent &&
-      this.props.refApplySubmit(this.callStopTyping.bind(this))
+      this.props.refApplyCallStopTyping(this.callStopTyping.bind(this))
   }
 
   componentWillReceiveProps(nextProps: Props) {
@@ -299,7 +299,7 @@ class Input extends Component<Props, State> {
       placeholder,
       prefix,
       readOnly,
-      refApplySubmit,
+      refApplyCallStopTyping,
       removeStateStylesOnFocus,
       resizable,
       seamless,

--- a/stories/Input.js
+++ b/stories/Input.js
@@ -141,7 +141,7 @@ stories.add('value', () => (
   </div>
 ))
 
-let applySubmit
+let applyCallStopTyping
 
 stories.add('onStartTyping', () => {
   return (
@@ -151,11 +151,11 @@ stories.add('onStartTyping', () => {
         onStartTyping={() => console.log('typing started')}
         onStopTyping={() => console.log('typing stopped')}
         placeholder="Regular"
-        refApplySubmit={fn => (applySubmit = fn)}
+        refApplyCallStopTyping={fn => (applyCallStopTyping = fn)}
         typingTimeoutDelay={4000}
         withTypingEvent={true}
       />
-      <Button onClick={() => applySubmit()}>Apply Submit</Button>
+      <Button onClick={() => applyCallStopTyping()}>Apply Stop Typing</Button>
     </div>
   )
 })


### PR DESCRIPTION
This update changes the naming of refApplySubmit to the much more accurate name refApplyCallStopTyping.