### PR TITLE
Fixes onStopTyping so it doesn't fire if there is no timeout

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -190,8 +190,11 @@ class Input extends Component<Props, State> {
   }
 
   callStopTyping() {
-    this.props.onStopTyping()
-    this.clearTypingTimeout()
+    /* istanbul ignore next */
+    if (this.state.typingTimeout) {
+      this.props.onStopTyping()
+      this.clearTypingTimeout()
+    }
   }
 
   clearTypingTimeout() {


### PR DESCRIPTION
This update fixes `onStopTyping` on inputs which should only be called if there is a `timeout` set.