### PR TITLE
Test: Refactor tests to use jest.useFakeTimeout

### DIFF
--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -4,11 +4,10 @@ import { MemoryRouter as Router } from 'react-router'
 import { default as Modal, ModalComponent } from '..'
 import { Card, Portal, Overlay, Scrollable } from '../../index'
 import Keys from '../../../constants/Keys'
-import wait from '../../../tests/helpers/wait'
-
-const MODAL_TEST_TIMEOUT = 400
 
 const trigger = <a className="trigger">Trigger</a>
+
+jest.useFakeTimers()
 
 beforeEach(() => {
   window.BluePortalWrapperGlobalManager = undefined
@@ -47,44 +46,35 @@ describe('Trigger', () => {
 })
 
 describe('Key events', () => {
-  test('Closes modal when ESCAPE is pressed', done => {
+  test('Closes modal when ESCAPE is pressed', () => {
     mount(<Modal isOpen trigger={trigger} />)
 
-    wait(60)
-      .then(() => {
-        const portal = document.body.childNodes[0]
-        const modal = portal.getElementsByClassName('c-Modal')[0]
+    const portal = document.body.childNodes[0]
+    const modal = portal.getElementsByClassName('c-Modal')[0]
 
-        expect(modal).toBeTruthy()
-      })
-      .then(() => {
-        simulateKeyPress(Keys.ESCAPE)
-      })
-      .then(() => wait(MODAL_TEST_TIMEOUT + 200))
-      .then(() => {
-        expect(document.querySelectorAll('.c-Modal').length).toBe(0)
-        done()
-      })
+    expect(modal).toBeTruthy()
+
+    simulateKeyPress(Keys.ESCAPE)
+    jest.runAllTimers()
+
+    expect(document.querySelectorAll('.c-Modal').length).toBe(0)
   })
 })
 
 describe('CloseIcon', () => {
-  test('Does not render closeIcon if specified', done => {
+  test('Does not render closeIcon if specified', () => {
     const wrapper = mount(<Modal isOpen trigger={trigger} closeIcon={false} />)
 
-    wait(60).then(() => {
-      const portal = document.body.childNodes[0]
-      const modal = portal.getElementsByClassName('c-Modal')[0]
-      const closeIcon = modal.getElementsByClassName('c-Modal__close')
+    const portal = document.body.childNodes[0]
+    const modal = portal.getElementsByClassName('c-Modal')[0]
+    const closeIcon = modal.getElementsByClassName('c-Modal__close')
 
-      expect(modal).toBeTruthy()
-      expect(closeIcon.length).toBeFalsy()
-      wrapper.unmount()
-      done()
-    })
+    expect(modal).toBeTruthy()
+    expect(closeIcon.length).toBeFalsy()
+    wrapper.unmount()
   })
 
-  test('Adjusts CloseButton position on mount', done => {
+  test('Adjusts CloseButton position on mount', () => {
     const wrapper = mount(
       <ModalComponent isOpen>
         <Modal.Body />
@@ -92,10 +82,7 @@ describe('CloseIcon', () => {
     )
     const o = wrapper.find('.c-Modal__close')
 
-    wait(200).then(() => {
-      expect(o.html()).toContain('right:')
-      done()
-    })
+    expect(o.html()).toContain('right:')
   })
 })
 
@@ -108,33 +95,25 @@ describe('Portal', () => {
     wrapper.unmount()
   })
 
-  test('Renders at the body', done => {
+  test('Renders at the body', () => {
     const wrapper = mount(<Modal isOpen trigger={trigger} />)
 
-    wait(60).then(() => {
-      const portal = document.body.childNodes[0]
-      const modal = portal.getElementsByClassName('c-Modal')[0]
+    const portal = document.body.childNodes[0]
+    const modal = portal.getElementsByClassName('c-Modal')[0]
 
-      expect(modal).toBeTruthy()
-      expect(document.body.childNodes.length).toBe(1)
-      wrapper.unmount()
-      done()
-    })
+    expect(modal).toBeTruthy()
+    expect(document.body.childNodes.length).toBe(1)
   })
 
-  test('Does not render by default', done => {
+  test('Does not render by default', () => {
     const wrapper = mount(<Modal trigger={trigger} />)
 
-    wait(MODAL_TEST_TIMEOUT).then(() => {
-      expect(document.body.childNodes.length).toBe(0)
-      wrapper.unmount()
-      done()
-    })
+    expect(document.body.childNodes.length).toBe(0)
   })
 })
 
 describe('Route', () => {
-  test('Automatically opens when a route path is defined', done => {
+  test('Automatically opens when a route path is defined', () => {
     const testBody = global.document.createElement('div')
     global.document.body.appendChild(testBody)
 
@@ -148,17 +127,14 @@ describe('Route', () => {
       { attachTo: testBody }
     )
 
-    wait(60).then(() => {
-      const modal = global.document.getElementsByClassName('c-Modal')[0]
+    const modal = global.document.getElementsByClassName('c-Modal')[0]
 
-      expect(modal).toBeTruthy()
+    expect(modal).toBeTruthy()
 
-      wrapper.detach()
-      done()
-    })
+    wrapper.detach()
   })
 
-  test('Automatically opens when a route path changes', done => {
+  test('Automatically opens when a route path changes', () => {
     const testBody = global.document.createElement('div')
     global.document.body.appendChild(testBody)
 
@@ -172,22 +148,15 @@ describe('Route', () => {
       { attachTo: testBody }
     )
 
-    wait()
-      .then(() => {
-        wrapper.getNode().history.goBack()
-      })
-      .then(() => wait(60))
-      .then(() => {
-        const modal = global.document.getElementsByClassName('c-Modal')[0]
+    wrapper.getNode().history.goBack()
+    const modal = global.document.getElementsByClassName('c-Modal')[0]
 
-        expect(modal).toBeTruthy()
+    expect(modal).toBeTruthy()
 
-        wrapper.detach()
-        done()
-      })
+    wrapper.detach()
   })
 
-  test('Does not open when a route path is defined, but not active', done => {
+  test('Does not open when a route path is defined, but not active', () => {
     const testBody = global.document.createElement('div')
     global.document.body.appendChild(testBody)
 
@@ -201,41 +170,33 @@ describe('Route', () => {
       { attachTo: testBody }
     )
 
-    wait(60).then(() => {
-      const modal = global.document.getElementsByClassName('c-Modal')[0]
+    const modal = global.document.getElementsByClassName('c-Modal')[0]
 
-      expect(modal).toBeFalsy()
+    expect(modal).toBeFalsy()
 
-      wrapper.detach()
-      done()
-    })
+    wrapper.detach()
   })
 })
 
 describe('Style', () => {
-  test('Can render extra styles', done => {
+  test('Can render extra styles', () => {
     const style = { background: 'red' }
     const wrapper = mount(
       <Modal isOpen trigger={trigger} closeIcon={false} style={style} />
     )
 
-    wait(60).then(() => {
-      const portal = document.body.childNodes[0]
-      const modal = portal.getElementsByClassName('c-Modal')[0]
+    const portal = document.body.childNodes[0]
+    const modal = portal.getElementsByClassName('c-Modal')[0]
 
-      expect(modal).toBeTruthy()
+    expect(modal).toBeTruthy()
 
-      const html = modal.outerHTML
+    const html = modal.outerHTML
 
-      expect(html).toContain('background')
-      expect(html).toContain('red')
-
-      wrapper.unmount()
-      done()
-    })
+    expect(html).toContain('background')
+    expect(html).toContain('red')
   })
 
-  test('Can render extra styles + zIndex', done => {
+  test('Can render extra styles + zIndex', () => {
     const style = { background: 'red' }
     const wrapper = mount(
       <Modal
@@ -247,48 +208,38 @@ describe('Style', () => {
       />
     )
 
-    wait(60).then(() => {
-      const portal = document.body.childNodes[0]
-      const modal = portal.getElementsByClassName('c-Modal')[0]
+    const portal = document.body.childNodes[0]
+    const modal = portal.getElementsByClassName('c-Modal')[0]
 
-      expect(modal).toBeTruthy()
+    expect(modal).toBeTruthy()
 
-      const html = modal.outerHTML
+    const html = modal.outerHTML
 
-      expect(html).toContain('background')
-      expect(html).toContain('red')
-      expect(html).toContain('z-index')
-      expect(html).toContain('2000')
-      wrapper.unmount()
-      done()
-    })
+    expect(html).toContain('background')
+    expect(html).toContain('red')
+    expect(html).toContain('z-index')
+    expect(html).toContain('2000')
   })
 
-  test('Can render zIndex, without style prop', done => {
+  test('Can render zIndex, without style prop', () => {
     const wrapper = mount(
       <Modal isOpen trigger={trigger} closeIcon={false} zIndex={2000} />
     )
 
-    wait(60).then(() => {
-      const portal = document.body.childNodes[0]
-      const modal = portal.getElementsByClassName('c-Modal')[0]
+    const portal = document.body.childNodes[0]
+    const modal = portal.getElementsByClassName('c-Modal')[0]
 
-      expect(modal).toBeTruthy()
+    expect(modal).toBeTruthy()
 
-      const html = modal.outerHTML
+    const html = modal.outerHTML
 
-      expect(html).toContain('z-index')
-      expect(html).toContain('2000')
-      wrapper.unmount()
-      done()
-    })
+    expect(html).toContain('z-index')
+    expect(html).toContain('2000')
   })
 })
 
 describe('PortalWrapper', () => {
-  jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
-
-  test('onBeforeClose callback works', done => {
+  test('onBeforeClose callback works', () => {
     const testBody = global.document.createElement('div')
     global.document.body.appendChild(testBody)
 
@@ -302,16 +253,11 @@ describe('PortalWrapper', () => {
       attachTo: testBody,
     })
 
-    wait(60)
-      .then(() => {
-        wrapper.unmount()
-      })
-      .then(() => wait(MODAL_TEST_TIMEOUT))
-      .then(() => {
-        expect(mockCallback.mock.calls.length).toBe(1)
-        wrapper.detach()
-        done()
-      })
+    wrapper.unmount()
+    jest.runAllTimers()
+
+    expect(mockCallback.mock.calls.length).toBe(1)
+    wrapper.detach()
   })
 })
 
@@ -344,25 +290,19 @@ describe('Seamless', () => {
 })
 
 describe('wrapperClassName', () => {
-  test('Adds default wrapperClassName', done => {
+  test('Adds default wrapperClassName', () => {
     mount(<Modal isOpen trigger={trigger} />)
 
-    wait(60).then(() => {
-      const o = document.body.childNodes[0]
-      expect(o.className).toContain('c-ModalWrapper')
-      done()
-    })
+    const o = document.body.childNodes[0]
+    expect(o.className).toContain('c-ModalWrapper')
   })
 
-  test('Can customize wrapperClassName', done => {
+  test('Can customize wrapperClassName', () => {
     mount(<Modal isOpen trigger={trigger} wrapperClassName="ron" />)
 
-    wait(60).then(() => {
-      const o = document.body.childNodes[0]
-      expect(o.className).toContain('ron')
-      expect(o.className).toContain('c-ModalWrapper')
-      done()
-    })
+    const o = document.body.childNodes[0]
+    expect(o.className).toContain('ron')
+    expect(o.className).toContain('c-ModalWrapper')
   })
 })
 
@@ -624,37 +564,27 @@ describe('Context', () => {
 })
 
 describe('isOpen', () => {
-  test('Can open wrapped component with isOpen prop change to true', done => {
+  test('Can open wrapped component with isOpen prop change to true', () => {
     const wrapper = mount(<Modal />)
 
-    wait(60)
-      .then(() => {
-        const o = document.body.childNodes[0]
-        expect(o).not.toBeTruthy()
+    const o = document.body.childNodes[0]
+    expect(o).not.toBeTruthy()
 
-        wrapper.setProps({ isOpen: true })
-      })
-      .then(() => wait(MODAL_TEST_TIMEOUT))
-      .then(() => {
-        const o = document.body.childNodes[0]
-        expect(o).toBeTruthy()
-        done()
-      })
+    wrapper.setProps({ isOpen: true })
+    jest.runAllTimers()
+
+    const o2 = document.body.childNodes[0]
+    expect(o2).toBeTruthy()
   })
 
-  test('Can close wrapped component with isOpen prop change to false', done => {
+  test('Can close wrapped component with isOpen prop change to false', () => {
     const wrapper = mount(<Modal isOpen timeout={0} />)
 
-    wait()
-      .then(() => {
-        wrapper.setProps({ isOpen: false })
-      })
-      .then(() => wait(MODAL_TEST_TIMEOUT))
-      .then(() => {
-        const o = document.body.childNodes[0]
-        expect(o).not.toBeTruthy()
-        done()
-      })
+    wrapper.setProps({ isOpen: false })
+    jest.runAllTimers()
+
+    const o = document.body.childNodes[0]
+    expect(o).not.toBeTruthy()
   })
 })
 
@@ -782,16 +712,15 @@ describe('Keyboard: Tab', () => {
 })
 
 describe('Card: Focus', () => {
-  test('Autofocuses card on mount', done => {
+  test('Autofocuses card on mount', () => {
     const spy = jest.fn()
     const wrapper = mount(<ModalComponent />)
     const o = wrapper.instance().cardNode
     o.onfocus = spy
     wrapper.setProps({ isOpen: true })
 
-    setTimeout(() => {
-      expect(spy).toHaveBeenCalled()
-      done()
-    }, 350)
+    jest.runAllTimers()
+
+    expect(spy).toHaveBeenCalled()
   })
 })

--- a/src/components/Portal/index.js
+++ b/src/components/Portal/index.js
@@ -124,7 +124,9 @@ class Portal extends Component {
 
     ReactDOM.unmountComponentAtNode(this.node)
     // Unmount from specified target, instead of document
-    this.mountSelector.removeChild(this.node)
+    if (this.mountSelector && this.node.parentNode === this.mountSelector) {
+      this.mountSelector.removeChild(this.node)
+    }
 
     if (onClose) onClose(this)
 

--- a/src/components/Portal/tests/Portal.test.js
+++ b/src/components/Portal/tests/Portal.test.js
@@ -2,304 +2,267 @@ import React from 'react'
 import { mount } from 'enzyme'
 import Portal from '..'
 
-// jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000
-const PORTAL_TEST_TIMEOUT = 300
-
-const cleanUp = wrapper => {
-  if (wrapper) wrapper.unmount()
+const cleanUp = () => {
   global.document.body.innerHTML = ''
 }
 
-describe('Renders', () => {
-  test('Renders at the body on mount', () => {
-    const preMountNodeCount = document.body.childNodes.length
-    const wrapper = mount(
-      <Portal>
-        <div className="brick">BRICK</div>
-      </Portal>
-    )
-    const portal = document.body.childNodes[0]
-    const el = portal.getElementsByClassName('brick')[0]
+describe('Portal', () => {
+  jest.useFakeTimers()
 
-    expect(document.body.childNodes.length).toBe(preMountNodeCount + 1)
-    expect(el).toBeTruthy()
-    expect(el.innerHTML).toBe('BRICK')
-
-    cleanUp(wrapper)
+  afterEach(() => {
+    cleanUp()
   })
 
-  test('Is removed from the body on unmount', done => {
-    const wrapper = mount(
-      <Portal>
-        <div className="brick">BRICK</div>
-      </Portal>
-    )
+  describe('Renders', () => {
+    test('Renders at the body on mount', () => {
+      const preMountNodeCount = document.body.childNodes.length
+      const wrapper = mount(
+        <Portal>
+          <div className="brick">BRICK</div>
+        </Portal>
+      )
+      const portal = document.body.childNodes[0]
+      const el = portal.getElementsByClassName('brick')[0]
 
-    wrapper.unmount()
+      expect(document.body.childNodes.length).toBe(preMountNodeCount + 1)
+      expect(el).toBeTruthy()
+      expect(el.innerHTML).toBe('BRICK')
+    })
 
-    setTimeout(() => {
+    test('Is removed from the body on unmount', () => {
+      const wrapper = mount(
+        <Portal>
+          <div className="brick">BRICK</div>
+        </Portal>
+      )
+
+      wrapper.unmount()
+      jest.runOnlyPendingTimers()
+
       expect(document.getElementsByClassName('brick').length).toBe(0)
-      cleanUp()
-      done()
-    }, PORTAL_TEST_TIMEOUT)
-  })
+    })
 
-  test('Can add custom className', () => {
-    const wrapper = mount(
-      <Portal className="champ">
-        <div className="brick">BRICK</div>
-      </Portal>
-    )
-
-    expect(document.getElementsByClassName('champ').length).toBe(1)
-
-    cleanUp(wrapper)
-  })
-
-  test('Can add custom ID', () => {
-    const wrapper = mount(
-      <Portal id="champ">
-        <div className="brick">BRICK</div>
-      </Portal>
-    )
-
-    expect(document.getElementById('champ')).toBeTruthy()
-
-    cleanUp(wrapper)
-  })
-})
-
-describe('renderTo', () => {
-  test('Can render to custom selector, if specified', () => {
-    const testBody = global.document.createElement('div')
-    global.document.body.appendChild(testBody)
-
-    const wrapper = mount(
-      <div className="channel4">
-        <div className="custom" />
-        <Portal id="champ" renderTo=".custom">
+    test('Can add custom className', () => {
+      const wrapper = mount(
+        <Portal className="champ">
           <div className="brick">BRICK</div>
         </Portal>
-      </div>,
-      { attachTo: testBody }
-    )
+      )
 
-    const custom = wrapper.find('.custom').html()
+      expect(document.getElementsByClassName('champ').length).toBe(1)
+    })
 
-    expect(custom).toContain('id')
-    expect(custom).toContain('champ')
-    expect(custom).toContain('BRICK')
-
-    wrapper.unmount()
-    wrapper.detach()
-    cleanUp()
-  })
-
-  test('Can render to custom DOM element, if specified', () => {
-    const testBody = global.document.createElement('div')
-    global.document.body.appendChild(testBody)
-
-    const wrapper = mount(
-      <div className="channel4">
-        <div className="custom" />
-        <Portal id="champ" renderTo={global.document.body}>
-          <div className="brick">BRICK</div>
-        </Portal>
-      </div>,
-      { attachTo: testBody }
-    )
-
-    const body = global.document.body.innerHTML
-
-    expect(body).toContain('id')
-    expect(body).toContain('champ')
-    expect(body).toContain('BRICK')
-
-    wrapper.unmount()
-    wrapper.detach()
-    cleanUp()
-  })
-
-  test('Can render to Portal.Container, if exists', () => {
-    const testBody = global.document.createElement('div')
-    global.document.body.appendChild(testBody)
-
-    const wrapper = mount(
-      <div className="channel4">
+    test('Can add custom ID', () => {
+      const wrapper = mount(
         <Portal id="champ">
           <div className="brick">BRICK</div>
         </Portal>
-        <p>Content</p>
-        <div className="channel4-inner">
-          <Portal.Container />
-        </div>
-      </div>,
-      { attachTo: testBody }
-    )
+      )
 
-    const custom = wrapper.find(Portal.Container).html()
-
-    expect(custom).toContain('id')
-    expect(custom).toContain('champ')
-    expect(custom).toContain('BRICK')
-
-    wrapper.unmount()
-    wrapper.detach()
-    cleanUp()
+      expect(document.getElementById('champ')).toBeTruthy()
+      cleanUp(wrapper)
+    })
   })
 
-  test("Fallsback to document.body if custom selector doesn't exist", () => {
-    const testBody = global.document.createElement('div')
-    global.document.body.appendChild(testBody)
+  describe('renderTo', () => {
+    test('Can render to custom selector, if specified', () => {
+      const testBody = global.document.createElement('div')
+      global.document.body.appendChild(testBody)
 
-    const nodeCount = global.document.body.childNodes.length
+      const wrapper = mount(
+        <div className="channel4">
+          <div className="custom" />
+          <Portal id="champ" renderTo=".custom">
+            <div className="brick">BRICK</div>
+          </Portal>
+        </div>,
+        { attachTo: testBody }
+      )
 
-    const wrapper = mount(
-      <div className="channel4">
-        <div className="custom" />
-        <Portal id="champ" renderTo=".nope">
+      const custom = wrapper.find('.custom').html()
+
+      expect(custom).toContain('id')
+      expect(custom).toContain('champ')
+      expect(custom).toContain('BRICK')
+    })
+
+    test('Can render to custom DOM element, if specified', () => {
+      const testBody = global.document.createElement('div')
+      global.document.body.appendChild(testBody)
+
+      const wrapper = mount(
+        <div className="channel4">
+          <div className="custom" />
+          <Portal id="champ" renderTo={global.document.body}>
+            <div className="brick">BRICK</div>
+          </Portal>
+        </div>,
+        { attachTo: testBody }
+      )
+
+      const body = global.document.body.innerHTML
+
+      expect(body).toContain('id')
+      expect(body).toContain('champ')
+      expect(body).toContain('BRICK')
+    })
+
+    test('Can render to Portal.Container, if exists', () => {
+      const testBody = global.document.createElement('div')
+      global.document.body.appendChild(testBody)
+
+      const wrapper = mount(
+        <div className="channel4">
+          <Portal id="champ">
+            <div className="brick">BRICK</div>
+          </Portal>
+          <p>Content</p>
+          <div className="channel4-inner">
+            <Portal.Container />
+          </div>
+        </div>,
+        { attachTo: testBody }
+      )
+
+      const custom = wrapper.find(Portal.Container).html()
+
+      expect(custom).toContain('id')
+      expect(custom).toContain('champ')
+      expect(custom).toContain('BRICK')
+    })
+
+    test("Fallsback to document.body if custom selector doesn't exist", () => {
+      const testBody = global.document.createElement('div')
+      global.document.body.appendChild(testBody)
+
+      const nodeCount = global.document.body.childNodes.length
+
+      const wrapper = mount(
+        <div className="channel4">
+          <div className="custom" />
+          <Portal id="champ" renderTo=".nope">
+            <div className="brick">BRICK</div>
+          </Portal>
+        </div>,
+        { attachTo: testBody }
+      )
+
+      const custom = wrapper.find('.custom').html()
+      const postMountNodeCount = global.document.body.childNodes.length
+      const portal = global.document.body.childNodes[1]
+
+      expect(custom).not.toContain('BRICK')
+      expect(nodeCount).toBe(postMountNodeCount - 1)
+      expect(portal).toBeTruthy()
+      expect(portal.innerHTML).toContain('BRICK')
+    })
+  })
+
+  describe('Events', () => {
+    test('onBeforeOpen callback works', () => {
+      const mockCallback = jest.fn()
+      const onBeforeOpen = open => {
+        open()
+        mockCallback()
+      }
+      const wrapper = mount(
+        <Portal onBeforeOpen={onBeforeOpen} isOpen>
           <div className="brick">BRICK</div>
         </Portal>
-      </div>,
-      { attachTo: testBody }
-    )
+      )
 
-    const custom = wrapper.find('.custom').html()
-    const postMountNodeCount = global.document.body.childNodes.length
-    const portal = global.document.body.childNodes[1]
-
-    expect(custom).not.toContain('BRICK')
-    expect(nodeCount).toBe(postMountNodeCount - 1)
-    expect(portal).toBeTruthy()
-    expect(portal.innerHTML).toContain('BRICK')
-
-    wrapper.unmount()
-    wrapper.detach()
-    cleanUp()
-  })
-})
-
-describe('Events', () => {
-  test('onBeforeOpen callback works', () => {
-    const mockCallback = jest.fn()
-    const onBeforeOpen = open => {
-      open()
-      mockCallback()
-    }
-    const wrapper = mount(
-      <Portal onBeforeOpen={onBeforeOpen} isOpen>
-        <div className="brick">BRICK</div>
-      </Portal>
-    )
-
-    expect(mockCallback.mock.calls.length).toBe(1)
-
-    cleanUp(wrapper)
-  })
-
-  test('onOpen callback works', () => {
-    const mockCallback = jest.fn()
-    const wrapper = mount(
-      <Portal onOpen={mockCallback} isOpen>
-        <div className="brick">BRICK</div>
-      </Portal>
-    )
-
-    expect(mockCallback.mock.calls.length).toBe(1)
-
-    cleanUp(wrapper)
-  })
-
-  test('onBeforeOpen + onOpen callback works', () => {
-    const mockCallback = jest.fn()
-    const onBeforeOpen = open => {
-      open()
-      mockCallback()
-    }
-    const wrapper = mount(
-      <Portal onBeforeOpen={onBeforeOpen} onOpen={mockCallback} isOpen>
-        <div className="brick">BRICK</div>
-      </Portal>
-    )
-
-    expect(mockCallback.mock.calls.length).toBe(2)
-
-    cleanUp(wrapper)
-  })
-
-  test('onBeforeClose callback works', done => {
-    const testBody = global.document.createElement('div')
-    global.document.body.appendChild(testBody)
-
-    const mockCallback = jest.fn()
-    const onBeforeClose = close => {
-      close()
-      mockCallback()
-    }
-
-    const wrapper = mount(
-      <Portal onBeforeClose={onBeforeClose} isOpen>
-        <div className="brick">BRICK</div>
-      </Portal>,
-      { attachTo: testBody }
-    )
-
-    wrapper.unmount()
-
-    setTimeout(() => {
       expect(mockCallback.mock.calls.length).toBe(1)
-      cleanUp()
-      wrapper.detach()
-      done()
-    }, PORTAL_TEST_TIMEOUT)
-  })
+    })
 
-  test('onClose callback works', done => {
-    const testBody = global.document.createElement('div')
-    global.document.body.appendChild(testBody)
-    const mockCallback = jest.fn()
+    test('onOpen callback works', () => {
+      const mockCallback = jest.fn()
+      const wrapper = mount(
+        <Portal onOpen={mockCallback} isOpen>
+          <div className="brick">BRICK</div>
+        </Portal>
+      )
 
-    const wrapper = mount(
-      <Portal onClose={mockCallback} isOpen>
-        <div className="brick">BRICK</div>
-      </Portal>,
-      { attachTo: testBody }
-    )
-
-    wrapper.unmount()
-
-    setTimeout(() => {
       expect(mockCallback.mock.calls.length).toBe(1)
-      cleanUp()
-      wrapper.detach()
-      done()
-    }, PORTAL_TEST_TIMEOUT)
-  })
+    })
 
-  test('onBeforeClose + onClose callback works', done => {
-    const testBody = global.document.createElement('div')
-    global.document.body.appendChild(testBody)
+    test('onBeforeOpen + onOpen callback works', () => {
+      const mockCallback = jest.fn()
+      const onBeforeOpen = open => {
+        open()
+        mockCallback()
+      }
+      const wrapper = mount(
+        <Portal onBeforeOpen={onBeforeOpen} onOpen={mockCallback} isOpen>
+          <div className="brick">BRICK</div>
+        </Portal>
+      )
 
-    const mockCallback = jest.fn()
-    const onBeforeClose = close => {
-      close()
-      mockCallback()
-    }
+      expect(mockCallback.mock.calls.length).toBe(2)
+    })
 
-    const wrapper = mount(
-      <Portal onBeforeClose={onBeforeClose} onClose={mockCallback} isOpen>
-        <div className="brick">BRICK</div>
-      </Portal>,
-      { attachTo: testBody }
-    )
+    test('onBeforeClose callback works', () => {
+      const testBody = global.document.createElement('div')
+      global.document.body.appendChild(testBody)
 
-    wrapper.unmount()
+      const mockCallback = jest.fn()
+      const onBeforeClose = close => {
+        close()
+        mockCallback()
+      }
 
-    setTimeout(() => {
+      const wrapper = mount(
+        <Portal onBeforeClose={onBeforeClose} isOpen>
+          <div className="brick">BRICK</div>
+        </Portal>,
+        { attachTo: testBody }
+      )
+
+      wrapper.unmount()
+      jest.runOnlyPendingTimers()
+
+      expect(mockCallback.mock.calls.length).toBe(1)
+    })
+
+    test('onClose callback works', () => {
+      const testBody = global.document.createElement('div')
+      global.document.body.appendChild(testBody)
+      const mockCallback = jest.fn()
+
+      const wrapper = mount(
+        <Portal onClose={mockCallback} isOpen>
+          <div className="brick">BRICK</div>
+        </Portal>,
+        { attachTo: testBody }
+      )
+
+      wrapper.unmount()
+
+      jest.runOnlyPendingTimers()
+      expect(mockCallback.mock.calls.length).toBe(1)
+    })
+
+    test('onBeforeClose + onClose callback works', () => {
+      const testBody = global.document.createElement('div')
+      global.document.body.appendChild(testBody)
+
+      const mockCallback = jest.fn()
+      const onBeforeClose = close => {
+        close()
+        mockCallback()
+      }
+
+      const wrapper = mount(
+        <Portal onBeforeClose={onBeforeClose} onClose={mockCallback} isOpen>
+          <div className="brick">BRICK</div>
+        </Portal>,
+        { attachTo: testBody }
+      )
+
+      wrapper.unmount()
+      jest.runOnlyPendingTimers()
+
       expect(mockCallback.mock.calls.length).toBe(2)
       wrapper.detach()
-      cleanUp()
-      done()
-    }, PORTAL_TEST_TIMEOUT)
+    })
   })
 })

--- a/src/components/PortalWrapper/tests/PortalWrapper.test.js
+++ b/src/components/PortalWrapper/tests/PortalWrapper.test.js
@@ -5,6 +5,8 @@ import Keys from '../../../constants/Keys'
 import classNames from '../../../utilities/classNames'
 import wait from '../../../tests/helpers/wait'
 
+jest.useFakeTimers()
+
 const TestButton = props => {
   const { className } = props
   const componentClassName = classNames('button', className)
@@ -40,44 +42,35 @@ const context = {
 }
 
 describe('HOC', () => {
-  test('Can create a component as a HOC', done => {
+  test('Can create a component as a HOC', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     mount(<TestComponent isOpen />, context)
 
-    wait().then(() => {
-      const c = document.body.childNodes[0]
-      expect(c.querySelector('button')).toBeTruthy()
-      done()
-    })
+    const c = document.body.childNodes[0]
+    expect(c.querySelector('button')).toBeTruthy()
   })
 })
 
 describe('ClassName', () => {
-  test('Can pass className to composed component', done => {
+  test('Can pass className to composed component', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     mount(<TestComponent className="ron" isOpen />, context)
 
-    wait().then(() => {
-      const o = document.querySelector('.button')
-      expect(o.classList.contains('ron')).toBeTruthy()
-      done()
-    })
+    const o = document.querySelector('.button')
+    expect(o.classList.contains('ron')).toBeTruthy()
   })
 })
 
 describe('ID', () => {
-  test('Adds default ID', done => {
+  test('Adds default ID', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     mount(<TestComponent isOpen />, context)
 
-    wait().then(() => {
-      const c = document.body.childNodes[0]
-      expect(c.id).toContain('PortalWrapper')
-      done()
-    })
+    const c = document.body.childNodes[0]
+    expect(c.id).toContain('PortalWrapper')
   })
 
-  test('Override default ID with options', done => {
+  test('Override default ID with options', () => {
     const options = {
       id: 'Brick',
       timeout: 0,
@@ -85,16 +78,13 @@ describe('ID', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     mount(<TestComponent isOpen />, context)
 
-    wait().then(() => {
-      const c = document.body.childNodes[0]
-      expect(c.id).toContain('Brick')
-      done()
-    })
+    const c = document.body.childNodes[0]
+    expect(c.id).toContain('Brick')
   })
 })
 
 describe('Manager', () => {
-  test('Can close last Manage item ', done => {
+  test('Can close last Manage item ', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     const wrapper = mount(
       <div>
@@ -106,15 +96,8 @@ describe('Manager', () => {
 
     const o = wrapper.find(TestComponent).last()
 
-    wait()
-      .then(() => {
-        o.getNode().closePortal()
-      })
-      .then(() => wait())
-      .then(() => {
-        expect(o.getNode().state.isOpen).toBe(false)
-        done()
-      })
+    o.getNode().closePortal()
+    expect(o.getNode().state.isOpen).toBe(false)
   })
 
   test('Cannot close Component that is not last in Manage list', () => {
@@ -134,79 +117,60 @@ describe('Manager', () => {
 })
 
 describe('wrapperClassName', () => {
-  test('Does not add a wrapperClassName to portal', done => {
+  test('Does not add a wrapperClassName to portal', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     mount(<TestComponent isOpen />, context)
 
-    wait().then(() => {
-      const c = document.body.childNodes[0]
-      expect(c.className).toBeFalsy()
-      done()
-    })
+    const c = document.body.childNodes[0]
+    expect(c.className).toBeFalsy()
   })
 
-  test('Can customize wrapperClassName', done => {
+  test('Can customize wrapperClassName', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     mount(<TestComponent isOpen wrapperClassName="blue" />, context)
 
-    wait().then(() => {
-      const c = document.body.childNodes[0]
-      expect(c.className).toContain('blue')
-      done()
-    })
+    const c = document.body.childNodes[0]
+    expect(c.className).toContain('blue')
   })
 })
 
 describe('isOpen', () => {
-  test('Can open wrapped component with isOpen prop change to true', done => {
+  test('Can open wrapped component with isOpen prop change to true', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     const wrapper = mount(<TestComponent />, context)
 
-    wait()
-      .then(() => {
-        const o = document.body.childNodes[0]
-        expect(o).not.toBeTruthy()
+    const o = document.body.childNodes[0]
+    expect(o).not.toBeTruthy()
 
-        wrapper.setProps({ isOpen: true })
-      })
-      .then(() => wait(10))
-      .then(() => {
-        const o = document.body.childNodes[0]
-        expect(o).toBeTruthy()
-        done()
-      })
+    wrapper.setProps({ isOpen: true })
+
+    const o2 = document.body.childNodes[0]
+    expect(o2).toBeTruthy()
   })
 
-  test('Can close wrapped component with isOpen prop change to false', done => {
+  test('Can close wrapped component with isOpen prop change to false', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
-    const wrapper = mount(<TestComponent isOpen timeout={0} />, context)
+    const wrapper = mount(<TestComponent isOpen={false} timeout={0} />, context)
 
-    wait()
-      .then(() => {
-        wrapper.setProps({ isOpen: false })
-      })
-      .then(() => wait(500))
-      .then(() => {
-        const o = document.body.childNodes[0]
-        expect(o).not.toBeTruthy()
-        done()
-      })
+    wrapper.setProps({ isOpen: true })
+    wrapper.setProps({ isOpen: false })
+    jest.runAllTimers()
+
+    const o = document.body.childNodes[0]
+    expect(o).not.toBeTruthy()
   })
 })
 
 describe('Router', () => {
-  test('Does not render if path is provided, but no context', done => {
+  test('Does not render if path is provided, but no context', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     mount(<TestComponent path="/test" timeout={0} />)
 
-    wait(10).then(() => {
-      const o = document.body.childNodes[0]
-      expect(o).not.toBeTruthy()
-      done()
-    })
+    const o = document.body.childNodes[0]
+    expect(o).not.toBeTruthy()
   })
 
-  test('Does not render if the router shape is in valid', done => {
+  test('Does not render if the router shape is in valid', () => {
     const context = {
       context: {
         router: {
@@ -218,14 +182,11 @@ describe('Router', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     mount(<TestComponent path="/diff" timeout={0} />, context)
 
-    wait(100).then(() => {
-      const o = document.body.childNodes[0]
-      expect(o).not.toBeTruthy()
-      done()
-    })
+    const o = document.body.childNodes[0]
+    expect(o).not.toBeTruthy()
   })
 
-  test('Does not render if the route path does not match', done => {
+  test('Does not render if the route path does not match', () => {
     const context = {
       context: {
         router: {
@@ -238,14 +199,11 @@ describe('Router', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     mount(<TestComponent path="/diff" timeout={0} />, context)
 
-    wait(100).then(() => {
-      const o = document.body.childNodes[0]
-      expect(o).not.toBeTruthy()
-      done()
-    })
+    const o = document.body.childNodes[0]
+    expect(o).not.toBeTruthy()
   })
 
-  test('Renders if path matches router', done => {
+  test('Renders if path matches router', () => {
     const context = {
       context: {
         router: {
@@ -258,11 +216,8 @@ describe('Router', () => {
     const TestComponent = PortalWrapper(options)(TestButton)
     mount(<TestComponent path="/test" timeout={0} />, context)
 
-    wait(10).then(() => {
-      const o = document.body.childNodes[0]
-      expect(o).toBeTruthy()
-      done()
-    })
+    const o = document.body.childNodes[0]
+    expect(o).toBeTruthy()
   })
 })
 
@@ -302,7 +257,7 @@ describe('Trigger', () => {
     expect(o.triggerNode).not.toBeTruthy()
   })
 
-  test('Does not focus triggerNode if prop change remains false', done => {
+  test('Does not focus triggerNode if prop change remains false', () => {
     const spy = jest.fn()
     const TestComponent = PortalWrapper(options)(TestButton)
     const trigger = <button>Trigger</button>
@@ -311,13 +266,10 @@ describe('Trigger', () => {
     o.getNode().onfocus = spy
     wrapper.setProps({ isOpen: false })
 
-    setTimeout(() => {
-      expect(spy).not.toHaveBeenCalled()
-      done()
-    }, 40)
+    expect(spy).not.toHaveBeenCalled()
   })
 
-  test('Focuses triggerNode on isOpen prop change to false', done => {
+  test('Focuses triggerNode on isOpen prop change to false', () => {
     const spy = jest.fn()
     const TestComponent = PortalWrapper(options)(TestButton)
     const trigger = <button>Trigger</button>
@@ -328,10 +280,7 @@ describe('Trigger', () => {
     o.getNode().onfocus = spy
     wrapper.setProps({ isOpen: false })
 
-    setTimeout(() => {
-      expect(spy).toHaveBeenCalled()
-      done()
-    }, 40)
+    expect(spy).toHaveBeenCalled()
   })
 
   test('Allows for ref', () => {


### PR DESCRIPTION
## Test: Refactor tests to use jest.useFakeTimeout

This update refactors some of the tests to use `jest.useFakeTimeout` instead
of real time outs.