### PR TITLE
Fancy: Update babel build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -218,9 +218,9 @@
       "integrity": "sha512-kAFHWyQTMLcOvse+RfEfJ6uwwOlVFZcUOMX0wuBvEMwnF3Zb/6VQ/xDgbx9fNlp3I6AAmijAtUtIyT2qVldpnA=="
     },
     "@helpscout/fancy": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.0.1.tgz",
-      "integrity": "sha512-0ygus7eKp/LsbbXOoZ/ZJy0Cf974hcj/0cjjdW9MCcXF4UvMhS4qO5DXo49WD0OxekJJ4e7r8b1v/86RkzndkQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.0.2.tgz",
+      "integrity": "sha512-gWnrzqr2DiOqu+TPUhqa2KSgYEGl772/9PAMDpqxZ7PZUrUlZeho8DEIfDkXOlXgFTnI6DegQ89BxQHS+ys5kg==",
       "requires": {
         "@emotion/hash": "^0.6.2",
         "@emotion/is-prop-valid": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-dom": "^15"
   },
   "dependencies": {
-    "@helpscout/fancy": "2.0.1",
+    "@helpscout/fancy": "2.0.2",
     "closest": "0.0.1",
     "create-react-context": "0.2.2",
     "emoji-mart": "^1.0.1",

--- a/src/components/Dropdown/__tests__/Menu.test.js
+++ b/src/components/Dropdown/__tests__/Menu.test.js
@@ -4,7 +4,8 @@ import { default as Menu, MenuComponent } from '../Menu'
 import Divider from '../Divider'
 import Item from '../Item'
 import Keys from '../../../constants/Keys'
-import wait from '../../../tests/helpers/wait'
+
+jest.useFakeTimers()
 
 const simulateKeyPress = (keyCode, eventType = 'keyup') => {
   const event = new Event(eventType)
@@ -34,17 +35,14 @@ describe('Classname', () => {
 })
 
 describe('Nodes', () => {
-  test('Has a reference to DOM nodes', done => {
+  test('Has a reference to DOM nodes', () => {
     const wrapper = mount(<MenuComponent isOpen />)
     const o = wrapper.instance()
 
-    wait().then(() => {
-      expect(o.node).toBeTruthy()
-      expect(o.wrapperNode).toBeTruthy()
-      expect(o.contentNode).toBeTruthy()
-      expect(o.listNode).toBeTruthy()
-      done()
-    })
+    expect(o.node).toBeTruthy()
+    expect(o.wrapperNode).toBeTruthy()
+    expect(o.contentNode).toBeTruthy()
+    expect(o.listNode).toBeTruthy()
   })
 })
 
@@ -248,20 +246,15 @@ describe('Items', () => {
     expect(spy).not.toHaveBeenCalled()
   })
 
-  test('Can trigger onBeforeClose callback', done => {
+  test('Can trigger onBeforeClose callback', () => {
     const spy = jest.fn()
     const wrapper = mount(<Menu selectedIndex={0} isOpen onBeforeClose={spy} />)
 
-    wait()
-      .then(() => {
-        wrapper.unmount()
-      })
-      .then(() => wait(300))
-      .then(() => {
-        expect(spy).toHaveBeenCalled()
-        wrapper.unmount()
-        done()
-      })
+    wrapper.unmount()
+
+    jest.runAllTimers()
+
+    expect(spy).toHaveBeenCalled()
   })
 
   test('Closes ALL menus when a sub-menu item is clicked', () => {
@@ -336,7 +329,7 @@ describe('Selected', () => {
 })
 
 describe('Height', () => {
-  test('Keeps height at null if Menu is within viewport', done => {
+  test('Keeps height at null if Menu is within viewport', () => {
     const wrapper = mount(<MenuComponent isOpen />)
     const o = wrapper.getNode()
 
@@ -349,10 +342,7 @@ describe('Height', () => {
       bottom: 0,
     })
 
-    setTimeout(() => {
-      expect(o.height).toBe(null)
-      done()
-    }, 1)
+    expect(o.height).toBe(null)
   })
 
   test('Attempts to update height on resize', () => {


### PR DESCRIPTION
## Fancy: Update babel build

This update bumps Fancy to the latest v2.0.2, which uses a better
babel transpilation for `dist` build.