### PR TITLE
Message.Content: Note theme

### DIFF
--- a/src/components/Message/ChatBlock.js
+++ b/src/components/Message/ChatBlock.js
@@ -27,6 +27,7 @@ class ChatBlock extends Component<Props> {
       children,
       className,
       icon,
+      isNote,
       ltr,
       rtl,
       read,

--- a/src/components/Message/Content.js
+++ b/src/components/Message/Content.js
@@ -1,8 +1,11 @@
 // @flow
 import React from 'react'
 import ChatBlock from './ChatBlock'
+import styled from '../styled'
+import PreviewCardContext from '../PreviewCard/Context'
 import classNames from '../../utilities/classNames'
 import { chatTypes } from './propTypes'
+import css from './styles/Content.css.js'
 import type { MessageChat } from './types'
 
 type Props = MessageChat
@@ -12,6 +15,7 @@ const Content = (props: Props) => {
     children,
     className,
     from,
+    isNote,
     ltr,
     rtl,
     to,
@@ -21,11 +25,16 @@ const Content = (props: Props) => {
     ...rest
   } = props
 
-  const componentClassName = classNames('c-MessageContent', className)
+  const componentClassName = classNames(
+    'c-MessageContent',
+    isNote && 'is-note',
+    className
+  )
 
   const innerComponentClassName = classNames(
     'c-MessageContent__content',
     from && 'is-from',
+    isNote && 'is-note',
     ltr && !rtl && 'is-ltr',
     !ltr && rtl && 'is-rtl',
     to && 'is-to'
@@ -41,15 +50,21 @@ const Content = (props: Props) => {
     to,
   }
 
+  const contextProps = {
+    isNote,
+  }
+
   return (
     <ChatBlock {...chatProps} className={componentClassName}>
-      <div className={innerComponentClassName} {...rest}>
-        {children}
-      </div>
+      <PreviewCardContext.Provider value={contextProps}>
+        <div className={innerComponentClassName} {...rest}>
+          {children}
+        </div>
+      </PreviewCardContext.Provider>
     </ChatBlock>
   )
 }
 
 Content.displayName = 'Message.Content'
 
-export default Content
+export default styled(Content)(css)

--- a/src/components/Message/Media.js
+++ b/src/components/Message/Media.js
@@ -1,5 +1,7 @@
 // @flow
-import React, { PureComponent as Component } from 'react'
+import type { Node } from 'react'
+import type { MessageBubble } from './types'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styled from '../styled'
 import Flexy from '../Flexy'
@@ -13,7 +15,6 @@ import classNames, { BEM } from '../../utilities/classNames'
 import { isString } from '../../utilities/is'
 import { noop } from '../../utilities/other'
 import { bubbleTypes, providerContextTypes } from './propTypes'
-import type { MessageBubble } from './types'
 import css from './styles/Media.css.js'
 
 type Props = MessageBubble & {
@@ -62,7 +63,7 @@ export class Media extends Component<Props> {
    *
    * @returns {string} The caption text.
    */
-  getCaption = () => {
+  getCaption = (): ?string => {
     const { caption, error, errorMessage } = this.props
 
     let text = caption
@@ -71,10 +72,11 @@ export class Media extends Component<Props> {
       text = isString(error) ? error : errorMessage
     }
 
+    // $FlowFixMe
     return text
   }
 
-  getSpinnerMarkup = () => {
+  getSpinnerMarkup = (): ?Node => {
     return (
       this.props.isUploading && (
         <Spinner className="c-MessageMedia__loadingSpinner" size="xs" />
@@ -82,7 +84,7 @@ export class Media extends Component<Props> {
     )
   }
 
-  getCaptionMarkup = () => {
+  getCaptionMarkup = (): ?Node => {
     const captionText = this.getCaption()
     const spinnerMarkup = this.getSpinnerMarkup()
     const tryAgainMarkup = this.getTryAgainMarkup()
@@ -105,7 +107,7 @@ export class Media extends Component<Props> {
     src,
     maxHeight,
     maxWidth,
-  }: { src?: string, maxHeight?: number, maxWidth?: number } = {}) => {
+  }: { src?: string, maxHeight?: number, maxWidth?: number } = {}): ?Node => {
     const {
       height,
       onMediaClick,
@@ -139,7 +141,7 @@ export class Media extends Component<Props> {
     )
   }
 
-  getTryAgainMarkup = () => {
+  getTryAgainMarkup = (): ?Node => {
     const { error, showErrorTryAgainLink, tryAgainLabel } = this.props
 
     if (!error || !showErrorTryAgainLink) return null

--- a/src/components/Message/__tests__/Content.test.js
+++ b/src/components/Message/__tests__/Content.test.js
@@ -1,24 +1,24 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import ChatBlock from '../ChatBlock'
 import Content from '../Content'
 
 const cx = 'c-MessageContent'
 const ui = {
-  main: `.${cx}`,
+  base: `.${cx}`,
   content: '.c-MessageContent__content',
 }
 
 describe('ClassNames', () => {
   test('Has default className', () => {
-    const wrapper = shallow(<Content />)
+    const wrapper = mount(<Content />)
     const o = wrapper.find(`.${cx}`)
 
     expect(o.length).toBeTruthy()
   })
 
   test('Accepts custom classNames', () => {
-    const wrapper = shallow(<Content className="mugatu" />)
+    const wrapper = mount(<Content className="mugatu" />)
     const o = wrapper.find(`.${cx}`)
 
     expect(o.hasClass('mugatu')).toBeTruthy()
@@ -27,21 +27,21 @@ describe('ClassNames', () => {
 
 describe('ChatBlock', () => {
   test('Contains a ChatBlock component', () => {
-    const wrapper = shallow(<Content />)
+    const wrapper = mount(<Content />)
     const o = wrapper.find(ChatBlock)
 
     expect(o.length).toBeTruthy()
   })
 
   test('ChatBlock does inherits component classNames', () => {
-    const wrapper = shallow(<Content />)
+    const wrapper = mount(<Content />)
     const o = wrapper.find(ChatBlock)
 
     expect(o.hasClass(cx)).toBeTruthy()
   })
 
   test('Passes correct props to ChatBlock', () => {
-    const wrapper = shallow(<Content from to read ltr rtl timestamp="time" />)
+    const wrapper = mount(<Content from to read ltr rtl timestamp="time" />)
     const props = wrapper.find(ChatBlock).getNode().props
 
     expect(props.from).toBeTruthy()
@@ -55,30 +55,39 @@ describe('ChatBlock', () => {
 
 describe('Styles', () => {
   test('Applies "from" styles, if defined', () => {
-    const wrapper = shallow(<Content from />)
+    const wrapper = mount(<Content from />)
     const o = wrapper.find(ui.content)
 
     expect(o.hasClass('is-from')).toBeTruthy()
   })
 
   test('Applies "to" styles, if defined', () => {
-    const wrapper = shallow(<Content to />)
+    const wrapper = mount(<Content to />)
     const o = wrapper.find(ui.content)
 
     expect(o.hasClass('is-to')).toBeTruthy()
   })
 
   test('Applies "ltr" styles, if defined', () => {
-    const wrapper = shallow(<Content ltr />)
+    const wrapper = mount(<Content ltr />)
     const o = wrapper.find(ui.content)
 
     expect(o.hasClass('is-ltr')).toBeTruthy()
   })
 
   test('Applies "rtl" styles, if defined', () => {
-    const wrapper = shallow(<Content rtl />)
+    const wrapper = mount(<Content rtl />)
     const o = wrapper.find(ui.content)
 
     expect(o.hasClass('is-rtl')).toBeTruthy()
+  })
+
+  test('Applies "isNote" styles, if defined', () => {
+    const wrapper = mount(<Content isNote />)
+    const b = wrapper.find(ui.base)
+    const o = wrapper.find(ui.content)
+
+    expect(b.hasClass('is-note')).toBeTruthy()
+    expect(o.hasClass('is-note')).toBeTruthy()
   })
 })

--- a/src/components/Message/__tests__/Message.test.js
+++ b/src/components/Message/__tests__/Message.test.js
@@ -248,3 +248,20 @@ describe('From', () => {
     expect(o.length).toBe(0)
   })
 })
+
+describe('Note', () => {
+  test('Can pass isNote prop to child Message sub-components', () => {
+    const wrapper = mount(
+      <Message isNote>
+        <Message.Chat />
+      </Message>
+    )
+    const o = wrapper.find('Chat').first()
+
+    expect(o.props().isNote).toBe(true)
+
+    wrapper.setProps({ isNote: false })
+
+    expect(o.props().isNote).toBe(false)
+  })
+})

--- a/src/components/Message/docs/Content.md
+++ b/src/components/Message/docs/Content.md
@@ -2,33 +2,39 @@
 
 A Content component provides the UI to render non text-based content within a [Message](./Message.md).
 
-
 ## Example
 
 ```jsx
-<Message to avatar={<Avatar name='Buddy' />}>
-  <Message.Chat read timestamp='9:41am'>
-    <Link href='https://en.wikipedia.org/wiki/Elf_(film)'>https://en.wikipedia.org/wiki/Elf_(film)</Link>
+<Message to avatar={<Avatar name="Buddy" />}>
+  <Message.Chat read timestamp="9:41am">
+    <Link href="https://en.wikipedia.org/wiki/Elf_(film)">
+      https://en.wikipedia.org/wiki/Elf_(film)
+    </Link>
   </Message.Chat>
   <Message.Content>
     <PreviewCard
-      href='https://en.wikipedia.org/wiki/Elf_(film)'
-      title='Wikipedia: Elf (film)'
-      target='_blank'
-    >Elf is a 2003 American Christmas fantasy comedy film directed by Jon Favreau and written by David Berenbaum. It stars Will Ferrell, James Caan, Zooey Deschanel, Mary Steenburgen, Daniel Tay, Edward Asner, and Bob Newhart...</PreviewCard>
+      href="https://en.wikipedia.org/wiki/Elf_(film)"
+      title="Wikipedia: Elf (film)"
+      target="_blank"
+    >
+      Elf is a 2003 American Christmas fantasy comedy film directed by Jon
+      Favreau and written by David Berenbaum. It stars Will Ferrell, James Caan,
+      Zooey Deschanel, Mary Steenburgen, Daniel Tay, Edward Asner, and Bob
+      Newhart...
+    </PreviewCard>
   </Message.Content>
 </Message>
 ```
 
-
 ## Props
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| className | `string` | Custom class names to be added to the component. |
-| from | `node`/`bool` | Provides author information and applies "From" styles. |
-| ltr | `bool` | Applies left-to-right text styles. |
-| read | `bool` | Determines if the Message is read. |
-| rtl | `bool` | Applies right-to-left text styles. |
-| timestamp | `string` | Timestamp for the Message. |
-| to | `node`/`bool` | Provides author information and applies "To" styles. |
+| Prop      | Type          | Description                                            |
+| --------- | ------------- | ------------------------------------------------------ |
+| className | `string`      | Custom class names to be added to the component.       |
+| from      | `node`/`bool` | Provides author information and applies "From" styles. |
+| isNote    | `bool`        | Applies the "Note" theme styles.                       |
+| ltr       | `bool`        | Applies left-to-right text styles.                     |
+| read      | `bool`        | Determines if the Message is read.                     |
+| rtl       | `bool`        | Applies right-to-left text styles.                     |
+| timestamp | `string`      | Timestamp for the Message.                             |
+| to        | `node`/`bool` | Provides author information and applies "To" styles.   |

--- a/src/components/Message/docs/Message.md
+++ b/src/components/Message/docs/Message.md
@@ -2,26 +2,25 @@
 
 A Message component provides a wrapper for smaller sub-components that create the content for an individual chat-based message.
 
-
 ## Example
 
 ```jsx
-<Message from avatar={<Avatar name='Buddy' />}>
-  <Message.Chat read timestamp='9:41am'>
+<Message from avatar={<Avatar name="Buddy" />}>
+  <Message.Chat read timestamp="9:41am">
     <strong>*NOT NOW ARCTIC PUFFIN!*</strong>
   </Message.Chat>
 </Message>
 ```
 
-
 ## Props
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| avatar | Element | An [Avatar](../../Avatar) component containing author details. |
-| className | `string` | Custom class names to be added to the component. |
-| from | `node`/`bool` | Provides author information and applies "From" styles. |
-| ltr | `bool` | Applies left-to-right text styles. |
-| rtl | `bool` | Applies right-to-left text styles. |
-| showAvatar | `bool` | Renders a space for the Avatar to appear. Default is `true`. |
-| to | `node`/`bool` | Provides author information and applies "To" styles. |
+| Prop       | Type          | Description                                                    |
+| ---------- | ------------- | -------------------------------------------------------------- |
+| avatar     | Element       | An [Avatar](../../Avatar) component containing author details. |
+| className  | `string`      | Custom class names to be added to the component.               |
+| from       | `node`/`bool` | Provides author information and applies "From" styles.         |
+| isNote     | `bool`        | Applies the "Note" theme styles.                               |
+| ltr        | `bool`        | Applies left-to-right text styles.                             |
+| rtl        | `bool`        | Applies right-to-left text styles.                             |
+| showAvatar | `bool`        | Renders a space for the Avatar to appear. Default is `true`.   |
+| to         | `node`/`bool` | Provides author information and applies "To" styles.           |

--- a/src/components/Message/styles/Content.css.js
+++ b/src/components/Message/styles/Content.css.js
@@ -1,0 +1,21 @@
+import baseStyles from '../../../styles/resets/baseStyles.css'
+import { BEM } from '../../../utilities/classNames'
+
+const bem = BEM('.c-MessageContent')
+
+const css = `
+  ${baseStyles}
+  margin-bottom: 20px;
+
+  ${bem.element('content')} {
+    max-width: 500px;
+    text-align: left;
+
+    &.is-rtl {
+      direction: rtl;
+      text-align: right;
+    }
+  }
+`
+
+export default css

--- a/src/components/Message/styles/Media.css.js
+++ b/src/components/Message/styles/Media.css.js
@@ -1,4 +1,5 @@
 import { breakpoint } from '../../../styles/mixins/breakpoints.css'
+import { noteBoxShadow } from '../../../styles/mixins/noteStyles.css'
 import { getColor } from '../../../styles/utilities/color.js'
 import baseStyles from '../../../styles/resets/baseStyles.css'
 import { BEM } from '../../../utilities/classNames'
@@ -42,10 +43,8 @@ const css = `
     }
 
     &.is-note {
+      ${noteBoxShadow()}
       background-color: ${getColor('yellow', 300)};
-      box-shadow:
-        0px 1px 3px 0px rgba(179, 113, 0, 0.2),
-        0px 0px 0px 1px ${getColor('yellow', 400)} inset;
       color: ${getColor('yellow', 800)};
     }
 

--- a/src/components/Message/types.js
+++ b/src/components/Message/types.js
@@ -5,6 +5,7 @@ export type Message = {
   children?: any,
   className?: string,
   from?: any,
+  isNote?: boolean,
   ltr?: boolean,
   rtl?: boolean,
   to?: any,

--- a/src/components/PreviewCard/Context.js
+++ b/src/components/PreviewCard/Context.js
@@ -1,0 +1,12 @@
+// @flow
+import createContext from 'create-react-context'
+
+export type PreviewCardContext = {
+  isNote?: boolean,
+}
+
+const contextProps: PreviewCardContext = {
+  isNote: false,
+}
+
+export default createContext(contextProps)

--- a/src/components/PreviewCard/__tests__/PreviewCard.test.js
+++ b/src/components/PreviewCard/__tests__/PreviewCard.test.js
@@ -1,8 +1,13 @@
 import React from 'react'
-import { shallow } from 'enzyme'
-import PreviewCard from '..'
+import { mount } from 'enzyme'
+import PreviewCard from '../index'
+import Context from '../Context'
 import { baseComponentTest } from '../../../tests/helpers/components'
 import { Card, Heading, Text } from '../../'
+
+const ui = {
+  base: '.c-PreviewCard',
+}
 
 const baseComponentOptions = {
   className: 'c-PreviewCard',
@@ -12,7 +17,7 @@ baseComponentTest(PreviewCard, baseComponentOptions)
 
 describe('Card', () => {
   test('Extends Card component', () => {
-    const wrapper = shallow(<PreviewCard />)
+    const wrapper = mount(<PreviewCard />)
     const o = wrapper.find(Card)
 
     expect(o.length).toBeTruthy()
@@ -22,7 +27,7 @@ describe('Card', () => {
 
 describe('Title', () => {
   test('Does not render a title by default', () => {
-    const wrapper = shallow(<PreviewCard />)
+    const wrapper = mount(<PreviewCard />)
     const o = wrapper.find(Heading)
     const p = wrapper.find('.c-PreviewCard__title')
 
@@ -31,7 +36,7 @@ describe('Title', () => {
   })
 
   test('Renders a title, if defined', () => {
-    const wrapper = shallow(<PreviewCard title="Mugatu" />)
+    const wrapper = mount(<PreviewCard title="Mugatu" />)
     const o = wrapper.find(Heading)
 
     expect(o.length).toBeTruthy()
@@ -42,11 +47,28 @@ describe('Title', () => {
 
 describe('Text', () => {
   test('Renders children in a Text component', () => {
-    const wrapper = shallow(<PreviewCard title="Mugatu">Relax</PreviewCard>)
+    const wrapper = mount(<PreviewCard title="Mugatu">Relax</PreviewCard>)
     const o = wrapper.find(Text)
 
     expect(o.length).toBeTruthy()
     expect(o.hasClass('c-PreviewCard__content')).toBeTruthy()
     expect(o.getNode().props.children).toBe('Relax')
+  })
+})
+
+describe('Context', () => {
+  test('Can consume properties from context', () => {
+    const wrapper = mount(
+      <Context.Provider value={{ isNote: true }}>
+        <PreviewCard />
+      </Context.Provider>
+    )
+    const o = wrapper.find(ui.base)
+
+    expect(o.hasClass('is-note')).toBe(true)
+
+    wrapper.setProps({ value: { isNote: false } })
+
+    expect(o.hasClass('is-note')).toBe(false)
   })
 })

--- a/src/components/PreviewCard/index.js
+++ b/src/components/PreviewCard/index.js
@@ -1,35 +1,53 @@
 // @flow
 import React from 'react'
+import Context from './Context'
 import Card from '../Card'
 import Heading from '../Heading'
 import Text from '../Text'
+import styled from '../styled'
 import classNames from '../../utilities/classNames'
+import css from './styles/PreviewCard.css.js'
 
 type Props = {
   children?: any,
   className?: string,
+  isNote?: boolean,
   title?: string,
 }
 
 const PreviewCard = (props: Props) => {
-  const { children, className, title, ...rest } = props
+  const { children, className, isNote, title, ...rest } = props
 
-  const componentClassName = classNames('c-PreviewCard', className)
+  const createMarkup = contextProps => {
+    const { isNote } = contextProps
 
-  const titleMarkup = title ? (
-    <Heading className="c-PreviewCard__title" size="h5">
-      {title}
-    </Heading>
-  ) : null
+    const componentClassName = classNames(
+      'c-PreviewCard',
+      isNote && 'is-note',
+      className
+    )
+
+    const titleMarkup = title ? (
+      <Heading className="c-PreviewCard__title" size="h5">
+        {title}
+      </Heading>
+    ) : null
+
+    return (
+      <Card className={componentClassName} {...rest}>
+        {titleMarkup}
+        <Text muted className="c-PreviewCard__content">
+          {children}
+        </Text>
+      </Card>
+    )
+  }
 
   return (
-    <Card className={componentClassName} {...rest}>
-      {titleMarkup}
-      <Text muted className="c-PreviewCard__content">
-        {children}
-      </Text>
-    </Card>
+    <Context.Consumer>
+      {contextProps => createMarkup(contextProps)}
+    </Context.Consumer>
   )
 }
 
-export default PreviewCard
+export default styled(PreviewCard)(css)

--- a/src/components/PreviewCard/styles/PreviewCard.css.js
+++ b/src/components/PreviewCard/styles/PreviewCard.css.js
@@ -1,0 +1,31 @@
+import { getColor } from '../../../styles/utilities/color.js'
+import { noteBoxShadowWithHover } from '../../../styles/mixins/noteStyles.css'
+import baseStyles from '../../../styles/resets/baseStyles.css'
+import { BEM } from '../../../utilities/classNames'
+
+const bem = BEM('.c-PreviewCard')
+
+const css = `
+  ${baseStyles}
+  text-decoration: none;
+  &:hover {
+    text-decoration: none;
+  }
+
+  ${bem.element('title')} {
+    margin-bottom: 4px;
+  }
+
+  // Modifiers
+  &.is-link {
+    ${bem.element('title')} {
+      color: ${getColor('blue', 500)};
+    }
+  }
+
+  &.is-note {
+    ${noteBoxShadowWithHover()}
+  }
+`
+
+export default css

--- a/src/styles/components/Message/Content.scss
+++ b/src/styles/components/Message/Content.scss
@@ -1,19 +1,2 @@
-@import 'pack/seed-family/_index';
-@import 'pack/seed-this/_index';
-@import '../../configs/color';
-
-.c-MessageContent {
-  @import '../../resets/base';
-  margin-bottom: 20px;
-
-  &__content {
-    max-width: 500px;
-    text-align: left;
-
-    // Direction
-    &.is-rtl {
-      direction: rtl;
-      text-align: right;
-    }
-  }
-}
+// Is now being rendered by Fancy :)
+// File exists to preserve @import implementation.

--- a/src/styles/components/PreviewCard.scss
+++ b/src/styles/components/PreviewCard.scss
@@ -1,22 +1,2 @@
-@import "../configs/color";
-@import "pack/seed-this/_index";
-
-.c-PreviewCard {
-  @import "../resets/base";
-  $block: this();
-  text-decoration: none;
-  &:hover {
-    text-decoration: none;
-  }
-
-  &__title {
-    margin-bottom: 4px;
-  }
-
-  // Modifiers
-  &.is-link {
-    #{$block}__title {
-      color: _color(blue);
-    }
-  }
-}
+// Is now being rendered by Fancy :)
+// File exists to preserve @import implementation.

--- a/src/styles/mixins/noteStyles.css.js
+++ b/src/styles/mixins/noteStyles.css.js
@@ -1,0 +1,20 @@
+import { getColor } from '../utilities/color'
+
+export const noteBoxShadow = () => `
+  box-shadow:
+    0px 1px 3px 0px rgba(179, 113, 0, 0.2),
+    inset 0px 0px 0px 1px ${getColor('yellow', 400)};
+`
+
+export const noteBoxShadowHover = () => `
+  box-shadow:
+    0 3px 12px 0 rgba(0, 0, 0, 0.1),
+    inset 0px 0px 0px 1px ${getColor('yellow', 400)};
+`
+
+export const noteBoxShadowWithHover = () => `
+  ${noteBoxShadow()}
+  &:hover {
+    ${noteBoxShadowHover()}
+  }
+`

--- a/stories/Message/index.js
+++ b/stories/Message/index.js
@@ -26,25 +26,46 @@ stories.add('action', () => (
 ))
 
 stories.add('content', () => (
-  <Message to avatar={<Avatar name="Buddy" />}>
-    <Message.Chat read timestamp="9:41am">
-      <Link href="https://en.wikipedia.org/wiki/Elf_(film)">
-        https://en.wikipedia.org/wiki/Elf_(film)
-      </Link>
-    </Message.Chat>
-    <Message.Content>
-      <PreviewCard
-        href="https://en.wikipedia.org/wiki/Elf_(film)"
-        title="Wikipedia: Elf (film)"
-        target="_blank"
-      >
-        Elf is a 2003 American Christmas fantasy comedy film directed by Jon
-        Favreau and written by David Berenbaum. It stars Will Ferrell, James
-        Caan, Zooey Deschanel, Mary Steenburgen, Daniel Tay, Edward Asner, and
-        Bob Newhart...
-      </PreviewCard>
-    </Message.Content>
-  </Message>
+  <div>
+    <Message to avatar={<Avatar name="Buddy" />}>
+      <Message.Chat read timestamp="9:41am">
+        <Link href="https://en.wikipedia.org/wiki/Elf_(film)">
+          https://en.wikipedia.org/wiki/Elf_(film)
+        </Link>
+      </Message.Chat>
+      <Message.Content>
+        <PreviewCard
+          href="https://en.wikipedia.org/wiki/Elf_(film)"
+          title="Wikipedia: Elf (film)"
+          target="_blank"
+        >
+          Elf is a 2003 American Christmas fantasy comedy film directed by Jon
+          Favreau and written by David Berenbaum. It stars Will Ferrell, James
+          Caan, Zooey Deschanel, Mary Steenburgen, Daniel Tay, Edward Asner, and
+          Bob Newhart...
+        </PreviewCard>
+      </Message.Content>
+    </Message>
+    <Message to avatar={<Avatar name="Buddy" />} isNote>
+      <Message.Chat read timestamp="9:41am">
+        <Link href="https://en.wikipedia.org/wiki/Elf_(film)">
+          https://en.wikipedia.org/wiki/Elf_(film)
+        </Link>
+      </Message.Chat>
+      <Message.Content>
+        <PreviewCard
+          href="https://en.wikipedia.org/wiki/Elf_(film)"
+          title="Wikipedia: Elf (film)"
+          target="_blank"
+        >
+          Elf is a 2003 American Christmas fantasy comedy film directed by Jon
+          Favreau and written by David Berenbaum. It stars Will Ferrell, James
+          Caan, Zooey Deschanel, Mary Steenburgen, Daniel Tay, Edward Asner, and
+          Bob Newhart...
+        </PreviewCard>
+      </Message.Content>
+    </Message>
+  </div>
 ))
 
 stories.add('note', () => (


### PR DESCRIPTION
## Message.Content: Note theme

![screen shot 2018-07-20 at 2 30 24 pm](https://user-images.githubusercontent.com/2322354/43019111-d0fa03dc-8c29-11e8-918c-9aec8c26204e.jpg)


This update enhances the `Message.Content` component to add `isNote` theme
support.

This is done by leveraging the (polyfilled) React 16 `context` API, which sets
up a Provider/Consumer relationship between the `Message` component and the
`Card` component that renders within.

The activation of the note theme happens internally.

CSS has been refactored for the `PreviewCard` and `Message.Content` to use
Fancy instead of SCSS.

Lastly, the main `Message` component was converted from a SFC to a React.Class
component for a performance/stability boost.