### PR TITLE
AvatarGrid: Remove animation

### DIFF
--- a/src/components/AvatarGrid/README.md
+++ b/src/components/AvatarGrid/README.md
@@ -16,14 +16,13 @@ This component is similar to [AvatarList](../AvatarList) with minor UI and anima
 
 ## Props
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| animationEasing | `string` | Easing of [animation](../Animate) applied to the child [Avatars](../Avatar). |
-| animationSequence | `string` | Style of [animation](../Animate) applied to the child [Avatars](../Avatar). |
-| animationStagger | `number` | Amount (in `ms`) to stagger the [animations](../Animate) of the [Avatars](../Avatar). |
-| center | `bool` | Center aligns the component. |
-| children | `array`/[`<Avatar>`](../Avatar) | An [Avatar](../Avatar) component or an array of Avatars. |
-| className | `string` | Custom class names to be added to the component. |
-| max | `number` | Number of avatars to display before truncating. |
-| shape | `string` | Shape of the avatars. |
-| size | `string` | Size of the avatars. |
+| Prop              | Type                            | Description                                                                  |
+| ----------------- | ------------------------------- | ---------------------------------------------------------------------------- |
+| animationEasing   | `string`                        | Easing of [animation](../Animate) applied to the child [Avatars](../Avatar). |
+| animationSequence | `string`                        | Style of [animation](../Animate) applied to the child [Avatars](../Avatar).  |
+| center            | `bool`                          | Center aligns the component.                                                 |
+| children          | `array`/[`<Avatar>`](../Avatar) | An [Avatar](../Avatar) component or an array of Avatars.                     |
+| className         | `string`                        | Custom class names to be added to the component.                             |
+| max               | `number`                        | Number of avatars to display before truncating.                              |
+| shape             | `string`                        | Shape of the avatars.                                                        |
+| size              | `string`                        | Size of the avatars.                                                         |

--- a/src/components/AvatarGrid/__tests__/AvatarGrid.test.js
+++ b/src/components/AvatarGrid/__tests__/AvatarGrid.test.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import AvatarGrid from '..'
-import { AnimateGroup, Animate, Avatar, Text } from '../../index'
+import { Animate, Avatar, Text } from '../../index'
 
 describe('ClassName', () => {
   test('Has default className', () => {
-    const wrapper = shallow(<AvatarGrid />)
+    const wrapper = mount(<AvatarGrid />)
     const o = wrapper.find('.c-AvatarGrid')
 
     expect(o.hasClass('c-AvatarGrid')).toBeTruthy()
@@ -13,7 +13,7 @@ describe('ClassName', () => {
 
   test('Applies custom className if specified', () => {
     const customClass = 'piano-key-neck-tie'
-    const wrapper = shallow(<AvatarGrid className={customClass} />)
+    const wrapper = mount(<AvatarGrid className={customClass} />)
     const o = wrapper.find('.c-AvatarGrid')
 
     expect(o.prop('className')).toContain(customClass)
@@ -21,46 +21,8 @@ describe('ClassName', () => {
 })
 
 describe('Animation', () => {
-  test('Wraps children in an Animate, within an AnimateGroup', () => {
-    const wrapper = shallow(
-      <AvatarGrid>
-        <Avatar />
-      </AvatarGrid>
-    )
-    const o = wrapper.find(AnimateGroup)
-    const anime = o.find(Animate)
-    const avatar = o.find(Avatar)
-
-    expect(o.length).toBe(1)
-    expect(anime.length).toBe(1)
-    expect(avatar.length).toBe(1)
-  })
-
-  test('Passes staggering props to AnimateGroup', () => {
-    const wrapper = shallow(
-      <AvatarGrid>
-        <Avatar />
-      </AvatarGrid>
-    )
-    const props = wrapper.find(AnimateGroup).props()
-
-    expect(props.stagger).toBe(true)
-    expect(props.staggerDelay).toBeTruthy()
-  })
-
-  test('Can set custom AnimateGroup props', () => {
-    const wrapper = shallow(
-      <AvatarGrid animationStagger={1000}>
-        <Avatar />
-      </AvatarGrid>
-    )
-    const props = wrapper.find(AnimateGroup).props()
-
-    expect(props.staggerDelay).toBe(1000)
-  })
-
   test('Can set custom Animate sequences', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <AvatarGrid animationSequence="fade">
         <Avatar />
       </AvatarGrid>
@@ -73,7 +35,7 @@ describe('Animation', () => {
 
 describe('Children', () => {
   test('Discards non-Avatar children', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <AvatarGrid>
         <Avatar />
         <Text />
@@ -89,7 +51,7 @@ describe('Children', () => {
 
 describe('Limit', () => {
   test('Can limit the amount of avatars', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <AvatarGrid max={2}>
         <Avatar />
         <Avatar />
@@ -106,7 +68,7 @@ describe('Limit', () => {
   })
 
   test('Cannot set limit to zero (0)', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <AvatarGrid max={0}>
         <Avatar />
         <Avatar />

--- a/src/components/AvatarGrid/index.js
+++ b/src/components/AvatarGrid/index.js
@@ -1,15 +1,17 @@
 // @flow
+import type { AvatarShape, AvatarSize } from '../Avatar/types'
 import React, { PureComponent as Component } from 'react'
 import classNames from '../../utilities/classNames'
-import AnimateGroup from '../AnimateGroup'
 import Animate from '../Animate'
 import Avatar from '../Avatar'
-import type { AvatarShape, AvatarSize } from '../Avatar/types'
+import styled from '../styled'
+import avatarGridWrapperCSS from './styles/AvatarGridWrapper.css.js'
+import avatarGridContainerCSS from './styles/AvatarGridContainer.css.js'
+import avatarGridCSS from './styles/AvatarGrid.css.js'
 
 type Props = {
   animationEasing: string,
   animationSequence: string,
-  animationStagger: number,
   center: boolean,
   children?: any,
   className?: string,
@@ -18,11 +20,14 @@ type Props = {
   size: AvatarSize,
 }
 
+const AvatarGridWrapper = styled('div')(avatarGridWrapperCSS)
+const AvatarGridContainer = styled('div')(avatarGridContainerCSS)
+const AvatarGridComponent = styled('div')(avatarGridCSS)
+
 class AvatarGrid extends Component<Props> {
   static defaultProps = {
     animationEasing: 'bounce',
     animationSequence: 'fade',
-    animationStagger: 20,
     center: true,
     max: 9,
     shape: 'rounded',
@@ -33,7 +38,6 @@ class AvatarGrid extends Component<Props> {
     const {
       animationEasing,
       animationSequence,
-      animationStagger,
       center,
       children,
       className,
@@ -94,19 +98,14 @@ class AvatarGrid extends Component<Props> {
     })
 
     return (
-      <div className={componentWrapperClassName}>
-        <div className="c-AvatarGridContainer">
-          <AnimateGroup
-            className={componentClassName}
-            stagger
-            staggerDelay={animationStagger}
-            {...rest}
-          >
+      <AvatarGridWrapper className={componentWrapperClassName}>
+        <AvatarGridContainer className="c-AvatarGridContainer">
+          <AvatarGridComponent className={componentClassName} {...rest}>
             {avatarMarkup}
             {additionalAvatarMarkup}
-          </AnimateGroup>
-        </div>
-      </div>
+          </AvatarGridComponent>
+        </AvatarGridContainer>
+      </AvatarGridWrapper>
     )
   }
 }

--- a/src/components/AvatarGrid/styles/AvatarGrid.css.js
+++ b/src/components/AvatarGrid/styles/AvatarGrid.css.js
@@ -1,0 +1,15 @@
+// @flow
+import baseStyles from '../../../styles/resets/baseStyles.css.js'
+
+const css = `
+  ${baseStyles}
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+
+  > * {
+    margin: 3px;
+  }
+`
+
+export default css

--- a/src/components/AvatarGrid/styles/AvatarGridContainer.css.js
+++ b/src/components/AvatarGrid/styles/AvatarGridContainer.css.js
@@ -1,0 +1,11 @@
+// @flow
+import baseStyles from '../../../styles/resets/baseStyles.css.js'
+
+const css = `
+  ${baseStyles}
+  display: inline-block;
+  min-width: 32px;
+  max-width: 260px;
+`
+
+export default css

--- a/src/components/AvatarGrid/styles/AvatarGridWrapper.css.js
+++ b/src/components/AvatarGrid/styles/AvatarGridWrapper.css.js
@@ -1,0 +1,12 @@
+// @flow
+import baseStyles from '../../../styles/resets/baseStyles.css.js'
+
+const css = `
+  ${baseStyles}
+
+  &.is-center {
+    text-align: center;
+  }
+`
+
+export default css

--- a/src/styles/components/AvatarGrid.scss
+++ b/src/styles/components/AvatarGrid.scss
@@ -1,26 +1,2 @@
-.c-AvatarGridWrapper {
-  @import '../resets/base';
-  &.is-center {
-    text-align: center;
-  }
-}
-
-.c-AvatarGridContainer {
-  @import '../resets/base';
-  display: inline-block;
-  min-width: 32px;
-  max-width: 260px;
-}
-
-.c-AvatarGrid {
-  @import '../resets/base';
-
-  align-items: center;
-  -ms-display: flex;
-  display: flex;
-  flex-wrap: wrap;
-
-  > * {
-    margin: 3px;
-  }
-}
+// Is now being rendered by Fancy :)
+// File exists to preserve @import implementation.

--- a/stories/AvatarGrid/index.js
+++ b/stories/AvatarGrid/index.js
@@ -35,20 +35,33 @@ const aFewAvatarsMarkup = AvatarSpec.generate(2).map(avatar => {
 class TestComponent extends Component {
   constructor() {
     super()
-    this.state = { someProp: 0 }
-    this.updateState = this.updateState.bind(this)
+    this.state = { avatars: [], someProp: 0 }
   }
-  updateState() {
+
+  updateState = () => {
+    const avatars = AvatarSpec.generate(30).map(avatar => {
+      const { name, image, status } = avatar
+      return (
+        <Avatar
+          image={image}
+          key={name}
+          name={name}
+          shape="rounded"
+          status={status}
+        />
+      )
+    })
+
     this.setState({
-      someProp: this.state.someProp + 1,
+      avatars,
     })
   }
+
   render() {
-    console.log(`AvatarGrid: TestComponent: render(${this.state.someProp})`)
     return (
       <div>
-        <AvatarGrid max={14}>{avatarsMarkup}</AvatarGrid>
-        <button onClick={this.updateState}>Update: State</button>
+        <button onClick={this.updateState}>(Re)Render avatars</button>
+        <AvatarGrid max={14}>{this.state.avatars}</AvatarGrid>
       </div>
     )
   }


### PR DESCRIPTION
## AvatarGrid: Remove animation

![screen recording 2018-07-26 at 12 00 pm](https://user-images.githubusercontent.com/2322354/43276053-824c99be-90d1-11e8-9dfd-eec2e8bc02eb.gif)


This update fixes the (re)rendering issues for AvatarGrid, caused by
`AnimateGroup`. The `AnimateGroup` component works correctly. However, the
combination of it within the `AvatarGrid` UI may not be ideal.

The CSS styles for `AvatarGrid` now live in Fancy CSS-in-JS, and the original
SCSS removed.

Lastly, tests and the README doc were updated to reflect the changes.

---

Notes on other changes!

I've also started replacing `shallow` with `mount`. [Mount testing is much better](https://blog.kentcdodds.com/why-i-never-use-shallow-rendering-c08851a68bb7) at catching render bugs. It's only a teeny tiny bit slower... maybe by a couple of `ms`. Worth it.