### PR TITLE
Add a throttler to throttle startTyping events

### DIFF
--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -60,6 +60,7 @@ An Input component is an enhanced version of the default HTML `<input>`. Input c
 | suffix                   | `string`             | Text to appear after the input.                                           |
 | type                     | `string`             | Determines the input type.                                                |
 | typingTimeoutDelay       | `function`           | Determines the delay of when `onStopTyping` fires after typing stops.     |
+| typingThrottleInterval   | `function`           | Determines the interval for firing `onStartTyping`.                       |
 | value                    | `string`             | Initial value of the input.                                               |
 | withTypingEvent          | `bool`               | Enables typing `onStartTyping` and `onStopTyping` event callbacks.        |
 

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -62,6 +62,7 @@ type Props = {
   style: Object,
   suffix: string,
   type: string,
+  typingThrottleInterval: number,
   typingTimeoutDelay: number,
   value: InputValue,
   withTypingEvent: false,
@@ -71,7 +72,8 @@ type State = {
   id: string,
   height: ?number,
   state: ?UIState,
-  typingTimeout: any,
+  typingThrottle: ?IntervalID,
+  typingTimeout: ?TimeoutID,
   value: InputValue,
 }
 
@@ -99,8 +101,8 @@ class Input extends Component<Props, State> {
     seamless: false,
     state: '',
     type: 'text',
-    typingTimeoutDelay: 5000,
     typingThrottleInterval: 500,
+    typingTimeoutDelay: 5000,
     value: '',
     withTypingEvent: false,
   }
@@ -115,6 +117,7 @@ class Input extends Component<Props, State> {
       id: props.id || uniqueID(),
       height: null,
       state: props.state,
+      typingThrottle: undefined,
       typingTimeout: undefined,
       value: props.value,
     }


### PR DESCRIPTION
This PR adds a `throttler` for the `onStartTyping` callback and a `typingThrottleInterval` prop (so we can rate limit the frequency at which it is fired).