### PR TITLE
Input/Select: Add error icon support

### DIFF
--- a/src/components/Animate/README.md
+++ b/src/components/Animate/README.md
@@ -2,39 +2,37 @@
 
 An Animate component is a wrapper component that provides CSS-based animations. Animate is an extension of `<Transition>` from [`react-transition-group`](https://github.com/reactjs/react-transition-group/).
 
-
 ## Example
 
 ##### Fade in animation
 
 ```jsx
-<Animate sequence='fade'>
+<Animate sequence="fade">
   <Avatar name="Will Ferrell" image="will.png" />
 </Animate>
 ```
 
-
 ## Props
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| animateOnMount | `bool` | Automatically animates when component is rendered. Default is `true` |
-| block | `bool` | Applies `display: block` to the component. |
-| className | `string` | Custom class names to be added to the component. |
-| delay | `number` | The duration (in `ms`) to delay the animations. |
-| duration | `number` | The duration (in `ms`) for the animation sequence. Default `200`. |
-| easing | `string` | Determines the CSS easing transition function. Default `ease-in-out`. |
-| in | `bool` | Programatically triggering the animation. |
-| inline | `bool` | Applies `display: inline` to the component. |
-| inlineBlock | `bool` | Applies `display: inline-block` to the component. |
-| mountOnEnter | `bool` | Mounts child component as soon as `Animate` mounts. Default is `true` |
-| mountOnExit | `bool` | Unmounts child component as soon as `Animate` unmounts. Default is `true` |
-| onEnter | `function` | Callback before the component's `enter` animation sequence. |
-| onEntered | `function` | Callback after the component's `enter` animation sequence. |
-| onEntering | `function` | Callback during the component's `enter` animation sequence. |
-| onExit | `function` | Callback after the component's `exit` animation sequence. |
-| onExit | `function` | Callback before the component's `exit` animation sequence. |
-| onExiting | `function` | Callback during the component's `exit` animation sequence. |
-| sequence | `array`/`string` | Names of animation styles to apply. |
-| timeout | `number` | The duration (in `ms`) to apply/remove the animations. Default `0`. |
-| transitionProperty | `string` | Determines the CSS transition property. Default `all`. |
+| Prop               | Type             | Description                                                               |
+| ------------------ | ---------------- | ------------------------------------------------------------------------- |
+| animateOnMount     | `bool`           | Automatically animates when component is rendered. Default is `true`      |
+| block              | `bool`           | Applies `display: block` to the component.                                |
+| className          | `string`         | Custom class names to be added to the component.                          |
+| delay              | `number`         | The duration (in `ms`) to delay the animations.                           |
+| duration           | `number`         | The duration (in `ms`) for the animation sequence. Default `200`.         |
+| easing             | `string`         | Determines the CSS easing transition function. Default `ease-in-out`.     |
+| in                 | `bool`           | Programatically triggering the animation.                                 |
+| inline             | `bool`           | Applies `display: inline` to the component.                               |
+| inlineBlock        | `bool`           | Applies `display: inline-block` to the component.                         |
+| mountOnEnter       | `bool`           | Mounts child component as soon as `Animate` mounts. Default is `true`     |
+| onEnter            | `function`       | Callback before the component's `enter` animation sequence.               |
+| onEntered          | `function`       | Callback after the component's `enter` animation sequence.                |
+| onEntering         | `function`       | Callback during the component's `enter` animation sequence.               |
+| onExit             | `function`       | Callback after the component's `exit` animation sequence.                 |
+| onExit             | `function`       | Callback before the component's `exit` animation sequence.                |
+| onExiting          | `function`       | Callback during the component's `exit` animation sequence.                |
+| sequence           | `array`/`string` | Names of animation styles to apply.                                       |
+| timeout            | `number`         | The duration (in `ms`) to apply/remove the animations. Default `0`.       |
+| transitionProperty | `string`         | Determines the CSS transition property. Default `all`.                    |
+| unmountOnExit      | `bool`           | Unmounts child component as soon as `Animate` unmounts. Default is `true` |

--- a/src/components/Heading/styles/Heading.css.js
+++ b/src/components/Heading/styles/Heading.css.js
@@ -15,8 +15,8 @@ export const HEADING_SIZES = {
   h2: 24,
   h3: 20,
   h4: 16,
-  h5: BASE_FONT_SIZE,
-  h6: 13,
+  h5: 14,
+  h6: BASE_FONT_SIZE,
   big: 20,
   small: 11,
 }

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -5,33 +5,40 @@ An Icon component renders an SVG icon.
 ## Example
 
 ```jsx
-<Icon name='emoji' />
+<Icon name="emoji" />
 ```
-
 
 ## Props
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| center | `bool` | Center aligns component. |
-| className | `string` | Custom class names to be added to the component. |
-| clickable | `bool` | Enables the component to be clickable. |
-| ignoreClick | `bool` | Ignores click events. Bubbles click event to parent component. |
-| inline | `bool` | Displays the component as `inline-block`. |
-| muted | `bool` | Applies muted styles. |
-| name | `string` | Determines the SVG image. Required. |
-| onClick | `function` | Callback function when component is clicked. |
-| shade | `string` | Changes icon color shade. |
-| size | `number`/`string` | Adjusts the size of the component. |
-| title | `string` | Provides a name for the component. |
-| withCaret | `bool` | Renders a caret icon, next to the component's SVG icon. |
-
+| Prop        | Type              | Description                                                    |
+| ----------- | ----------------- | -------------------------------------------------------------- |
+| center      | `bool`            | Center aligns component.                                       |
+| className   | `string`          | Custom class names to be added to the component.               |
+| clickable   | `bool`            | Enables the component to be clickable.                         |
+| ignoreClick | `bool`            | Ignores click events. Bubbles click event to parent component. |
+| inline      | `bool`            | Displays the component as `inline-block`.                      |
+| muted       | `bool`            | Applies muted styles.                                          |
+| name        | `string`          | Determines the SVG image. Required.                            |
+| onClick     | `function`        | Callback function when component is clicked.                   |
+| state       | `string`          | Changes icon color to represent a state.                       |
+| shade       | `string`          | Changes icon color shade.                                      |
+| size        | `number`/`string` | Adjusts the size of the component.                             |
+| title       | `string`          | Provides a name for the component.                             |
+| withCaret   | `bool`            | Renders a caret icon, next to the component's SVG icon.        |
 
 ### Shades
 
-| Prop | Description |
-| --- | --- |
-| `subtle` | Medium-light grey. |
-| `muted` | Lighter grey. |
-| `faint` | Very lighter grey. |
-| `extraMuted` | Extra light grey. |
+| Prop         | Description        |
+| ------------ | ------------------ |
+| `subtle`     | Medium-light grey. |
+| `muted`      | Lighter grey.      |
+| `faint`      | Very lighter grey. |
+| `extraMuted` | Extra light grey.  |
+
+### States
+
+| Prop      | Description              |
+| --------- | ------------------------ |
+| `error`   | Changes color to red.    |
+| `success` | Changes color to green.  |
+| `warning` | Changes color to yellow. |

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -1,6 +1,6 @@
 // @flow
 import type { IconSize } from './types'
-import type { TextShade } from '../../constants/types'
+import type { TextShade, UIState } from '../../constants/types'
 import React from 'react'
 import ICONS from './icons'
 import styled from '../styled'
@@ -20,6 +20,7 @@ type Props = {
   name: string,
   onClick: () => void,
   shade?: TextShade,
+  state?: UIState,
   size: IconSize,
   subtle?: boolean,
   title?: string,
@@ -39,6 +40,7 @@ const Icon = (props: Props) => {
     name,
     shade,
     size,
+    state,
     subtle,
     title,
     withCaret,
@@ -55,6 +57,7 @@ const Icon = (props: Props) => {
     name && `is-iconName-${name}`,
     muted && 'is-muted',
     shade && `is-${shade}`,
+    state && `is-${state}`,
     subtle && 'is-subtle',
     size && `is-${size}`,
     withCaret && 'is-withCaret',

--- a/src/components/Icon/styles/Icon.css.js
+++ b/src/components/Icon/styles/Icon.css.js
@@ -1,8 +1,9 @@
 // @flow
 import { BEM } from '../../../utilities/classNames'
 import baseStyles from '../../../styles/resets/base.css.js'
+import { STATES, TEXT_SHADES } from '../../../styles/configs/constants'
 import { getColor } from '../../../styles/utilities/color'
-import { TEXT_SHADES } from '../../../styles/configs/constants'
+import forEach from '../../../styles/utilities/forEach'
 
 const bem = BEM('.c-Icon')
 
@@ -39,6 +40,7 @@ const css = `
 
   ${makeShadeStyles()}
   ${makeSizeStyles()}
+  ${makeStateColorStyles()}
 
   &.is-withCaret {
     ${bem.element('icon')} {
@@ -76,17 +78,19 @@ const css = `
 `
 
 function makeShadeStyles(): string {
-  return TEXT_SHADES.map(
+  return forEach(
+    TEXT_SHADES,
     shade => `
     &.is-${shade} {
       color: ${getColor('text', shade)};
     }
   `
-  ).join('')
+  )
 }
 
 function makeSizeStyles(): string {
-  return ICON_SIZES.map(
+  return forEach(
+    ICON_SIZES,
     size => `
     &.is-${size} {
       height: ${size}px;
@@ -97,7 +101,18 @@ function makeSizeStyles(): string {
       }
     }
   `
-  ).join('')
+  )
+}
+
+function makeStateColorStyles(): string {
+  return forEach(
+    STATES,
+    state => `
+    &.is-${state} {
+      color: ${getColor('state', state, 'default')};
+    }
+  `
+  )
 }
 
 export default css

--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -26,43 +26,45 @@ An Input component is an enhanced version of the default HTML `<input>`. Input c
 
 ## Props
 
-| Prop                     | Type                 | Description                                                               |
-| ------------------------ | -------------------- | ------------------------------------------------------------------------- |
-| autoFocus                | `bool`               | Automatically focuses the input.                                          |
-| className                | `string`             | Custom class names to be added to the component.                          |
-| disabled                 | `bool`               | Disable the input.                                                        |
-| forceAutoFocusTimeout    | `bool`               | Determines the amount of time (`ms`) for the component to focus on mount. |
-| helpText                 | `string`/`component` | Displays text underneath input.                                           |
-| hintText                 | `string`/`component` | Displays text above input.                                                |
-| id                       | `string`             | ID for the input.                                                         |
-| isFocused                | `string`             | Determines if the component is focused.                                   |
-| label                    | `string`/`component` | Label for the input.                                                      |
-| maxHeight                | `number`/`string`    | Sets the `max-height` for the input. Used with `multiline`.               |
-| moveCursorToEnd          | `boolean`            | Moves the selection cursor to the end, on focus. Default `false`.         |
-| multiline                | `bool`/`number`      | Transforms input into an auto-expanding textarea.                         |
-| name                     | `string`             | Name for the input.                                                       |
-| offsetAmount             | `number`             | Number of characters to offset (bottom-right) for multiline resizing.     |
-| onBlur                   | `function`           | Callback when input is blurred.                                           |
-| onChange                 | `function`           | Callback when input value is changed.                                     |
-| onFocus                  | `function`           | Callback when input is focused.                                           |
-| onStartTyping            | `function`           | Callback when user starts typing, rate limited by `typingThrottleInterval`|
-| onStopTyping             | `function`           | Callback when user stops typing after delay of `typingTimeoutDelay`.      |
-| placeholder              | `string`             | Placeholder text for the input.                                           |
-| prefix                   | `string`             | Text to appear before the input.                                          |
-| readOnly                 | `bool`               | Disable editing of the input.                                             |
-| refApplyCallStopTyping   | `function`           | Exposes `CallStopTyping`, so that it can be called outside itself.        |
-| removeStateStylesOnFocus | `bool`               | Removes the `state` styles on input focus. Default `false`.               |
-| resizable                | `bool`               | Enables resizing for the textarea (only enabled for `multiline`).         |
-| scrollLock               | `bool`               | Enables scrollLock for component. Default `false`.                        |
-| seamless                 | `bool`               | Removes the border around the input.                                      |
-| size                     | `string`             | Determines the size of the input.                                         |
-| state                    | `string`             | Change input to state color.                                              |
-| suffix                   | `string`             | Text to appear after the input.                                           |
-| type                     | `string`             | Determines the input type.                                                |
-| typingTimeoutDelay       | `number`             | Determines the delay of when `onStopTyping` fires after typing stops.     |
-| typingThrottleInterval   | `number`             | Determines the rate limiting interval for firing `onStartTyping`.         |
-| value                    | `string`             | Initial value of the input.                                               |
-| withTypingEvent          | `bool`               | Enables typing `onStartTyping` and `onStopTyping` event callbacks.        |
+| Prop                     | Type                 | Description                                                                |
+| ------------------------ | -------------------- | -------------------------------------------------------------------------- |
+| autoFocus                | `bool`               | Automatically focuses the input.                                           |
+| className                | `string`             | Custom class names to be added to the component.                           |
+| disabled                 | `bool`               | Disable the input.                                                         |
+| errorIcon                | `string`             | Icon that renders when the state is `error`.                               |
+| errorMessage             | `string`             | Error message that renders into a Tooltip.                                 |
+| forceAutoFocusTimeout    | `bool`               | Determines the amount of time (`ms`) for the component to focus on mount.  |
+| helpText                 | `string`/`component` | Displays text underneath input.                                            |
+| hintText                 | `string`/`component` | Displays text above input.                                                 |
+| id                       | `string`             | ID for the input.                                                          |
+| isFocused                | `string`             | Determines if the component is focused.                                    |
+| label                    | `string`/`component` | Label for the input.                                                       |
+| maxHeight                | `number`/`string`    | Sets the `max-height` for the input. Used with `multiline`.                |
+| moveCursorToEnd          | `boolean`            | Moves the selection cursor to the end, on focus. Default `false`.          |
+| multiline                | `bool`/`number`      | Transforms input into an auto-expanding textarea.                          |
+| name                     | `string`             | Name for the input.                                                        |
+| offsetAmount             | `number`             | Number of characters to offset (bottom-right) for multiline resizing.      |
+| onBlur                   | `function`           | Callback when input is blurred.                                            |
+| onChange                 | `function`           | Callback when input value is changed.                                      |
+| onFocus                  | `function`           | Callback when input is focused.                                            |
+| onStartTyping            | `function`           | Callback when user starts typing, rate limited by `typingThrottleInterval` |
+| onStopTyping             | `function`           | Callback when user stops typing after delay of `typingTimeoutDelay`.       |
+| placeholder              | `string`             | Placeholder text for the input.                                            |
+| prefix                   | `string`             | Text to appear before the input.                                           |
+| readOnly                 | `bool`               | Disable editing of the input.                                              |
+| refApplyCallStopTyping   | `function`           | Exposes `CallStopTyping`, so that it can be called outside itself.         |
+| removeStateStylesOnFocus | `bool`               | Removes the `state` styles on input focus. Default `false`.                |
+| resizable                | `bool`               | Enables resizing for the textarea (only enabled for `multiline`).          |
+| scrollLock               | `bool`               | Enables scrollLock for component. Default `false`.                         |
+| seamless                 | `bool`               | Removes the border around the input.                                       |
+| size                     | `string`             | Determines the size of the input.                                          |
+| state                    | `string`             | Change input to state color.                                               |
+| suffix                   | `string`             | Text to appear after the input.                                            |
+| type                     | `string`             | Determines the input type.                                                 |
+| typingTimeoutDelay       | `number`             | Determines the delay of when `onStopTyping` fires after typing stops.      |
+| typingThrottleInterval   | `number`             | Determines the rate limiting interval for firing `onStartTyping`.          |
+| value                    | `string`             | Initial value of the input.                                                |
+| withTypingEvent          | `bool`               | Enables typing `onStartTyping` and `onStopTyping` event callbacks.         |
 
 ### States
 

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -1,14 +1,17 @@
 import React from 'react'
-import { mount, shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import Input from '..'
 import Resizer from '../Resizer'
 
 const ui = {
   field: '.c-InputField',
+  errorIcon: '.c-Input__errorIcon',
   helpText: '.c-Input__helpText',
   hintText: '.c-Input__hintText',
   input: '.c-Input',
   label: '.c-Input__label',
+  suffix: '.c-Input__suffix',
+  tooltip: '.c-Tooltip',
 }
 
 describe('ClassName', () => {
@@ -25,7 +28,7 @@ describe('ClassName', () => {
 
   test('Accepts custom className', () => {
     const className = 'milk-was-a-bad-choice'
-    const wrapper = shallow(<Input className={className} />)
+    const wrapper = mount(<Input className={className} />)
     const o = wrapper.find(`.${className}`)
 
     expect(o.exists()).toBeTruthy()
@@ -34,14 +37,14 @@ describe('ClassName', () => {
 
 describe('Autofocus', () => {
   test('Does not autoFocus by default', () => {
-    const wrapper = shallow(<Input />)
+    const wrapper = mount(<Input />)
     const input = wrapper.find('input')
 
     expect(input.prop('autoFocus')).toBeFalsy()
   })
 
   test('Autofocuses if specified', () => {
-    const wrapper = shallow(<Input autoFocus />)
+    const wrapper = mount(<Input autoFocus />)
     const input = wrapper.find('input')
 
     expect(input.prop('autoFocus')).toBeTruthy()
@@ -186,24 +189,25 @@ describe('ID', () => {
 
 describe('Multiline', () => {
   test('Default selector is an input', () => {
-    const wrapper = shallow(<Input />)
-    const o = wrapper.find(ui.field)
+    const wrapper = mount(<Input />)
+    const o = wrapper.find(ui.field).getNode()
 
-    expect(o.getNode().type).toBe('input')
+    expect(o.tagName.toLowerCase()).toBe('input')
+    expect(o.type).toBe('text')
   })
 
   test('Selector becomes a textarea if multiline is defined', () => {
-    const wrapper = shallow(<Input multiline />)
-    const o = wrapper.find(ui.field)
+    const wrapper = mount(<Input multiline />)
+    const o = wrapper.find(ui.field).getNode()
 
-    expect(o.getNode().type).toBe('textarea')
+    expect(o.type).toBe('textarea')
   })
 
   test('Accepts number argument', () => {
     const wrapper = mount(<Input multiline={5} />)
-    const o = wrapper.find(ui.field)
+    const o = wrapper.find(ui.field).getNode()
 
-    expect(o.getNode().type).toBe('textarea')
+    expect(o.type).toBe('textarea')
   })
 
   test('Adds Resizer component if multiline is defined', () => {
@@ -213,14 +217,14 @@ describe('Multiline', () => {
   })
 
   test('Applies resizable styles if specified', () => {
-    const wrapper = shallow(<Input multiline resizable />)
+    const wrapper = mount(<Input multiline resizable />)
     const o = wrapper.find(ui.input)
 
     expect(o.prop('className')).toContain('is-resizable')
   })
 
   test('Has regular height without multiline', () => {
-    const wrapper = shallow(<Input />)
+    const wrapper = mount(<Input />)
     const o = wrapper.find(ui.field)
 
     expect(o.prop('style')).toBe(null)
@@ -375,21 +379,21 @@ describe('Prefix/Suffix', () => {
 
 describe('Styles', () => {
   test('Applies seamless styles if specified', () => {
-    const wrapper = shallow(<Input seamless />)
+    const wrapper = mount(<Input seamless />)
     const o = wrapper.find(ui.input)
 
     expect(o.prop('className')).toContain('is-seamless')
   })
 
   test('Applies sizing styles if specified', () => {
-    const wrapper = shallow(<Input size="sm" />)
+    const wrapper = mount(<Input size="sm" />)
     const o = wrapper.find(ui.field)
 
     expect(o.prop('className')).toContain('is-sm')
   })
 
   test('Passes style prop to wrapper', () => {
-    const wrapper = shallow(<Input size="sm" style={{ background: 'red' }} />)
+    const wrapper = mount(<Input size="sm" style={{ background: 'red' }} />)
 
     expect(wrapper.prop('style').background).toBe('red')
   })
@@ -397,7 +401,7 @@ describe('Styles', () => {
 
 describe('States', () => {
   test('Applies disabled styles if specified', () => {
-    const wrapper = shallow(<Input disabled />)
+    const wrapper = mount(<Input disabled />)
     const o = wrapper.find(ui.input)
     const input = wrapper.find('input')
 
@@ -406,7 +410,7 @@ describe('States', () => {
   })
 
   test('Applies readOnly styles if specified', () => {
-    const wrapper = shallow(<Input readOnly />)
+    const wrapper = mount(<Input readOnly />)
     const o = wrapper.find(ui.input)
     const input = wrapper.find('input')
 
@@ -415,21 +419,21 @@ describe('States', () => {
   })
 
   test('Applies error styles if specified', () => {
-    const wrapper = shallow(<Input state="error" />)
+    const wrapper = mount(<Input state="error" />)
     const o = wrapper.find(ui.input)
 
     expect(o.prop('className')).toContain('is-error')
   })
 
   test('Applies success styles if specified', () => {
-    const wrapper = shallow(<Input state="success" />)
+    const wrapper = mount(<Input state="success" />)
     const o = wrapper.find(ui.input)
 
     expect(o.prop('className')).toContain('is-success')
   })
 
   test('Applies warning styles if specified', () => {
-    const wrapper = shallow(<Input state="warning" />)
+    const wrapper = mount(<Input state="warning" />)
     const o = wrapper.find(ui.input)
 
     expect(o.prop('className')).toContain('is-warning')
@@ -661,5 +665,42 @@ describe('Typing events', () => {
     refs.applySubmit()
     expect(spies.onStopTyping).toHaveBeenCalledTimes(1)
     expect(spies.clearTypingTimeout).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('ErrorMessage', () => {
+  test('Does not render an error Icon if suffix is defined', () => {
+    const wrapper = mount(<Input suffix="Derek" />)
+    const el = wrapper.find(ui.errorIcon)
+
+    expect(el.length).toBe(0)
+  })
+
+  test('Can render an error Icon and suffix', () => {
+    const wrapper = mount(<Input suffix="Derek" state="error" />)
+    const error = wrapper.find(ui.errorIcon)
+    const suffix = wrapper.find(ui.suffix)
+
+    expect(error.length).toBe(1)
+    expect(suffix.length).toBe(2) // Error is rendered within a Suffix
+  })
+
+  test('Renders a Tooltip, if error', () => {
+    const wrapper = mount(
+      <Input suffix="Derek" state="error" errorMessage="Nope!" />
+    )
+    const el = wrapper.find('Tooltip')
+
+    expect(el.length).toBe(1)
+    expect(el.props().title).toBe('Nope!')
+  })
+
+  test('Can customize error Icon', () => {
+    const wrapper = mount(
+      <Input suffix="Derek" state="error" errorIcon="chat" />
+    )
+    const el = wrapper.find('Icon')
+
+    expect(el.props().name).toBe('chat')
   })
 })

--- a/src/components/Input/__tests__/Resizer.test.js
+++ b/src/components/Input/__tests__/Resizer.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount, shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import Resizer from '../Resizer'
 
 describe('onResize', () => {
@@ -13,7 +13,7 @@ describe('onResize', () => {
 
 describe('ReplaceEntity', () => {
   test('Converts greater/less than characters', () => {
-    const wrapper = shallow(<Resizer contents="<strong>News team!</strong>" />)
+    const wrapper = mount(<Resizer contents="<strong>News team!</strong>" />)
     const o = wrapper.find('.c-InputGhost').first()
     const html = o
       .html()
@@ -27,7 +27,7 @@ describe('ReplaceEntity', () => {
   })
 
   test('Converts \\n characters to <br>', () => {
-    const wrapper = shallow(<Resizer contents={`\nSan Diego\n`} />)
+    const wrapper = mount(<Resizer contents={`\nSan Diego\n`} />)
     const o = wrapper.find('.c-InputGhost').first()
     const html = o
       .html()
@@ -39,7 +39,7 @@ describe('ReplaceEntity', () => {
   })
 
   test('Converts & characters to &amp;', () => {
-    const wrapper = shallow(<Resizer contents="San & Diego" />)
+    const wrapper = mount(<Resizer contents="San & Diego" />)
     const o = wrapper.find('.c-InputGhost').first()
     const html = o
       .html()
@@ -51,7 +51,7 @@ describe('ReplaceEntity', () => {
   })
 
   test('Does not convert if content does not contain special characters', () => {
-    const wrapper = shallow(<Resizer contents="San Diego" />)
+    const wrapper = mount(<Resizer contents="San Diego" />)
     const o = wrapper.find('.c-InputGhost').first()
     const html = o
       .html()

--- a/src/components/Input/__tests__/Static.test.js
+++ b/src/components/Input/__tests__/Static.test.js
@@ -1,16 +1,16 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import Static from '../Static'
 
 describe('ClassName', () => {
   test('Has the correct CSS class', () => {
-    const wrapper = shallow(<Static />)
+    const wrapper = mount(<Static />)
 
     expect(wrapper.hasClass('c-InputStatic')).toBeTruthy()
   })
 
   test('Accepts additional classNames', () => {
-    const wrapper = shallow(<Static className="mugatu" />)
+    const wrapper = mount(<Static className="mugatu" />)
 
     expect(wrapper.hasClass('mugatu')).toBeTruthy()
   })
@@ -18,7 +18,7 @@ describe('ClassName', () => {
 
 describe('Children', () => {
   test('Can render child components', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <Static>
         <div className="mugatu" />
       </Static>
@@ -33,7 +33,7 @@ describe('Children', () => {
 describe('Style', () => {
   test('Accepts style prop', () => {
     const style = { background: 'red' }
-    const wrapper = shallow(<Static style={style} />)
+    const wrapper = mount(<Static style={style} />)
 
     expect(wrapper.html()).toContain('style')
     expect(wrapper.html()).toContain('background')
@@ -43,7 +43,7 @@ describe('Style', () => {
 
 describe('Size', () => {
   test('Can render an additional size', () => {
-    const wrapper = shallow(<Static size="md" />)
+    const wrapper = mount(<Static size="md" />)
 
     expect(wrapper.hasClass('c-InputStatic')).toBeTruthy()
     expect(wrapper.hasClass('is-md')).toBeTruthy()
@@ -52,7 +52,7 @@ describe('Size', () => {
 
 describe('Alignment', () => {
   test('Can be aligned left', () => {
-    const wrapper = shallow(<Static align="left" />)
+    const wrapper = mount(<Static align="left" />)
 
     expect(wrapper.hasClass('c-InputStatic')).toBeTruthy()
     expect(wrapper.hasClass('is-block')).toBeTruthy()
@@ -60,7 +60,7 @@ describe('Alignment', () => {
   })
 
   test('Can be aligned center', () => {
-    const wrapper = shallow(<Static align="center" />)
+    const wrapper = mount(<Static align="center" />)
 
     expect(wrapper.hasClass('c-InputStatic')).toBeTruthy()
     expect(wrapper.hasClass('is-block')).toBeTruthy()
@@ -68,7 +68,7 @@ describe('Alignment', () => {
   })
 
   test('Can be aligned right', () => {
-    const wrapper = shallow(<Static align="right" />)
+    const wrapper = mount(<Static align="right" />)
 
     expect(wrapper.hasClass('c-InputStatic')).toBeTruthy()
     expect(wrapper.hasClass('is-block')).toBeTruthy()

--- a/src/components/Pop/Popper.js
+++ b/src/components/Pop/Popper.js
@@ -1,4 +1,5 @@
 // @flow
+import type { PopProps, PopperStyles } from './types'
 import React, { Component } from 'react'
 import ReactPopper from '../Popper/Popper'
 import Animate from '../Animate'
@@ -6,7 +7,6 @@ import Portal from '../Portal'
 import Arrow from './Arrow'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
-import type { PopProps, Placement, PopperStyles } from './types'
 
 type Props = PopProps
 
@@ -66,6 +66,7 @@ class Popper extends Component<Props> {
       duration: animationDuration,
       easing: animationEasing,
       sequence: animationSequence,
+      timeout: 0,
     }
 
     return (

--- a/src/components/Pop/Reference.js
+++ b/src/components/Pop/Reference.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react'
 import ReactPopperReference from '../Popper/Reference'
+import styled from '../styled'
 
 type Props = any
 
@@ -9,12 +10,20 @@ class Reference extends Component<Props> {
     return (
       <ReactPopperReference>
         {({ ref }) => (
-          <span className="c-PopReference" ref={ref} {...this.props} />
+          <ReferenceUI
+            className="c-PopReference"
+            innerRef={ref}
+            {...this.props}
+          />
         )}
       </ReactPopperReference>
     )
   }
 }
+
+const ReferenceUI = styled('span')`
+  display: ${props => props.display};
+`
 
 Reference.displayName = 'Pop.Reference'
 

--- a/src/components/Pop/index.js
+++ b/src/components/Pop/index.js
@@ -1,17 +1,18 @@
 // @flow
+import type { PopProps } from './types'
 import React, { Component } from 'react'
 import EventListener from '../EventListener'
 import KeypressListener from '../KeypressListener'
-import Portal from '../Portal'
 import Manager from './Manager'
 import Arrow from './Arrow'
 import Popper from './Popper'
 import Reference from './Reference'
+import styled from '../styled'
 import Keys from '../../constants/Keys'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 import { createUniqueIDFactory } from '../../utilities/id'
-import type { PopProps } from './types'
+import css from './styles/Pop.css.js'
 
 type Props = PopProps
 
@@ -21,6 +22,8 @@ type State = {
 }
 
 const uniqueID = createUniqueIDFactory('Pop')
+
+const PopUI = styled('span')(css)
 
 class Pop extends Component<Props, State> {
   static defaultProps = {
@@ -140,6 +143,7 @@ class Pop extends Component<Props, State> {
         child.type === Reference
           ? React.cloneElement(child, {
               'aria-describedby': id,
+              display,
             })
           : null
     )
@@ -168,9 +172,9 @@ class Pop extends Component<Props, State> {
 
     return (
       <Manager>
-        <span
+        <PopUI
           className={componentClassName}
-          ref={node => (this.node = node)}
+          innerRef={node => (this.node = node)}
           onMouseEnter={this.handleMouseEnter}
           onMouseLeave={this.handleMouseLeave}
           onClick={this.handleClick}
@@ -179,7 +183,7 @@ class Pop extends Component<Props, State> {
           <KeypressListener keyCode={Keys.ESCAPE} handler={this.handleOnEsc} />
           {referenceMarkup}
           {shouldShowPopper ? popperMarkup : null}
-        </span>
+        </PopUI>
       </Manager>
     )
   }

--- a/src/components/Pop/styles/Pop.css.js
+++ b/src/components/Pop/styles/Pop.css.js
@@ -1,0 +1,15 @@
+import baseStyles from '../../../styles/resets/baseStyles.css.js'
+
+const css = `
+  ${baseStyles}
+
+  &.is-display-block {
+    display: block;
+  }
+
+  &.is-display-inline-block {
+    display: inline-block;
+  }
+`
+
+export default css

--- a/src/components/Pop/styles/PopArrow.css.js
+++ b/src/components/Pop/styles/PopArrow.css.js
@@ -1,3 +1,5 @@
+import baseStyles from '../../../styles/resets/baseStyles.css.js'
+
 const css = props => {
   const { color, placement, size } = props
   const sizePx = `${size}px`
@@ -30,6 +32,7 @@ const css = props => {
   `
 
   return `
+    ${baseStyles}
     ${borderColor}
     border-style: solid;
     height: 0;

--- a/src/components/Select/README.md
+++ b/src/components/Select/README.md
@@ -2,28 +2,29 @@
 
 A Select component is an enhanced version of the default HTML `<select>`.
 
-
 ## Example
 
 ```jsx
-<Select placeholder="Pick one" options={['You sit on a throne of lies!', 'Son of a nutcracker!']} autoFocus />
+<Select
+  placeholder="Pick one"
+  options={['You sit on a throne of lies!', 'Son of a nutcracker!']}
+  autoFocus
+/>
 ```
-
 
 ### Option groups
 
 ```jsx
-<Select options={[
-  {
-    label: 'Quotes',
-    value: [
-      'You sit on a throne of lies!',
-      'Son of a nutcracker!'
-    ]
-  }
-  ]} autoFocus />
+<Select
+  options={[
+    {
+      label: 'Quotes',
+      value: ['You sit on a throne of lies!', 'Son of a nutcracker!'],
+    },
+  ]}
+  autoFocus
+/>
 ```
-
 
 ### Children options
 
@@ -37,40 +38,40 @@ This component also accepts regular `<option>` elements as children.
 </Select>
 ```
 
-
 ## Props
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| autoFocus | `bool` | Automatically focuses the select. |
-| className | `string` | Custom class names to be added to the component. |
-| disabled | `bool` | Disable the select. |
-| forceAutoFocusTimeout | `bool` | Determines the amount of time (`ms`) for the component to focus on mount. |
-| helpText | `string`/`component` | Displays text underneath select. |
-| hintText | `string`/`component` | Displays text above select. |
-| id | `string` | ID for the select. |
-| isFocused | `string` | Determines if the component is focused. |
-| label | `string`/`component` | Label for the select. |
-| name | `string` | Name for the select. |
-| onBlur | `function` | Callback when select is blurred. |
-| onChange | `function` | Callback when select value is changed. |
-| onFocus | `function` | Callback when select is focused. |
-| options | `array`/`object`/`string` | List of options to choose from. |
-| placeholder | `string` | Placeholder text for the select. |
-| prefix | `string` | Text to appear before the select. |
-| readOnly | `bool` | Disable editing of the select. |
-| removeStateStylesOnFocus | `bool` | Removes the `state` styles on input focus. Default `false`. |
-| seamless | `bool` | Removes the border around the select. |
-| size | `bool` | Determines the size of the select. |
-| state | `string` | Change select to state color. |
-| suffix | `string` | Text to appear after the select. |
-| value | `string` | Initial value of the select. |
-
+| Prop                     | Type                      | Description                                                               |
+| ------------------------ | ------------------------- | ------------------------------------------------------------------------- |
+| autoFocus                | `bool`                    | Automatically focuses the select.                                         |
+| className                | `string`                  | Custom class names to be added to the component.                          |
+| disabled                 | `bool`                    | Disable the select.                                                       |
+| errorIcon                | `string`                  | Icon that renders when the state is `error`.                              |
+| errorMessage             | `string`                  | Error message that renders into a Tooltip.                                |
+| forceAutoFocusTimeout    | `bool`                    | Determines the amount of time (`ms`) for the component to focus on mount. |
+| helpText                 | `string`/`component`      | Displays text underneath select.                                          |
+| hintText                 | `string`/`component`      | Displays text above select.                                               |
+| id                       | `string`                  | ID for the select.                                                        |
+| isFocused                | `string`                  | Determines if the component is focused.                                   |
+| label                    | `string`/`component`      | Label for the select.                                                     |
+| name                     | `string`                  | Name for the select.                                                      |
+| onBlur                   | `function`                | Callback when select is blurred.                                          |
+| onChange                 | `function`                | Callback when select value is changed.                                    |
+| onFocus                  | `function`                | Callback when select is focused.                                          |
+| options                  | `array`/`object`/`string` | List of options to choose from.                                           |
+| placeholder              | `string`                  | Placeholder text for the select.                                          |
+| prefix                   | `string`                  | Text to appear before the select.                                         |
+| readOnly                 | `bool`                    | Disable editing of the select.                                            |
+| removeStateStylesOnFocus | `bool`                    | Removes the `state` styles on input focus. Default `false`.               |
+| seamless                 | `bool`                    | Removes the border around the select.                                     |
+| size                     | `bool`                    | Determines the size of the select.                                        |
+| state                    | `string`                  | Change select to state color.                                             |
+| suffix                   | `string`                  | Text to appear after the select.                                          |
+| value                    | `string`                  | Initial value of the select.                                              |
 
 ### States
 
-| Prop | Description |
-| --- | --- |
-| `error` | Changes color to red. |
-| `success` | Changes color to green. |
+| Prop      | Description              |
+| --------- | ------------------------ |
+| `error`   | Changes color to red.    |
+| `success` | Changes color to green.  |
 | `warning` | Changes color to yellow. |

--- a/src/components/Select/tests/Select.test.js
+++ b/src/components/Select/tests/Select.test.js
@@ -1,12 +1,15 @@
 import React from 'react'
-import { mount, shallow } from 'enzyme'
-import Select from '..'
+import { mount } from 'enzyme'
+import Select from '../index'
 
 const ui = {
+  errorIcon: '.c-Select__errorIcon',
   helpText: '.c-Select__helpText',
   hintText: '.c-Select__hintText',
   label: '.c-Select__label',
 }
+
+jest.useFakeTimers()
 
 describe('Placeholder', () => {
   test('Renders a placeholder if defined', () => {
@@ -287,7 +290,7 @@ describe('HintText', () => {
 
 describe('States', () => {
   test('Disables select if disabled prop is true', () => {
-    const wrapper = shallow(<Select disabled />)
+    const wrapper = mount(<Select disabled />)
     const o = wrapper.find('select')
 
     expect(o.prop('disabled')).toBeTruthy()
@@ -295,7 +298,7 @@ describe('States', () => {
 
   describe('Error', () => {
     test('Applies error styles if error prop is true', () => {
-      const wrapper = shallow(<Select state="error" />)
+      const wrapper = mount(<Select state="error" />)
       const o = wrapper.find('.c-Select')
 
       expect(o.prop('className')).toContain('is-error')
@@ -312,7 +315,7 @@ describe('States', () => {
 
   describe('Success', () => {
     test('Applies success styles if success prop is true', () => {
-      const wrapper = shallow(<Select state="success" />)
+      const wrapper = mount(<Select state="success" />)
       const o = wrapper.find('.c-Select')
 
       expect(o.prop('className')).toContain('is-success')
@@ -329,7 +332,7 @@ describe('States', () => {
 
   describe('Warning', () => {
     test('Applies warning styles if warning prop is true', () => {
-      const wrapper = shallow(<Select state="warning" />)
+      const wrapper = mount(<Select state="warning" />)
       const o = wrapper.find('.c-Select')
 
       expect(o.prop('className')).toContain('is-warning')
@@ -376,7 +379,7 @@ describe('Styles', () => {
   })
 
   test('Passes style prop to wrapper', () => {
-    const wrapper = shallow(<Select style={{ background: 'red' }} />)
+    const wrapper = mount(<Select style={{ background: 'red' }} />)
 
     expect(wrapper.prop('style').background).toBe('red')
   })
@@ -422,19 +425,18 @@ describe('selectNode', () => {
 })
 
 describe('isFocused', () => {
-  test('Can focus select using isFocused prop', done => {
+  test('Can focus select using isFocused prop', () => {
     const spy = jest.fn()
     const wrapper = mount(<Select isFocused />)
     const o = wrapper.getNode().selectNode
     o.onfocus = spy
 
-    setTimeout(() => {
-      expect(spy).toHaveBeenCalled()
-      done()
-    }, 160)
+    jest.runOnlyPendingTimers()
+
+    expect(spy).toHaveBeenCalled()
   })
 
-  test('Can focus select using custom timeout', done => {
+  test('Can focus select using custom timeout', () => {
     const spy = jest.fn()
     const wrapper = mount(<Select isFocused forceAutoFocusTimeout={20} />)
     const o = wrapper.getNode().selectNode
@@ -442,13 +444,12 @@ describe('isFocused', () => {
 
     expect(spy).not.toHaveBeenCalled()
 
-    setTimeout(() => {
-      expect(spy).toHaveBeenCalled()
-      done()
-    }, 40)
+    jest.runOnlyPendingTimers()
+
+    expect(spy).toHaveBeenCalled()
   })
 
-  test('Can toggle isFocused', done => {
+  test('Can toggle isFocused', () => {
     const spy = jest.fn()
     const wrapper = mount(
       <Select onFocus={spy} isFocused={false} forceAutoFocusTimeout={20} />
@@ -458,9 +459,32 @@ describe('isFocused', () => {
 
     wrapper.setProps({ isFocused: true })
 
-    setTimeout(() => {
-      expect(spy).toHaveBeenCalled()
-      done()
-    }, 40)
+    jest.runOnlyPendingTimers()
+
+    expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('ErrorMessage', () => {
+  test('Can render an error Icon ', () => {
+    const wrapper = mount(<Select state="error" />)
+    const error = wrapper.find(ui.errorIcon)
+
+    expect(error.length).toBe(1)
+  })
+
+  test('Renders a Tooltip, if error', () => {
+    const wrapper = mount(<Select state="error" errorMessage="Nope!" />)
+    const el = wrapper.find('Tooltip')
+
+    expect(el.length).toBe(1)
+    expect(el.props().title).toBe('Nope!')
+  })
+
+  test('Can customize error Icon', () => {
+    const wrapper = mount(<Select state="error" errorIcon="chat" />)
+    const el = wrapper.find('Icon')
+
+    expect(el.props().name).toBe('chat')
   })
 })

--- a/src/components/Select/types.js
+++ b/src/components/Select/types.js
@@ -1,0 +1,15 @@
+export type SelectValue = string
+
+export type Option = {
+  disable: boolean,
+  label: string,
+  value: SelectValue
+}
+
+export type SelectOption = Option | SelectValue
+export type SelectOptions = Array<SelectOption>
+
+export type SelectGroup = {
+  label: string,
+  value: SelectOptions,
+}

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -1,13 +1,12 @@
 // @flow
 import React, { Component } from 'react'
 import styled from '../styled'
-import Animate from '../Animate'
 import Pop from '../Pop'
 import Popper from './Popper'
 import classNames, { BEM } from '../../utilities/classNames'
 import { isFunction } from '../../utilities/is'
 import css from './styles/Tooltip.css.js'
-import type { PopProps, Placements } from '../Pop/types'
+import type { PopProps } from '../Pop/types'
 
 type Props = {|
   ...PopProps,
@@ -18,7 +17,7 @@ type Props = {|
 class Tooltip extends Component<Props> {
   static defaultProps = {
     animationDelay: 100,
-    animationDuration: 200,
+    animationDuration: 100,
     animationSequence: 'fade up',
     isOpen: false,
     modifiers: {},

--- a/src/components/Truncate/index.js
+++ b/src/components/Truncate/index.js
@@ -123,6 +123,7 @@ export class BaseComponent extends Component<Props, State> {
     const content = shouldShowTooltip ? (
       <Tooltip
         {...tooltipProps}
+        display="block"
         placement={tooltipPlacement}
         title={title || this.getText()}
       >

--- a/src/components/Truncate/styles/Truncate.css.js
+++ b/src/components/Truncate/styles/Truncate.css.js
@@ -1,12 +1,24 @@
+import { BEM } from '../../../utilities/classNames'
+
+const bem = BEM('.c-Truncate')
+
+const truncateStyles = `
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`
+
 const css = `
   box-sizing: border-box;
   will-change: contents;
 
   &.is-auto {
     display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    ${truncateStyles}
+
+    ${bem.element('content')} {
+      ${truncateStyles}
+    }
   }
 `
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,5 @@
+export const STATES = {
+  error: 'error',
+  success: 'success',
+  warning: 'warning',
+}

--- a/src/styles/components/Select/SelectIcon.scss
+++ b/src/styles/components/Select/SelectIcon.scss
@@ -1,6 +1,6 @@
 .c-SelectIcon {
-  @import "../../resets/base";
-  @import "../../configs/color";
+  @import '../../resets/base';
+  @import '../../configs/color';
 
   $arrowOffset: 2px;
   $arrowSize: 3px;
@@ -23,7 +23,7 @@
     border-left: $arrowSize solid transparent;
     border-right: $arrowSize solid transparent;
     bottom: 0;
-    content: "";
+    content: '';
     margin: $arrowOffset;
     position: absolute;
   }
@@ -32,9 +32,13 @@
     border-top: ($arrowSize + 1) solid currentColor;
     border-left: $arrowSize solid transparent;
     border-right: $arrowSize solid transparent;
-    content: "";
+    content: '';
     margin: $arrowOffset;
     position: absolute;
     top: 0;
+  }
+
+  &.is-error {
+    margin-right: 28px;
   }
 }

--- a/src/styles/mixins/input-styles.scss
+++ b/src/styles/mixins/input-styles.scss
@@ -1,4 +1,5 @@
-@import "pack/seed-family/_index";
+@import 'pack/seed-family/_index';
+@import '../configs/constants';
 
 @mixin input-styles($padding: 8px) {
   align-items: center;
@@ -26,17 +27,40 @@
     top: 0;
     white-space: nowrap;
 
-    @include parent(".has-value >") {
+    @include parent('.has-value >') {
       opacity: 1;
     }
+
+    &.is-icon {
+      opacity: 1;
+
+      @include parent('.is-multiline >') {
+        align-self: flex-start;
+        padding-top: 9px;
+      }
+    }
+
+    // States
+    @each $state in $STATES {
+      @include parent('.is-#{$state} > ') {
+        color: _color(state, $state, color);
+      }
+    }
+  }
+
+  &__prefix.is-icon {
+    margin-left: -8px;
+  }
+
+  &__suffix.is-icon {
+    margin-right: -8px;
   }
 }
 
 @mixin input-normalize-autofill-styles($background: white) {
   &:-webkit-autofill,
   &:-webkit-autofill:hover,
-  &:-webkit-autofill:focus
-  &:-webkit-autofill {
+  &:-webkit-autofill:focus &:-webkit-autofill {
     -webkit-box-shadow: 0 0 0px 1000px $background inset;
     background-clip: content-box;
     transition: background-color 5000s ease-in-out 0s;

--- a/stories/Input.js
+++ b/stories/Input.js
@@ -109,6 +109,19 @@ stories.add('states', () => (
   </div>
 ))
 
+stories.add('state: error', () => (
+  <div>
+    <Input state="error" errorMessage="This is incorrect!" />
+    <br />
+    <Input state="error" suffix=".00" errorMessage="This is incorrect!" />
+    <br />
+    <Input state="error" size="sm" errorMessage="This is incorrect!" />
+    <br />
+    <Input state="error" errorMessage="This is incorrect!" multiline={3} />
+    <br />
+  </div>
+))
+
 stories.add('scrollock', () => (
   <Input
     multiline={3}

--- a/stories/Select.js
+++ b/stories/Select.js
@@ -48,6 +48,15 @@ stories.add('states', () => (
   </div>
 ))
 
+stories.add('state: error', () => (
+  <div>
+    <Select state="error" errorMessage="This is error." />
+    <br />
+    <Select state="error" size="sm" errorMessage="This is error." />
+    <br />
+  </div>
+))
+
 stories.add('sizes', () => (
   <div>
     <Select autoFocus placeholder="Regular" />


### PR DESCRIPTION
## Input/Select: Add error icon support

![screen recording 2018-07-30 at 01 07 pm](https://user-images.githubusercontent.com/2322354/43418173-259b79f0-940b-11e8-9410-f3c7b03950c7.gif)


This update enhances the `Input` and `Select` components with error icon
rendering. If these components have a `state` (prop) of `error`, they will
automatically add an error `Icon` at the end.

These error `Icon` have the ability to render a `Tooltip` message, if
the prop `errorMessage` is provided.

The `Select` component was refactored with Flow (yay).

![screen shot 2018-07-30 at 2 47 13 pm](https://user-images.githubusercontent.com/2322354/43418181-2bda714a-940b-11e8-90d7-6309333d4c1b.jpg)

(Select + error)

For this update, I held off refactoring the CSS of `Input` and `Select`
with Fancy (for now).

Other updates include swapping `shallow` for `mount` rendering in tests,
updating tests, and improving `Truncate`/`Tooltip`/`Pop` rendering.