### PR TITLE
Truncate: Improve calculation reliability

### DIFF
--- a/src/components/Pop/styles/Pop.css.js
+++ b/src/components/Pop/styles/Pop.css.js
@@ -1,4 +1,5 @@
-import baseStyles from '../../../styles/resets/baseStyles.css.js'
+// @flow
+import baseStyles from '../../../styles/resets/base.css.js'
 
 const css = `
   ${baseStyles}

--- a/src/components/Pop/styles/PopArrow.css.js
+++ b/src/components/Pop/styles/PopArrow.css.js
@@ -1,7 +1,8 @@
-import baseStyles from '../../../styles/resets/baseStyles.css.js'
+// @flow
+import baseStyles from '../../../styles/resets/base.css.js'
 
-const css = props => {
-  const { color, placement, size } = props
+const css = (props: Object) => {
+  const { color, size } = props
   const sizePx = `${size}px`
   const dblSizePx = `${size * 2}px`
 

--- a/src/components/Tooltip/styles/Tooltip.css.js
+++ b/src/components/Tooltip/styles/Tooltip.css.js
@@ -1,5 +1,6 @@
-import baseStyles from '../../../styles/resets/base.css'
-import { color } from './variables.css'
+// @flow
+import baseStyles from '../../../styles/resets/base.css.js'
+import { color } from './variables.css.js'
 
 const css = `
   ${baseStyles}

--- a/src/components/Tooltip/styles/TooltipPopper.css.js
+++ b/src/components/Tooltip/styles/TooltipPopper.css.js
@@ -1,5 +1,6 @@
-import baseStyles from '../../../styles/resets/baseStyles.css'
-import { color } from './variables.css'
+// @flow
+import baseStyles from '../../../styles/resets/base.css.js'
+import { color } from './variables.css.js'
 
 const css = `
   ${baseStyles}

--- a/src/components/Truncate/__tests__/Truncate.test.js
+++ b/src/components/Truncate/__tests__/Truncate.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { createSpec, faker } from '@helpscout/helix'
-import { mount, shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import Tooltip from '../../Tooltip'
 import { BaseComponent as Truncate } from '../index'
 
@@ -19,14 +19,14 @@ describe('default', () => {
 describe('className', () => {
   test('Has default className', () => {
     const words = fixture.generate()
-    const wrapper = shallow(<Truncate>{words}</Truncate>)
+    const wrapper = mount(<Truncate>{words}</Truncate>)
 
     expect(wrapper.hasClass('c-Truncate')).toBeTruthy()
   })
 
   test('Accepts additional className', () => {
     const words = fixture.generate()
-    const wrapper = shallow(<Truncate className="mugatu">{words}</Truncate>)
+    const wrapper = mount(<Truncate className="mugatu">{words}</Truncate>)
 
     expect(wrapper.hasClass('mugatu')).toBeTruthy()
   })
@@ -36,7 +36,7 @@ describe('ellipsis', () => {
   test('Can render custom ellipsis', () => {
     const words = fixture.generate()
     const ellipsis = 'RELAX!! ++ '
-    const wrapper = shallow(
+    const wrapper = mount(
       <Truncate ellipsis={ellipsis} type="start" limit={20}>
         {words}
       </Truncate>
@@ -106,22 +106,33 @@ describe('Truncate: Check', () => {
   test('isTruncated can calculate truncation', () => {
     const props = { type: 'auto' }
     const wrapper = mount(<Truncate>Words</Truncate>)
+    const o = wrapper.getNode()
 
-    wrapper.getNode().node = {
+    o.node = {
       offsetWidth: 100,
-      scrollWidth: 1000,
     }
-    expect(wrapper.getNode().isTruncated(props)).toBe(true)
+    o.contentNode = {
+      style: {
+        display: undefined,
+      },
+      offsetWidth: 200,
+    }
+    expect(o.isTruncated(props)).toBe(true)
 
-    wrapper.getNode().node = {
+    o.node = {
       offsetWidth: 1000,
-      scrollWidth: 100,
     }
-    expect(wrapper.getNode().isTruncated(props)).toBe(false)
+    o.contentNode = {
+      style: {
+        display: undefined,
+      },
+      offsetWidth: 200,
+    }
+    expect(o.isTruncated(props)).toBe(false)
   })
 
   test('Recalculates on appropriate prop change', () => {
-    const wrapper = mount(<Truncate>Words</Truncate>)
+    const wrapper = mount(<Truncate type="auto">Words</Truncate>)
 
     expect(wrapper.state().isTruncated).toBe(false)
 

--- a/src/components/Truncate/propTypes.js
+++ b/src/components/Truncate/propTypes.js
@@ -1,3 +1,0 @@
-import PropTypes from 'prop-types'
-
-export const truncateTypes = PropTypes.oneOf(['auto', 'start', 'middle', 'end'])

--- a/src/components/Truncate/styles/Truncate.css.js
+++ b/src/components/Truncate/styles/Truncate.css.js
@@ -3,6 +3,7 @@ import { BEM } from '../../../utilities/classNames'
 const bem = BEM('.c-Truncate')
 
 const truncateStyles = `
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -13,7 +14,6 @@ const css = `
   will-change: contents;
 
   &.is-auto {
-    display: block;
     ${truncateStyles}
 
     ${bem.element('content')} {

--- a/stories/Truncate.js
+++ b/stories/Truncate.js
@@ -12,7 +12,7 @@ stories.add('default', () => (
   <div>
     <p>
       Auto:<br />
-      <Truncate>{fixture.generate()}</Truncate>
+      <Truncate showTooltipOnTruncate>{fixture.generate()}</Truncate>
     </p>
     <p>
       Start:<br />


### PR DESCRIPTION
## Truncate: Improve calculation reliability

![screen recording 2018-07-31 at 12 27 pm](https://user-images.githubusercontent.com/2322354/43473312-c9ac2096-94bd-11e8-9cee-4ff27740de43.gif)

(GIF: Demonstrates truncation triggering a tooltip to display - But only when truncation occurs)

This update improves the truncation calculation for the `Truncate` component.
This is achieved by normalizing the necessary DOM elements to grab the
width variables for MATH'ing. These DOM elements are then reset to their
neutral states, is if nothing happened ;).

`Tooltip`/`Pop` components were also improved to be made less "opinionated"
regarding CSS font-size rendering.