### PR TITLE
Animate: Improve rendering for Safari (iOS)

### DIFF
--- a/src/components/Animate/styles/Animate.css.js
+++ b/src/components/Animate/styles/Animate.css.js
@@ -7,20 +7,6 @@ const css = `
   transition-property: all;
   transition-duration: 200ms;
   transition-timing-function: ease-in-out;
-  visibility: hidden;
-
-  &.ax-entering {
-    visibility: hidden;
-  }
-  &.ax-entered {
-    visibility: visible;
-  }
-  &.ax-exiting {
-    visibility: visible;
-  }
-  &.ax-exited {
-    visibility: hidden;
-  }
 
   &.is-block {
     display: block;


### PR DESCRIPTION
## Animate: Improve rendering for Safari (iOS)

This update removes the `visibility` CSS prop from the `Animate` lifecycle
styles. After some investigating/testing, I've noticed that this is somehow
causing render issues in iOS Safari (for certain render cases).

Example:

![2018-08-02 09 00 19](https://user-images.githubusercontent.com/2322354/43585275-b94463fa-9632-11e8-9a20-db327829b74d.jpg)


Elements would stay invisible, unless a repaint/re-render is forced.

By removing this CSS prop, we avoid potential visibility render issues
all together!