### PR TITLE
Message: Support Embedded HTML Content

### DIFF
--- a/src/components/Message/Embed.js
+++ b/src/components/Message/Embed.js
@@ -1,0 +1,40 @@
+// @flow
+import type { MessageThemeContext } from './types'
+import React from 'react'
+import styled from '../styled'
+import Chat from './Chat'
+import classNames from '../../utilities/classNames'
+import css from './styles/Embed.css.js'
+
+type Props = {
+  className?: string,
+  html: string,
+}
+
+type Context = MessageThemeContext
+
+export const Embed = (props: Props, context: Context) => {
+  const { className, html, ...rest } = props
+  const { theme } = context
+
+  const componentClassName = classNames(
+    'c-MessageEmbed',
+    theme && `is-theme-${theme}`,
+    className
+  )
+
+  return (
+    <Chat
+      {...rest}
+      bubbleClassName="c-MessageEmbed__bubble"
+      className={componentClassName}
+    >
+      <div
+        dangerouslySetInnerHTML={{ __html: html }}
+        className="c-MessageEmbed__html"
+      />
+    </Chat>
+  )
+}
+
+export default styled(Embed)(css)

--- a/src/components/Message/Embed.js
+++ b/src/components/Message/Embed.js
@@ -1,6 +1,6 @@
 // @flow
 import type { MessageThemeContext } from './types'
-import React from 'react'
+import React, { PureComponent } from 'react'
 import styled from '../styled'
 import Chat from './Chat'
 import classNames from '../../utilities/classNames'
@@ -13,28 +13,32 @@ type Props = {
 
 type Context = MessageThemeContext
 
-export const Embed = (props: Props, context: Context) => {
-  const { className, html, ...rest } = props
-  const { theme } = context
+class Embed extends PureComponent<Props, Context> {
+  static displayName = 'Message.Embed'
 
-  const componentClassName = classNames(
-    'c-MessageEmbed',
-    theme && `is-theme-${theme}`,
-    className
-  )
+  render() {
+    const { className, html, ...rest } = this.props
+    const { theme } = this.context
 
-  return (
-    <Chat
-      {...rest}
-      bubbleClassName="c-MessageEmbed__bubble"
-      className={componentClassName}
-    >
-      <div
-        dangerouslySetInnerHTML={{ __html: html }}
-        className="c-MessageEmbed__html"
-      />
-    </Chat>
-  )
+    const componentClassName = classNames(
+      'c-MessageEmbed',
+      theme && `is-theme-${theme}`,
+      className
+    )
+
+    return (
+      <Chat
+        {...rest}
+        bubbleClassName="c-MessageEmbed__bubble"
+        className={componentClassName}
+      >
+        <div
+          dangerouslySetInnerHTML={{ __html: html }}
+          className="c-MessageEmbed__html"
+        />
+      </Chat>
+    )
+  }
 }
 
 export default styled(Embed)(css)

--- a/src/components/Message/Message.js
+++ b/src/components/Message/Message.js
@@ -10,6 +10,7 @@ import Bubble from './Bubble'
 import Caption from './Caption'
 import Chat from './Chat'
 import Content from './Content'
+import Embed from './Embed'
 import Media from './Media'
 import Provider from './Provider'
 import Question from './Question'
@@ -35,6 +36,7 @@ export class Message extends Component<Props> {
   static Caption = Caption
   static Chat = Chat
   static Content = Content
+  static Embed = Embed
   static Media = Media
   static Provider = Provider
   static Question = Question
@@ -46,7 +48,15 @@ export class Message extends Component<Props> {
   }
 
   isChatType = (child: any): boolean => {
-    const chatTypes = [Action, Attachment, Chat, Content, Media, Question]
+    const chatTypes = [
+      Action,
+      Attachment,
+      Chat,
+      Content,
+      Embed,
+      Media,
+      Question,
+    ]
 
     return chatTypes.some(type => {
       return (

--- a/src/components/Message/README.md
+++ b/src/components/Message/README.md
@@ -2,11 +2,9 @@
 
 Message components provides the UI to display content within a Chat context.
 
-
 ## Main component
 
 * [Message](./docs/Message.md)
-
 
 ## Sub-Components
 
@@ -19,6 +17,7 @@ Message provides a collection of smaller components:
 * [Chat](./docs/Chat.md)
 * [ChatBlock](./docs/ChatBlock.md)
 * [Content](./docs/Content.md)
+* [Embed](./docs/Embed.md)
 * [Media](./docs/Media.md)
 * [Provider](./docs/Provider.md)
 * [Question](./docs/Question.md)

--- a/src/components/Message/__tests__/Embed.test.js
+++ b/src/components/Message/__tests__/Embed.test.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import Embed from '../Embed'
+import Message from '../Message'
+
+const cx = 'c-MessageEmbed'
+
+const html = '<div><iframe src="https://example.com"></iframe></div>'
+
+describe('ClassNames', () => {
+  test('Has default className', () => {
+    const wrapper = mount(<Embed />)
+    const o = wrapper.find(`.${cx}`)
+    expect(o.length).toBeTruthy()
+  })
+
+  test('Accepts custom classNames', () => {
+    const wrapper = mount(<Embed className="mugatu" />)
+    const o = wrapper.find(`.${cx}`)
+    expect(o.hasClass('mugatu')).toBeTruthy()
+  })
+})
+
+describe('Context', () => {
+  test('Adds className based on context.theme', () => {
+    const wrapper = mount(
+      <Message.Provider theme="embed">
+        <Embed />
+      </Message.Provider>
+    )
+    const el = wrapper.find(`.${cx}`)
+    expect(el.props().className).toContain('is-theme-embed')
+  })
+})
+
+describe('Content', () => {
+  test('Renders html inside component', () => {
+    const wrapper = mount(<Embed html={html} />)
+    const o = wrapper.find(`.${cx}`)
+    expect(o.html()).toContain(html)
+  })
+})
+
+describe('Display name', () => {
+  test('Has a display name', () => {
+    expect(Embed.displayName).toEqual('Styled(Message.Embed)')
+  })
+})

--- a/src/components/Message/__tests__/Embed.test.js
+++ b/src/components/Message/__tests__/Embed.test.js
@@ -22,14 +22,20 @@ describe('ClassNames', () => {
 })
 
 describe('Context', () => {
+  test('Should not have a theme className by default', () => {
+    const wrapper = mount(<Embed />)
+    const o = wrapper.find(`.${cx}`)
+    expect(o.props().className).not.toContain('is-theme')
+  })
+
   test('Adds className based on context.theme', () => {
     const wrapper = mount(
       <Message.Provider theme="embed">
         <Embed />
       </Message.Provider>
     )
-    const el = wrapper.find(`.${cx}`)
-    expect(el.props().className).toContain('is-theme-embed')
+    const o = wrapper.find(`.${cx}`)
+    expect(o.props().className).toContain('is-theme-embed')
   })
 })
 

--- a/src/components/Message/docs/Embed.md
+++ b/src/components/Message/docs/Embed.md
@@ -1,0 +1,41 @@
+# Embed
+
+An embed component provides the UI to render rich-media embed content within a
+[Message](./Message.md).
+
+## Example
+
+```jsx
+const html = `
+  <div style="left: 0;
+              width: 100%;
+              height: 0;
+              position: relative;
+              padding-bottom: 56.2493%;"
+  >
+    <iframe src="https://www.youtube.com/embed/evvzG0Xz69Q?rel=0&showinfo=0"
+            style="border: 0;
+                   top: 0;
+                   left: 0;
+                   width: 100%;
+                   height: 100%;
+                   position: absolute;"
+            allowfullscreen
+            scrolling="no"
+    ></iframe>
+  </div>
+`
+<Message from avatar={<Avatar name="Artic Puffin" />}>
+  <Message.Chat read timestamp="9:41am">
+    Hey Buddy!
+  </Message.Chat>
+  <Message.Embed html={html} />
+</Message>
+```
+
+## Props
+
+| Prop      | Type     | Description                                             |
+| --------- | -------- | ------------------------------------------------------- |
+| className | `string` | Custom class names to be added to the component.        |
+| html      | `string` | HTML markup to be dangerously set inside the component. |

--- a/src/components/Message/styles/Embed.css.js
+++ b/src/components/Message/styles/Embed.css.js
@@ -1,0 +1,45 @@
+// @flow
+import baseStyles from '../../../styles/resets/baseStyles.css.js'
+import { BEM } from '../../../utilities/classNames'
+import { getColor } from '../../../styles/utilities/color.js'
+import { noteBoxShadow } from '../../../styles/mixins/noteStyles.css'
+
+const config = {
+  embedBorderRadius: '3px',
+  embedWidth: '9999px',
+  embedMaxWidth: '300px',
+}
+
+const bem = BEM('.c-MessageEmbed')
+
+export const css = `
+  ${baseStyles}
+
+  ${bem.element('html')} {
+    border-radius: ${config.embedBorderRadius};
+    max-width: ${config.embedMaxWidth};
+    overflow: hidden;
+    width: ${config.embedWidth};
+  }
+
+  ${bem.element('bubble')}.c-MessageBubble {
+    background-color: white;
+    border: none;
+    box-shadow:
+      0px 1px 3px 0px rgba(0,0,0,0.1),
+      0px 0px 0px 1px rgba(193,203,212,.7) inset,
+      0px -1px 0px 0px ${getColor('grey.600')} inset;
+    color: ${getColor('charcoal.200')};
+    display: inline-block;
+    overflow: hidden;
+    padding: 3px;
+
+    &.is-note {
+      ${noteBoxShadow()}
+      background-color: ${getColor('yellow.300')};
+      color: ${getColor('yellow.800')};
+    }
+  }
+`
+
+export default css

--- a/src/components/Message/styles/Embed.css.js
+++ b/src/components/Message/styles/Embed.css.js
@@ -17,7 +17,7 @@ export const css = `
 
   ${bem.element('html')} {
     border-radius: ${config.embedBorderRadius};
-    max-width: ${config.embedMaxWidth};
+    max-width: 100%;
     overflow: hidden;
     width: ${config.embedWidth};
   }
@@ -31,8 +31,10 @@ export const css = `
       0px -1px 0px 0px ${getColor('grey.600')} inset;
     color: ${getColor('charcoal.200')};
     display: inline-block;
+    max-width: ${config.embedMaxWidth};
     overflow: hidden;
     padding: 3px;
+    width: 100%;
 
     &.is-note {
       ${noteBoxShadow()}

--- a/src/components/Message/styles/Embed.css.js
+++ b/src/components/Message/styles/Embed.css.js
@@ -2,7 +2,7 @@
 import baseStyles from '../../../styles/resets/baseStyles.css.js'
 import { BEM } from '../../../utilities/classNames'
 import { getColor } from '../../../styles/utilities/color.js'
-import { noteBoxShadow } from '../../../styles/mixins/noteStyles.css'
+import { noteBoxShadow } from '../../../styles/mixins/noteStyles.css.js'
 
 const config = {
   embedBorderRadius: '3px',

--- a/stories/Message/embed.js
+++ b/stories/Message/embed.js
@@ -1,0 +1,105 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { Avatar, Message } from '../../src/index.js'
+
+const stories = storiesOf('Message/Embed', module)
+const html = `
+  <div style="left: 0;
+              width: 100%;
+              height: 0;
+              position: relative;
+              padding-bottom: 56.2493%;"
+  >
+    <iframe src="https://www.youtube.com/embed/evvzG0Xz69Q?rel=0&showinfo=0"
+            style="border: 0;
+                   top: 0;
+                   left: 0;
+                   width: 100%;
+                   height: 100%;
+                   position: absolute;"
+            allowfullscreen
+            scrolling="no"
+    ></iframe>
+  </div>
+`
+const html2 = `
+  <iframe src="https://open.spotify.com/embed/track/6tgTTBaIf0tO6lvDhoXfMg"
+          style="border: 0;
+                 width: 100%;
+                 height: 380px;"
+          allowfullscreen
+  ></iframe>
+`
+const html3 = `
+  <div style="left: 0;
+              width: 100%;
+              height: 0;
+              position: relative;
+              padding-bottom: 56.2493%;"
+  >
+    <iframe src="https://player.vimeo.com/video/60743582?byline=0&amp;badge=0&amp;portrait=0&amp;title=0"
+            style="border: 0;
+                   top: 0;
+                   left: 0;
+                   width: 100%;
+                   height: 100%;
+                   position: absolute;"
+            allowfullscreen
+            scrolling="no"
+    >
+    </iframe>
+  </div>
+`
+const html4 = `
+<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 83.9419%;"><iframe src="//speakerdeck.com/player/19b85c8a3b63450d85f6df64db9d0359" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen scrolling="no"></iframe></div>
+`
+
+stories.add('default', () => (
+  <Message.Provider theme="embed">
+    <Message from avatar={<Avatar name="Artic Puffin" />}>
+      <Message.Embed html={html} />
+    </Message>
+  </Message.Provider>
+))
+
+stories.add('note', () => (
+  <Message.Provider theme="embed">
+    <Message from avatar={<Avatar name="Artic Puffin" />}>
+      <Message.Embed isNote html={html} />
+    </Message>
+  </Message.Provider>
+))
+
+stories.add('left-right', () => {
+  return (
+    <div>
+      <Message to avatar={<Avatar name="Artic Puffin" />}>
+        <Message.Chat>Agent chat</Message.Chat>
+        <Message.Embed html={html} />
+      </Message>
+      <Message from avatar={<Avatar name="Dapper Duck" />}>
+        <Message.Chat>Reply</Message.Chat>
+        <Message.Embed html={html2} />
+        <Message.Embed html={html3} />
+      </Message>
+      <Message to avatar={<Avatar name="Artic Puffin" />}>
+        <Message.Chat isNote>Private note</Message.Chat>
+        <Message.Embed isNote html={html4} />
+      </Message>
+    </div>
+  )
+})
+
+stories.add('consecutive', () => {
+  return (
+    <div>
+      <Message to avatar={<Avatar name="Artic Puffin" />}>
+        <Message.Chat>Agent Chat</Message.Chat>
+        <Message.Embed html={html} />
+        <Message.Embed html={html2} />
+        <Message.Embed html={html3} />
+        <Message.Embed html={html4} />
+      </Message>
+    </div>
+  )
+})

--- a/stories/Message/index.js
+++ b/stories/Message/index.js
@@ -5,6 +5,7 @@ import { Avatar, Link, Message, PreviewCard } from '../../src/index.js'
 export { default as defaultStories } from './default'
 export { default as chatStories } from './chat'
 export { default as attachmentStories } from './attachment'
+export { default as embedStories } from './embed'
 export { default as mediaStories } from './media'
 
 const stories = storiesOf('Message', module)


### PR DESCRIPTION
## Message: Support Embedded HTML Content

This update adds a new `Message.Embed` component to Blue. It accepts an `html` prop and renders the HTML inside the component with style treatments similar to `Message.Media`. Unlike `Message.Media`, it does not open the content in a modal.

![Screenshot](https://dha4w82d62smt.cloudfront.net/items/20040D3J3Q3f0t0D0F0p/Image%202018-08-10%20at%205.21.44%20PM.png?X-CloudApp-Visitor-Id=2338876&v=59529e1a)