### PR TITLE
Message: Fix Bubble border-radius

### DIFF
--- a/src/components/Message/styles/Chat.css.js
+++ b/src/components/Message/styles/Chat.css.js
@@ -1,6 +1,10 @@
 // @flow
 import baseStyles from '../../../styles/resets/baseStyles.css.js'
 import { config as BubbleConfig } from './Bubble.css.js'
+import { BEM } from '../../../utilities/classNames'
+
+const bem = BEM('.c-MessageChat')
+const MessageBubble = '.c-MessageBubble'
 
 const css = `
   ${baseStyles}
@@ -11,21 +15,21 @@ const css = `
     margin-bottom: 0;
   }
 
-  & ~ & {
-    .c-MessageBubble {
+  & ~ ${bem.block} {
+    ${MessageBubble} {
       border-top-right-radius: ${BubbleConfig.borderRadius.sm}px;
     }
   }
 
   &.is-from {
-    & ~ & {
-      .c-MessageBubble {
+    ${bem.block} ~ ${bem.block} {
+      ${MessageBubble} {
         border-top-right-radius: ${BubbleConfig.borderRadius.md}px;
       }
     }
 
     &:last-child {
-      .c-MessageBubble {
+      ${MessageBubble} {
         border-top-right-radius: ${BubbleConfig.borderRadius.md}px;
         border-bottom-left-radius: ${BubbleConfig.borderRadius.md}px;
       }

--- a/stories/Message/index.js
+++ b/stories/Message/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Avatar, Link, Message, PreviewCard } from '../../src/index.js'
+import { ScopeProvider } from '../../src/components/styled'
 
 export { default as defaultStories } from './default'
 export { default as chatStories } from './chat'
@@ -28,46 +29,48 @@ stories.add('action', () => (
 ))
 
 stories.add('content', () => (
-  <div>
-    <Message to avatar={<Avatar name="Buddy" />}>
-      <Message.Chat read timestamp="9:41am">
-        <Link href="https://en.wikipedia.org/wiki/Elf_(film)">
-          https://en.wikipedia.org/wiki/Elf_(film)
-        </Link>
-      </Message.Chat>
-      <Message.Content>
-        <PreviewCard
-          href="https://en.wikipedia.org/wiki/Elf_(film)"
-          title="Wikipedia: Elf (film)"
-          target="_blank"
-        >
-          Elf is a 2003 American Christmas fantasy comedy film directed by Jon
-          Favreau and written by David Berenbaum. It stars Will Ferrell, James
-          Caan, Zooey Deschanel, Mary Steenburgen, Daniel Tay, Edward Asner, and
-          Bob Newhart...
-        </PreviewCard>
-      </Message.Content>
-    </Message>
-    <Message to avatar={<Avatar name="Buddy" />}>
-      <Message.Chat read timestamp="9:41am" isNote>
-        <Link href="https://en.wikipedia.org/wiki/Elf_(film)">
-          https://en.wikipedia.org/wiki/Elf_(film)
-        </Link>
-      </Message.Chat>
-      <Message.Content isNote>
-        <PreviewCard
-          href="https://en.wikipedia.org/wiki/Elf_(film)"
-          title="Wikipedia: Elf (film)"
-          target="_blank"
-        >
-          Elf is a 2003 American Christmas fantasy comedy film directed by Jon
-          Favreau and written by David Berenbaum. It stars Will Ferrell, James
-          Caan, Zooey Deschanel, Mary Steenburgen, Daniel Tay, Edward Asner, and
-          Bob Newhart...
-        </PreviewCard>
-      </Message.Content>
-    </Message>
-  </div>
+  <ScopeProvider scope="#Messages">
+    <div id="Messages">
+      <Message to avatar={<Avatar name="Buddy" />}>
+        <Message.Chat read timestamp="9:41am">
+          <Link href="https://en.wikipedia.org/wiki/Elf_(film)">
+            https://en.wikipedia.org/wiki/Elf_(film)
+          </Link>
+        </Message.Chat>
+        <Message.Content>
+          <PreviewCard
+            href="https://en.wikipedia.org/wiki/Elf_(film)"
+            title="Wikipedia: Elf (film)"
+            target="_blank"
+          >
+            Elf is a 2003 American Christmas fantasy comedy film directed by Jon
+            Favreau and written by David Berenbaum. It stars Will Ferrell, James
+            Caan, Zooey Deschanel, Mary Steenburgen, Daniel Tay, Edward Asner,
+            and Bob Newhart...
+          </PreviewCard>
+        </Message.Content>
+      </Message>
+      <Message to avatar={<Avatar name="Buddy" />}>
+        <Message.Chat read timestamp="9:41am" isNote>
+          <Link href="https://en.wikipedia.org/wiki/Elf_(film)">
+            https://en.wikipedia.org/wiki/Elf_(film)
+          </Link>
+        </Message.Chat>
+        <Message.Content isNote>
+          <PreviewCard
+            href="https://en.wikipedia.org/wiki/Elf_(film)"
+            title="Wikipedia: Elf (film)"
+            target="_blank"
+          >
+            Elf is a 2003 American Christmas fantasy comedy film directed by Jon
+            Favreau and written by David Berenbaum. It stars Will Ferrell, James
+            Caan, Zooey Deschanel, Mary Steenburgen, Daniel Tay, Edward Asner,
+            and Bob Newhart...
+          </PreviewCard>
+        </Message.Content>
+      </Message>
+    </div>
+  </ScopeProvider>
 ))
 
 stories.add('note', () => (


### PR DESCRIPTION
## Message: Fix Bubble border-radius

![screen shot 2018-08-13 at 1 02 20 pm](https://user-images.githubusercontent.com/2322354/44046322-20ea276e-9ef9-11e8-8cbc-8b0de7ac0953.jpg)

This update fixes the border-radius rendering for Chat Bubbles, when
used within a Scope.

The issue was the `&` was inheriting the full scope style path.