### PR TITLE
Changing the close button tab index in a modal to 0

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -227,7 +227,7 @@ class Modal extends Component {
           this.closeNode = node
         }}
       >
-        <CloseButton onClick={closePortal} tabIndex="-1" />
+        <CloseButton onClick={closePortal} tabIndex="0" />
       </div>
     ) : null
 


### PR DESCRIPTION
This PR changes the close button tab index on a modal to 0, so that it can be tab focused to.

For more info:
https://trello.com/c/CsX0PDSX/552-accessibility-issues-tabbing-escing-highlighting-within-embed