### PR TITLE
Remove tabindex on close button for modals

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -227,7 +227,7 @@ class Modal extends Component {
           this.closeNode = node
         }}
       >
-        <CloseButton onClick={closePortal} tabIndex="0" />
+        <CloseButton onClick={closePortal} />
       </div>
     ) : null
 

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -227,7 +227,7 @@ class Modal extends Component {
           this.closeNode = node
         }}
       >
-        <CloseButton onClick={closePortal} tabIndex="-1" />
+        <CloseButton onClick={closePortal} tabIndex="0" />
       </div>
     ) : null
 

--- a/src/components/Modal/tests/Modal.test.js
+++ b/src/components/Modal/tests/Modal.test.js
@@ -661,7 +661,7 @@ describe('Keyboard: Tab', () => {
         <button className="three">three</button>
       </ModalComponent>
     )
-    const o = wrapper.find('.one').getNode()
+    const o = wrapper.find('.c-CloseButton').getNode()
 
     wrapper.instance().handleOnShiftTab({
       target: o,


### PR DESCRIPTION
This PR removes the `tabindex` attribute from modal close buttons. This fixes some 'focus tab' issues where the user can't tab to the close button.

more info: https://trello.com/c/CsX0PDSX/552-accessibility-issues-tabbing-escing-highlighting-within-embed