### PR TITLE
Do not enlarge images

### DIFF
--- a/src/components/Image/__tests__/Image.test.js
+++ b/src/components/Image/__tests__/Image.test.js
@@ -121,7 +121,7 @@ describe('Width/Height', () => {
   test('Use the width/height as aspect fit width/height if less than max', () => {
     const wrapper = mount(
       <Image
-        src="mugatu.jgp"
+        src="mugatu.jpg"
         width={75}
         height={50}
         maxWidth={100}

--- a/src/components/Image/__tests__/Image.test.js
+++ b/src/components/Image/__tests__/Image.test.js
@@ -117,4 +117,22 @@ describe('Width/Height', () => {
     expect(o.prop('style').width).toBe(100)
     expect(o.prop('style').height).toBe(50)
   })
+
+  test('Use the width/height as aspect fit width/height if less than max', () => {
+    const wrapper = mount(
+      <Image
+        src="mugatu.jgp"
+        width={75}
+        height={50}
+        maxWidth={100}
+        maxHeight={100}
+      />
+    )
+    const o = wrapper.find('img')
+
+    expect(wrapper.prop('width')).toBe(75)
+    expect(wrapper.prop('height')).toBe(50)
+    expect(o.prop('style').width).toBe(75)
+    expect(o.prop('style').height).toBe(50)
+  })
 })

--- a/src/utilities/images.js
+++ b/src/utilities/images.js
@@ -8,6 +8,13 @@ export const calculateAspectRatioFit = (props: {
 }): { width: number, height: number } => {
   const { width, height, maxWidth, maxHeight } = props
 
+  if (width < maxWidth && height < maxHeight) {
+    return {
+      width,
+      height,
+    }
+  }
+
   const ratioWidth = maxWidth / width
   const ratioHeight = maxHeight / height
   const ratio = Math.min(ratioWidth, ratioHeight)

--- a/stories/Image.js
+++ b/stories/Image.js
@@ -2,34 +2,37 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Image } from '../src/index.js'
 
-storiesOf('Image', module)
-  .add('default', () => (
-    <Image
-      src="https://img.buzzfeed.com/buzzfeed-static/static/2014-12/5/11/enhanced/webdr06/longform-original-7538-1417798667-22.jpg?downsize=715:*&output-format=auto&output-quality=auto"
-      alt="Not now, Arctic Puffin!"
-      title="Not now, Arctic Puffin!"
-      width="300"
-    />
-  ))
-  .add('with aspec ratio fit', () => (
-    <Image
-      src="https://picsum.photos/360/360"
-      alt="Not now, Arctic Puffin!"
-      title="Not now, Arctic Puffin!"
-      maxHeight="260"
-      maxWidth="260"
-      height="360"
-      width="360"
-    />
-  ))
-  .add('without aspect ratio fit', () => (
-    <Image
-      src="https://picsum.photos/160/160"
-      alt="Not now, Articic Puffin!"
-      title="Not now, Artic Puffin!"
-      maxHeight="260"
-      maxWidth="260"
-      height="160"
-      width="160"
-    />
-  ))
+const stories = storiesOf('Image', module)
+
+stories.add('default', () => (
+  <Image
+    src="https://img.buzzfeed.com/buzzfeed-static/static/2014-12/5/11/enhanced/webdr06/longform-original-7538-1417798667-22.jpg?downsize=715:*&output-format=auto&output-quality=auto"
+    alt="Not now, Arctic Puffin!"
+    title="Not now, Arctic Puffin!"
+    width="300"
+  />
+))
+
+stories.add('with aspec ratio fit', () => (
+  <Image
+    src="https://picsum.photos/360/360"
+    alt="Not now, Arctic Puffin!"
+    title="Not now, Arctic Puffin!"
+    maxHeight="260"
+    maxWidth="260"
+    height="360"
+    width="360"
+  />
+))
+
+stories.add('without aspect ratio fit', () => (
+  <Image
+    src="https://picsum.photos/160/160"
+    alt="Not now, Articic Puffin!"
+    title="Not now, Artic Puffin!"
+    maxHeight="260"
+    maxWidth="260"
+    height="160"
+    width="160"
+  />
+))

--- a/stories/Image.js
+++ b/stories/Image.js
@@ -2,11 +2,34 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Image } from '../src/index.js'
 
-storiesOf('Image', module).add('default', () => (
-  <Image
-    src="https://img.buzzfeed.com/buzzfeed-static/static/2014-12/5/11/enhanced/webdr06/longform-original-7538-1417798667-22.jpg?downsize=715:*&output-format=auto&output-quality=auto"
-    alt="Not now, Arctic Puffin!"
-    title="Not now, Arctic Puffin!"
-    width="300"
-  />
-))
+storiesOf('Image', module)
+  .add('default', () => (
+    <Image
+      src="https://img.buzzfeed.com/buzzfeed-static/static/2014-12/5/11/enhanced/webdr06/longform-original-7538-1417798667-22.jpg?downsize=715:*&output-format=auto&output-quality=auto"
+      alt="Not now, Arctic Puffin!"
+      title="Not now, Arctic Puffin!"
+      width="300"
+    />
+  ))
+  .add('with aspec ratio fit', () => (
+    <Image
+      src="https://picsum.photos/360/360"
+      alt="Not now, Arctic Puffin!"
+      title="Not now, Arctic Puffin!"
+      maxHeight="260"
+      maxWidth="260"
+      height="360"
+      width="360"
+    />
+  ))
+  .add('without aspect ratio fit', () => (
+    <Image
+      src="https://picsum.photos/160/160"
+      alt="Not now, Articic Puffin!"
+      title="Not now, Artic Puffin!"
+      maxHeight="260"
+      maxWidth="260"
+      height="160"
+      width="160"
+    />
+  ))


### PR DESCRIPTION
**[Trello Card](https://trello.com/c/F42QuDSu)**

When the Image component is provided with a maxWidth and maxHeight, we would calculate an aspect ratio for the image that would fit within those bounds. This would create values that we could multiple the width and height by to get new widths and heights. The problem was in doing this when the width and height were less than the maxWidth and maxHeight. In such a case we would multiple the width and height resulting in larger numbers. In these cases, we should not apply a multiplier, setting the width and height to their original values.