### PR TITLE
Switch: Add loading state

### DIFF
--- a/src/components/Switch/README.md
+++ b/src/components/Switch/README.md
@@ -10,16 +10,18 @@ A Switch component is an alternative to a [Checkbox](../Checkbox) that provides 
 
 ## Props
 
-| Prop      | Type              | Description                                      |
-| --------- | ----------------- | ------------------------------------------------ |
-| checked   | `bool`            | Determines if the component is checked.          |
-| className | `string`          | Custom class names to be added to the component. |
-| id        | `string`          | Sets a custom ID for the component.              |
-| inputRef  | `function`        | Callback to retrieve the `input` node.           |
-| name      | `string`          | Name attribute for the component's `input` node. |
-| onBlur    | `function`        | Callback function when component blurs.          |
-| onChange  | `function`        | Callback function when component changes.        |
-| onFocus   | `function`        | Callback function when component focuses.        |
-| size      | `string`          | Adjusts the size of the component.               |
-| state     | `string`          | Applies state-based styling.                     |
-| value     | `string`/`number` | Value for the component.                         |
+| Prop      | Type              | Description                                         |
+| --------- | ----------------- | --------------------------------------------------- |
+| checked   | `bool`            | Determines if the component is checked.             |
+| className | `string`          | Custom class names to be added to the component.    |
+| id        | `string`          | Sets a custom ID for the component.                 |
+| isLoading | `bool`            | Activates the loading state.                        |
+| inputRef  | `function`        | Callback to retrieve the `input` node.              |
+| name      | `string`          | Name attribute for the component's `input` node.    |
+| onBlur    | `function`        | Callback function when component blurs.             |
+| onClick   | `function`        | Callback function when component is clicked.        |
+| onChange  | `function`        | Callback function when component `checked` changes. |
+| onFocus   | `function`        | Callback function when component focuses.           |
+| size      | `string`          | Adjusts the size of the component.                  |
+| state     | `string`          | Applies state-based styling.                        |
+| value     | `string`/`number` | Value for the component.                            |

--- a/src/components/Switch/__tests__/Switch.test.js
+++ b/src/components/Switch/__tests__/Switch.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import Switch from '../Switch'
 import FormLabel from '../../FormLabel'
+import { SwitchUI, BackdropUI, ToggleUI } from '../styles/Switch.css.js'
 
 describe('ClassName', () => {
   test('Has default className', () => {
@@ -81,7 +82,7 @@ describe('Checked', () => {
     const o = wrapper.instance()
     const input = wrapper.find('input')
 
-    input.simulate('change')
+    wrapper.setProps({ checked: false })
 
     expect(o.state.checked).toBe(false)
     expect(wrapper.find('input').props().checked).toBe(false)
@@ -90,6 +91,60 @@ describe('Checked', () => {
 
     expect(o.state.checked).toBe(true)
     expect(wrapper.find('input').props().checked).toBe(true)
+  })
+})
+
+describe('Loading', () => {
+  test('Is not loading by default', () => {
+    const wrapper = mount(<Switch />)
+
+    expect(wrapper.prop('isLoading')).toBe(false)
+  })
+
+  test('Does not render checked/active styles if onLoading', () => {
+    const wrapper = mount(<Switch checked isLoading />)
+    wrapper.setState({ isActive: true })
+
+    const comp = wrapper.find(SwitchUI)
+    const backdrop = wrapper.find(BackdropUI)
+    const toggle = wrapper.find(ToggleUI)
+
+    expect(comp.hasClass('is-checked')).toBe(false)
+    expect(backdrop.hasClass('is-checked')).toBe(false)
+    expect(toggle.hasClass('is-checked')).toBe(false)
+    expect(toggle.hasClass('is-active')).toBe(false)
+  })
+
+  test('Can render checked/active styles if not onLoading', () => {
+    const wrapper = mount(<Switch checked isLoading={false} />)
+    wrapper.setState({ isActive: true })
+
+    const comp = wrapper.find(SwitchUI)
+    const backdrop = wrapper.find(BackdropUI)
+    const toggle = wrapper.find(ToggleUI)
+
+    expect(comp.hasClass('is-checked')).toBe(true)
+    expect(backdrop.hasClass('is-checked')).toBe(true)
+    expect(toggle.hasClass('is-checked')).toBe(true)
+    expect(toggle.hasClass('is-active')).toBe(true)
+  })
+})
+
+describe('Toggle', () => {
+  test('Toggles active styles on mousedown/mouseup', () => {
+    const wrapper = mount(<Switch />)
+    const comp = wrapper.find(SwitchUI)
+    const toggle = wrapper.find(ToggleUI)
+
+    expect(toggle.hasClass('is-active')).toBe(false)
+
+    comp.simulate('mousedown')
+
+    expect(toggle.hasClass('is-active')).toBe(true)
+
+    comp.simulate('mouseup')
+
+    expect(toggle.hasClass('is-active')).toBe(false)
   })
 })
 
@@ -114,12 +169,40 @@ describe('Events', () => {
     expect(spy).toHaveBeenCalledWith('Mugatu')
   })
 
+  test('onClick callback can be triggered, by onChange', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Switch onClick={spy} value="Mugatu" />)
+    const input = wrapper.find('input')
+
+    input.simulate('change')
+
+    expect(spy).toHaveBeenCalled()
+  })
+
   test('onFocus callback can be triggered', () => {
     const spy = jest.fn()
     const wrapper = mount(<Switch onFocus={spy} />)
     const input = wrapper.find('input')
 
     input.simulate('focus')
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('onMouseDown callback can be triggered', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Switch onMouseDown={spy} />)
+
+    wrapper.find(SwitchUI).simulate('mousedown')
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('onMouseUp callback can be triggered', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Switch onMouseUp={spy} />)
+
+    wrapper.find(SwitchUI).simulate('mouseup')
 
     expect(spy).toHaveBeenCalled()
   })

--- a/src/components/Switch/styles/Switch.css.js
+++ b/src/components/Switch/styles/Switch.css.js
@@ -1,6 +1,7 @@
 // @flow
 import baseStyles from '../../../styles/resets/baseStyles.css.js'
 import { getColor } from '../../../styles/utilities/color'
+import forEach from '../../../styles/utilities/forEach'
 import styled from '../../styled'
 
 export const config = {
@@ -33,17 +34,22 @@ export const config = {
   },
 }
 
-export const SwitchWrapperUI = styled('div')`
+export const WrapperUI = styled('div')`
   ${baseStyles} display: inline-block;
 `
 
 export const SwitchUI = styled('label')`
-  ${baseStyles} display: block;
+  ${baseStyles} cursor: pointer;
+  display: block;
   margin: 0;
   position: relative;
+
+  &.is-loading {
+    pointer-events: none;
+  }
 `
 
-export const SwitchInputUI = styled('input')`
+export const InputUI = styled('input')`
   ${baseStyles} bottom: 0;
   left: 0;
   opacity: 0;
@@ -53,7 +59,7 @@ export const SwitchInputUI = styled('input')`
   z-index: 1;
 `
 
-export const SwitchToggleUI = styled('div')`
+export const BackdropUI = styled('div')`
   background-color: ${config.backgroundColor.default};
   border-radius: ${config.borderRadius}px;
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.1) inset;
@@ -62,24 +68,13 @@ export const SwitchToggleUI = styled('div')`
   cursor: pointer;
   font-size: ${config.fontSize}px;
   padding: ${config.padding};
+  pointer-events: none;
   position: relative;
   text-align: right;
   transition: ${config.transition.switch};
   z-index: 1;
 
-  &::before {
-    background-color: white;
-    border-radius: ${config.borderRadius}px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    box-sizing: border-box;
-    content: '';
-    left: ${config.toggle.offset}px;
-    position: absolute;
-    top: ${config.toggle.offset}px;
-    transition: ${config.transition.toggle};
-  }
-
-  ${makeSizeStyles(config.size.md)} &.is-focused {
+  &.is-focused {
     background-color: ${config.backgroundColor.hover};
   }
 
@@ -88,34 +83,65 @@ export const SwitchToggleUI = styled('div')`
     color: ${config.color.checked};
     text-align: left;
 
-    &::before {
-      left: inherit;
-      right: ${config.toggle.offset}px;
-    }
-
     &.is-focused {
       background-color: ${config.backgroundColorChecked.hover};
     }
   }
 
-  &.is-lg {
-    ${makeSizeStyles(config.size.lg)};
-  }
-  &.is-md {
-    ${makeSizeStyles(config.size.md)};
-  }
-  &.is-sm {
-    ${makeSizeStyles(config.size.sm)};
-  }
-
-  &:active {
-    &::before {
-      width: 60%;
-    }
-  }
+  ${makeSizeStyles(config)};
 `
 
-export const SwitchStateUI = styled('div')`
+export const ToggleUI = styled('div')`
+  background-color: white;
+  border-radius: ${config.borderRadius}px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-sizing: border-box;
+  content: '';
+  left: ${config.toggle.offset}px;
+  pointer-events: none;
+  position: absolute;
+  top: ${config.toggle.offset}px;
+  transition: ${config.transition.toggle};
+
+  ${makeToggleSizeStyles(config)}
+
+  &.is-active {
+    width: 60%;
+  }
+
+  &.is-checked {
+    left: inherit;
+    right: ${config.toggle.offset}px;
+  }
+
+  &.is-loading {
+    animation: SwitchTogglePulse 1000ms linear infinite;
+    left: 50%;
+    right: inherit;
+
+    ${makeToggleOffsetStyles(config)}
+  }
+
+  @keyframes SwitchTogglePulse {
+    0% {
+      box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+      transform: scale(0.8);
+    }
+
+    50% {
+      box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+      transform: scale(0.6);
+    }
+
+    100% {
+      box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+   	  transform: scale(0.8);
+    }
+  }
+}
+`
+
+export const StateUI = styled('div')`
   border-radius: 100px;
   bottom: 0;
   box-shadow: 0 0 0 2px ${getColor('state.error')};
@@ -132,17 +158,40 @@ function getWidth(size: number): number {
   return Math.floor(size * 2)
 }
 
-function makeSizeStyles(size: number): string {
-  return `
-    height: ${size}px;
-    line-height: ${size}px;
-    width: ${getWidth(size)}px;
-
-    &::before {
-      height: ${size - config.toggle.offset * 2}px;
-      width: ${size - config.toggle.offset * 2}px;
+function makeSizeStyles(config: Object): string {
+  return forEach(
+    config.size,
+    (size, value) => `
+    &.is-${size} {
+      height: ${value}px;
+      line-height: ${value}px;
+      width: ${getWidth(value)}px;
     }
   `
+  )
+}
+
+function makeToggleSizeStyles(config: Object): string {
+  return forEach(
+    config.size,
+    (size, value) => `
+    &.is-${size} {
+      height: ${value - config.toggle.offset * 2}px;
+      width: ${value - config.toggle.offset * 2}px;
+    }
+  `
+  )
+}
+
+function makeToggleOffsetStyles(config: Object): string {
+  return forEach(
+    config.size,
+    (size, value) => `
+    &.is-${size} {
+      margin-left: -${value / 2 - config.toggle.offset / 1}px;
+    }
+  `
+  )
 }
 
 export default SwitchUI

--- a/stories/Switch.js
+++ b/stories/Switch.js
@@ -66,6 +66,24 @@ stories.add('state', () => (
   </form>
 ))
 
+stories.add('loading', () => (
+  <form style={{ width: 300 }}>
+    <Hr size="sm" />
+    <Flexy>
+      <Flexy.Item>
+        <Text>Relax (Regular)</Text>
+        <br />
+        <Text faint size="13">
+          When you want to go to it
+        </Text>
+      </Flexy.Item>
+      <Flexy.Item>
+        <LoadingSwitch />
+      </Flexy.Item>
+    </Flexy>
+  </form>
+))
+
 stories.add('sizes', () => (
   <form style={{ width: 300 }}>
     <Hr size="sm" />
@@ -110,6 +128,44 @@ stories.add('sizes', () => (
     <Hr size="sm" />
   </form>
 ))
+
+class LoadingSwitch extends React.Component {
+  state = {
+    on: false,
+    isLoading: false,
+  }
+
+  handleOnClick = () => {
+    const nextValue = !this.state.on
+
+    this.setState({
+      isLoading: true,
+    })
+
+    setTimeout(() => {
+      this.setState({
+        on: nextValue,
+        isLoading: false,
+      })
+    }, 1000)
+  }
+
+  handleOnChange = value => {
+    console.log('toggle', value, this.state.on)
+  }
+
+  render() {
+    return (
+      <Switch
+        value="on"
+        checked={this.state.on}
+        isLoading={this.state.isLoading}
+        onClick={this.handleOnClick}
+        onChange={this.handleOnChange}
+      />
+    )
+  }
+}
 
 class App extends React.Component {
   state = {


### PR DESCRIPTION
## Switch: Add loading state

![screen recording 2018-09-05 at 05 05 pm](https://user-images.githubusercontent.com/2322354/45123976-9ae74c00-b136-11e8-858a-30d7e9fcccaa.gif)

Above: Example shows the loading state, which is resolved after 1 second. The parent component is handling the state switching for the `Switch`.

This update adds a new "loading" state for the `Switch`. The loading state
can be triggered by passing `isLoading` = `true` as a prop. The UI adjusts
to a loading animation. During this state, clicks/changes are blocked, until
`isLoading` is set back to false.