### PR TITLE
Switch: Fix `onChange`/`onClick` callbacks

### DIFF
--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -27,7 +27,6 @@ type Props = {
   name: string,
   onBlur: (event: Event) => void,
   onChange: (value: SwitchValue) => void,
-  onClick: (event: Event, value: SwitchValue) => void,
   onFocus: (event: Event) => void,
   onMouseDown: (event: Event) => void,
   onMouseUp: (event: Event) => void,
@@ -55,7 +54,6 @@ class Switch extends Component<Props, State> {
     labelOff: 'Off',
     onBlur: noop,
     onChange: noop,
-    onClick: noop,
     onFocus: noop,
     onMouseDown: noop,
     onMouseUp: noop,
@@ -85,23 +83,15 @@ class Switch extends Component<Props, State> {
     }
   }
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
-    const { onChange, value } = this.props
-
-    if (prevState.checked !== this.state.checked) {
-      onChange(value)
-    }
-  }
-
   handleOnChange = (event: Event) => {
-    const { onClick, value } = this.props
+    const { onChange, value } = this.props
 
     /* istanbul ignore else */
     if (this.shouldAutoUpdateChecked) {
       this.setState({ checked: !this.state.checked })
     }
 
-    onClick(event, value)
+    onChange(value)
   }
 
   handleOnBlur = (event: Event) => {

--- a/src/components/Switch/__tests__/Switch.test.js
+++ b/src/components/Switch/__tests__/Switch.test.js
@@ -172,9 +172,9 @@ describe('Events', () => {
   test('onClick callback can be triggered, by onChange', () => {
     const spy = jest.fn()
     const wrapper = mount(<Switch onClick={spy} value="Mugatu" />)
-    const input = wrapper.find('input')
+    const input = wrapper.find(SwitchUI)
 
-    input.simulate('change')
+    input.simulate('click')
 
     expect(spy).toHaveBeenCalled()
   })

--- a/stories/Switch.js
+++ b/stories/Switch.js
@@ -160,8 +160,8 @@ class LoadingSwitch extends React.Component {
         value="on"
         checked={this.state.on}
         isLoading={this.state.isLoading}
-        onClick={this.handleOnClick}
         onChange={this.handleOnChange}
+        onClick={this.handleOnClick}
       />
     )
   }


### PR DESCRIPTION
## Switch: Fix `onChange`/`onClick` callbacks

This update fixes the `onChange` regression that was introduced with the
new ["loading" state](https://github.com/helpscout/blue/pull/341) for the `Switch`.


### Switch loading state

This does not change the Component API for implementing the `Switch` loading state. It should still be written like:

```jsx
<Switch
  value="on"
  checked={this.state.checked}
  isLoading={this.state.isLoading}
  onChange={this.handleOnChange}
  onClick={this.handleOnClick}
/>
```

`onClick` will trigger the action to determined if the `Switch` should be checked or not, which should be updated in the parent component `state`.

Once that is done, it'll then get passed into `Switch` as `checked`.

Once that changes, the `onChange` callback action will be called.