### PR TITLE
Add styles for disabled state on the Switch component

### DIFF
--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -192,6 +192,7 @@ class Switch extends Component<Props, State> {
 
     const componentClassName = classNames(
       'c-Switch',
+      disabled && 'is-disabled',
       shouldShowChecked && 'is-checked',
       isLoading && 'is-loading',
       size && `is-${size}`,

--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -21,6 +21,7 @@ import { COMPONENT_KEY } from './utils'
 type Props = {
   className?: string,
   checked: boolean,
+  disabled: boolean,
   id: string,
   isLoading: boolean,
   inputRef: (ref: any) => void,
@@ -134,7 +135,14 @@ class Switch extends Component<Props, State> {
   }
 
   getInputMarkup = (props: Object = {}) => {
-    const { checked: propActive, inputRef, name, value, ...rest } = this.props
+    const {
+      checked: propActive,
+      disabled,
+      inputRef,
+      name,
+      value,
+      ...rest
+    } = this.props
     const { checked } = this.state
 
     const id = this.getIdFromContextProps(props)
@@ -145,6 +153,7 @@ class Switch extends Component<Props, State> {
         aria-checked={checked}
         className="c-Switch__input"
         checked={checked}
+        disabled={disabled}
         id={id}
         name={name}
         onBlur={this.handleOnBlur}
@@ -162,6 +171,7 @@ class Switch extends Component<Props, State> {
   render() {
     const {
       className,
+      disabled,
       onBlur,
       onChange,
       onFocus,
@@ -192,6 +202,7 @@ class Switch extends Component<Props, State> {
     const backdropClassName = classNames(
       'c-Switch__backdrop',
       shouldShowChecked && 'is-checked',
+      disabled && 'is-disabled',
       isFocused && 'is-focused',
       size && `is-${size}`
     )

--- a/src/components/Switch/__tests__/Switch.test.js
+++ b/src/components/Switch/__tests__/Switch.test.js
@@ -94,6 +94,28 @@ describe('Checked', () => {
   })
 })
 
+describe('Disabled', () => {
+  test('Is false by default', () => {
+    const wrapper = mount(<Switch />)
+    const o = wrapper.instance()
+
+    const backdrop = wrapper.find(BackdropUI)
+
+    expect(o.props.disabled).toBeFalsy()
+    expect(backdrop.hasClass('is-disabled')).not.toBeTruthy()
+  })
+
+  test('Can be set to true', () => {
+    const wrapper = mount(<Switch disabled />)
+    const o = wrapper.instance()
+
+    const backdrop = wrapper.find(BackdropUI)
+
+    expect(o.props.disabled).toBeTruthy()
+    expect(backdrop.hasClass('is-disabled')).toBeTruthy()
+  })
+})
+
 describe('Loading', () => {
   test('Is not loading by default', () => {
     const wrapper = mount(<Switch />)

--- a/src/components/Switch/styles/Switch.css.js
+++ b/src/components/Switch/styles/Switch.css.js
@@ -7,15 +7,18 @@ import styled from '../../styled'
 export const config = {
   backgroundColor: {
     default: getColor('grey.500'),
+    disabled: getColor('grey.300'),
     hover: getColor('grey.600'),
   },
   backgroundColorChecked: {
     default: getColor('green.500'),
+    disabled: getColor('green.300'),
     hover: getColor('green.600'),
   },
   borderRadius: 100,
   color: {
     default: getColor('charcoal.200'),
+    disabled: getColor('charcoal.400'),
     checked: 'white',
   },
   fontSize: 12,
@@ -81,6 +84,11 @@ export const BackdropUI = styled('div')`
     background-color: ${config.backgroundColor.hover};
   }
 
+  &.is-disabled {
+    background-color: ${config.backgroundColor.disabled};
+    color: ${config.color.disabled};
+  }
+
   &.is-checked {
     background-color: ${config.backgroundColorChecked.default};
     color: ${config.color.checked};
@@ -88,6 +96,11 @@ export const BackdropUI = styled('div')`
 
     &.is-focused {
       background-color: ${config.backgroundColorChecked.hover};
+    }
+
+    &.is-disabled {
+      background-color: ${config.backgroundColorChecked.disabled};
+      color: ${config.color.disabled};
     }
   }
 

--- a/src/components/Switch/styles/Switch.css.js
+++ b/src/components/Switch/styles/Switch.css.js
@@ -47,6 +47,10 @@ export const SwitchUI = styled('label')`
   margin: 0;
   position: relative;
 
+  &.is-disabled {
+    pointer-events: none;
+  }
+
   &.is-loading {
     pointer-events: none;
   }

--- a/stories/Switch.js
+++ b/stories/Switch.js
@@ -66,6 +66,47 @@ stories.add('state', () => (
   </form>
 ))
 
+stories.add('disabled', () => (
+  <form style={{ width: 300 }}>
+    <Hr size="sm" />
+    <Flexy>
+      <Flexy.Item>
+        <Text>Disabled (checked)</Text>
+      </Flexy.Item>
+      <Flexy.Item>
+        <Switch checked disabled size="sm" />
+      </Flexy.Item>
+    </Flexy>
+    <Hr size="sm" />
+    <Flexy>
+      <Flexy.Item>
+        <Text>Disabled</Text>
+      </Flexy.Item>
+      <Flexy.Item>
+        <Switch disabled size="sm" />
+      </Flexy.Item>
+    </Flexy>
+    <Hr size="sm" />
+    <Flexy>
+      <Flexy.Item>
+        <Text>Enabled (checked)</Text>
+      </Flexy.Item>
+      <Flexy.Item>
+        <Switch checked disabled={false} size="sm" />
+      </Flexy.Item>
+    </Flexy>
+    <Hr size="sm" />
+    <Flexy>
+      <Flexy.Item>
+        <Text>Enabled</Text>
+      </Flexy.Item>
+      <Flexy.Item>
+        <Switch disabled={false} size="sm" />
+      </Flexy.Item>
+    </Flexy>
+  </form>
+))
+
 stories.add('loading', () => (
   <form style={{ width: 300 }}>
     <Hr size="sm" />


### PR DESCRIPTION
## Switch: Add styles for disabled state

Within Beacon Builder we have a number of switches that are sometimes in a disabled state. This functions as expected, however it's not visually clear that the switch is disabled. We have had a number of false bug reports due to this.

This change adds some styling for the disabled state. I have attempted to make the switches slightly opaque when disabled to differentiate to the enabled switches. It doesn't quite look right to me, but code wise it's working.

![screen shot 2018-09-10 at 18 18 45](https://user-images.githubusercontent.com/6132043/45313581-2f7eef00-b527-11e8-9066-25c7282fe15e.png)

@digitaldesigner Do you have any input on this? I couldn't see this state in the designs https://github.com/helpscout/library-hsapp/wiki/Example:-Settings-Refresh