### PR TITLE
Switch: Update onChange callback values

### DIFF
--- a/src/components/Switch/README.md
+++ b/src/components/Switch/README.md
@@ -10,18 +10,28 @@ A Switch component is an alternative to a [Checkbox](../Checkbox) that provides 
 
 ## Props
 
-| Prop      | Type              | Description                                         |
-| --------- | ----------------- | --------------------------------------------------- |
-| checked   | `bool`            | Determines if the component is checked.             |
-| className | `string`          | Custom class names to be added to the component.    |
-| id        | `string`          | Sets a custom ID for the component.                 |
-| isLoading | `bool`            | Activates the loading state.                        |
-| inputRef  | `function`        | Callback to retrieve the `input` node.              |
-| name      | `string`          | Name attribute for the component's `input` node.    |
-| onBlur    | `function`        | Callback function when component blurs.             |
-| onClick   | `function`        | Callback function when component is clicked.        |
-| onChange  | `function`        | Callback function when component `checked` changes. |
-| onFocus   | `function`        | Callback function when component focuses.           |
-| size      | `string`          | Adjusts the size of the component.                  |
-| state     | `string`          | Applies state-based styling.                        |
-| value     | `string`/`number` | Value for the component.                            |
+| Prop      | Type              | Description                                                                 |
+| --------- | ----------------- | --------------------------------------------------------------------------- |
+| checked   | `bool`            | Determines if the component is checked.                                     |
+| className | `string`          | Custom class names to be added to the component.                            |
+| id        | `string`          | Sets a custom ID for the component.                                         |
+| isLoading | `bool`            | Activates the loading state.                                                |
+| inputRef  | `function`        | Callback to retrieve the `input` node.                                      |
+| name      | `string`          | Name attribute for the component's `input` node.                            |
+| onBlur    | `function`        | Callback function when component blurs.                                     |
+| onClick   | `function`        | Callback function when component is clicked.                                |
+| onChange  | `function`        | Callback function when component `checked` changes. Returns switched state. |
+| onFocus   | `function`        | Callback function when component focuses.                                   |
+| size      | `string`          | Adjusts the size of the component.                                          |
+| state     | `string`          | Applies state-based styling.                                                |
+| value     | `string`/`number` | Value for the component.                                                    |
+
+### `onChange(nextValue, { event, value })`
+
+The `onChange` callback returns the next switch state. Additionally, the `onChange` and `value` props are provided as an Object as a second argument.
+
+| Prop      | Type    | Description                             |
+| --------- | ------- | --------------------------------------- |
+| nextValue | `bool`  | The next switch state value.            |
+| event     | `Event` | The `onChange` event.                   |
+| value     | `any`   | The specified `value` of the component. |

--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -88,13 +88,14 @@ class Switch extends Component<Props, State> {
 
   handleOnChange = (event: Event) => {
     const { onChange, value } = this.props
+    const nextChecked = !this.state.checked
 
     /* istanbul ignore else */
     if (this.shouldAutoUpdateChecked) {
-      this.setState({ checked: !this.state.checked })
+      this.setState({ checked: nextChecked })
     }
 
-    onChange(value)
+    onChange(nextChecked, { event, value })
   }
 
   handleOnClick = (event: Event) => {

--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -27,7 +27,7 @@ type Props = {
   inputRef: (ref: any) => void,
   name: string,
   onBlur: (event: Event) => void,
-  onChange: (value: SwitchValue) => void,
+  onChange: (state: boolean, { event: Event, value: SwitchValue }) => void,
   onClick: (event: Event) => void,
   onFocus: (event: Event) => void,
   onMouseDown: (event: Event) => void,

--- a/src/components/Switch/__tests__/Switch.test.js
+++ b/src/components/Switch/__tests__/Switch.test.js
@@ -199,7 +199,22 @@ describe('Events', () => {
 
     input.simulate('change')
 
-    expect(spy).toHaveBeenCalledWith('Mugatu')
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('onChange callback also receives value and event', () => {
+    let callbackProps = []
+    const onChange = (...args) => (callbackProps = [...args])
+    const wrapper = mount(
+      <Switch onChange={onChange} value="Mugatu" checked={false} />
+    )
+    const input = wrapper.find('input')
+
+    input.simulate('change')
+
+    expect(callbackProps[0]).toBe(true)
+    expect(callbackProps[1].event).toBeTruthy()
+    expect(callbackProps[1].value).toBe('Mugatu')
   })
 
   test('onClick callback can be triggered, by onChange', () => {
@@ -304,6 +319,24 @@ describe('ID', () => {
 })
 
 describe('State', () => {
+  test('onChange callback receives next switch state ', () => {
+    let callbackProps = []
+    const onChange = (...args) => (callbackProps = [...args])
+    const wrapper = mount(
+      <Switch
+        onChange={onChange}
+        checked={false}
+        value="Mugatu"
+        checked={false}
+      />
+    )
+    const input = wrapper.find('input')
+
+    input.simulate('change')
+
+    expect(callbackProps[0]).toBe(true)
+  })
+
   test('Can render error styles', () => {
     const wrapper = mount(<Switch state="error" />)
     const el = wrapper.find('.c-Switch').getNode()

--- a/stories/Switch.js
+++ b/stories/Switch.js
@@ -215,11 +215,8 @@ class App extends React.Component {
   }
 
   handleOnChange = value => {
-    const nextValue = !this.state.on
-    console.log(value, 'toggle', nextValue)
-
     this.setState({
-      on: nextValue,
+      on: value,
     })
   }
 
@@ -227,7 +224,7 @@ class App extends React.Component {
     return (
       <Switch
         value="on"
-        active={this.state.on}
+        checked={this.state.on}
         onChange={this.handleOnChange}
         id="Switch"
       />


### PR DESCRIPTION
## Switch: Update onChange callback values

This update modifies `Switch` to return a more intuitive callback value
that represents the next switch state (after engagement).

Additionally, the `onChange` event and value are provided as a second
argument, wrapped within an object.

Minor bump for this update!