### PR TITLE
Avatar group component fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/blue",
-  "version": "1.6.1",
+  "version": "1.6.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/blue",
-  "version": "1.6.1",
+  "version": "1.6.2-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -22,20 +22,21 @@ This component can be themed using a [ThemeProvider](../styled).
 
 ## Props
 
-| Prop             | Type              | Description                                                               |
-| ---------------- | ----------------- | ------------------------------------------------------------------------- |
-| borderColor      | `string`          | Color for the Avatar border.                                              |
-| className        | `string`          | Custom class names to be added to the component.                          |
-| count            | `number`/`string` | Used to display an additional avatar count.                               |
-| image            | `string`          | URL of the image to display.                                              |
-| light            | `bool`            | Applies a "light" style to the component.                                 |
-| initials         | `string`          | Custom initials to display.                                               |
-| name             | `string`          | Name of the user. Required.                                               |
-| onError          | `function`        | Callback when avatar image fails to load.                                 |
-| onLoad           | `function`        | Callback when avatar image loads.                                         |
-| outerBorderColor | `string`          | Color for the Avatar's outer border.                                      |
-| shape            | `string`          | Shape of the avatar.                                                      |
-| size             | `string`          | Size of the avatar.                                                       |
-| title            | `string`          | Text for the image `alt` and `title` attributes.                          |
-| status           | `string`          | Renders a [StatusDot](../StatusDot) with the status type.                 |
-| statusIcon       | `string`          | Name of the [Icon](../Icon) to render into the [StatusDot](../StatusDot). |
+| Prop                  | Type              | Description                                                               |
+| --------------------- | ----------------- | ------------------------------------------------------------------------- |
+| borderColor           | `string`          | Color for the Avatar border.                                              |
+| className             | `string`          | Custom class names to be added to the component.                          |
+| count                 | `number`/`string` | Used to display an additional avatar count.                               |
+| image                 | `string`          | URL of the image to display.                                              |
+| light                 | `bool`            | Applies a "light" style to the component.                                 |
+| initials              | `string`          | Custom initials to display.                                               |
+| name                  | `string`          | Name of the user. Required.                                               |
+| onError               | `function`        | Callback when avatar image fails to load.                                 |
+| onLoad                | `function`        | Callback when avatar image loads.                                         |
+| outerBorderColor      | `string`          | Color for the Avatar's outer border.                                      |
+| shape                 | `string`          | Shape of the avatar.                                                      |
+| size                  | `string`          | Size of the avatar.                                                       |
+| title                 | `string`          | Text for the image `alt` and `title` attributes.                          |
+| showStatusBorderColor | `bool`            | Renders the [StatusDot](../StatusDot) border.                             |
+| status                | `string`          | Renders a [StatusDot](../StatusDot) with the status type.                 |
+| statusIcon            | `string`          | Name of the [Icon](../Icon) to render into the [StatusDot](../StatusDot). |

--- a/src/components/AvatarGrid/AvatarGrid.js
+++ b/src/components/AvatarGrid/AvatarGrid.js
@@ -1,24 +1,29 @@
 // @flow
 import type { AvatarShape, AvatarSize } from '../Avatar/types'
 import React, { PureComponent as Component } from 'react'
+import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import Avatar from '../Avatar'
 import Animate from '../Animate'
 import styled from '../styled'
 import { classNames } from '../../utilities/classNames'
-import { namespaceComponent } from '../../utilities/component'
+import { namespaceComponent, isComponentNamed } from '../../utilities/component'
 import avatarGridWrapperCSS from './styles/AvatarGridWrapper.css.js'
 import avatarGridContainerCSS from './styles/AvatarGridContainer.css.js'
 import avatarGridCSS from './styles/AvatarGrid.css.js'
 import { COMPONENT_KEY } from './utils'
+import { COMPONENT_KEY as AVATAR_KEY } from '../Avatar/utils'
 
 type Props = {
   animationEasing: string,
   animationSequence: string,
+  borderColor?: string,
   center: boolean,
   children?: any,
   className?: string,
   max: number,
+  outerBorderColor?: string,
   shape: AvatarShape,
+  showStatusBorderColor: boolean,
   size: AvatarSize,
 }
 
@@ -30,9 +35,11 @@ class AvatarGrid extends Component<Props> {
   static defaultProps = {
     animationEasing: 'bounce',
     animationSequence: 'fade',
+    borderColor: 'transparent',
     center: true,
     max: 9,
     shape: 'rounded',
+    showStatusBorderColor: true,
     size: 'md',
   }
 
@@ -40,17 +47,20 @@ class AvatarGrid extends Component<Props> {
     const {
       animationEasing,
       animationSequence,
+      borderColor,
       center,
       children,
       className,
       max,
+      outerBorderColor,
       shape,
+      showStatusBorderColor,
       size,
       ...rest
     } = this.props
 
-    const avatars = React.Children.toArray(children).filter(
-      child => child.type && child.type === Avatar
+    const avatars = React.Children.toArray(children).filter(child =>
+      isComponentNamed(child, AVATAR_KEY)
     )
 
     const totalAvatarCount = avatars.length
@@ -72,10 +82,13 @@ class AvatarGrid extends Component<Props> {
       >
         <div className="c-AvatarGrid__item is-additional">
           <Avatar
+            borderColor={borderColor}
             count={`+${additionalAvatarCount}`}
             light
             name={`+${additionalAvatarCount}`}
+            outerBorderColor={outerBorderColor}
             shape={shape}
+            showStatusBorderColor={showStatusBorderColor}
             size={size}
           />
         </div>
@@ -84,7 +97,10 @@ class AvatarGrid extends Component<Props> {
 
     const avatarMarkup = avatarList.map(avatar => {
       const composedAvatar = React.cloneElement(avatar, {
+        borderColor,
+        outerBorderColor,
         shape,
+        showStatusBorderColor,
         size,
       })
 
@@ -102,7 +118,10 @@ class AvatarGrid extends Component<Props> {
     return (
       <AvatarGridWrapper className={componentWrapperClassName}>
         <AvatarGridContainer className="c-AvatarGridContainer">
-          <AvatarGridComponent className={componentClassName} {...rest}>
+          <AvatarGridComponent
+            {...getValidProps(rest)}
+            className={componentClassName}
+          >
             {avatarMarkup}
             {additionalAvatarMarkup}
           </AvatarGridComponent>

--- a/src/components/AvatarGrid/README.md
+++ b/src/components/AvatarGrid/README.md
@@ -16,13 +16,16 @@ This component is similar to [AvatarList](../AvatarList) with minor UI and anima
 
 ## Props
 
-| Prop              | Type                            | Description                                                                  |
-| ----------------- | ------------------------------- | ---------------------------------------------------------------------------- |
-| animationEasing   | `string`                        | Easing of [animation](../Animate) applied to the child [Avatars](../Avatar). |
-| animationSequence | `string`                        | Style of [animation](../Animate) applied to the child [Avatars](../Avatar).  |
-| center            | `bool`                          | Center aligns the component.                                                 |
-| children          | `array`/[`<Avatar>`](../Avatar) | An [Avatar](../Avatar) component or an array of Avatars.                     |
-| className         | `string`                        | Custom class names to be added to the component.                             |
-| max               | `number`                        | Number of avatars to display before truncating.                              |
-| shape             | `string`                        | Shape of the avatars.                                                        |
-| size              | `string`                        | Size of the avatars.                                                         |
+| Prop                  | Type                            | Description                                                                  |
+| --------------------- | ------------------------------- | ---------------------------------------------------------------------------- |
+| animationEasing       | `string`                        | Easing of [animation](../Animate) applied to the child [Avatars](../Avatar). |
+| animationSequence     | `string`                        | Style of [animation](../Animate) applied to the child [Avatars](../Avatar).  |
+| borderColor           | `string`                        | Color for the Avatar border.                                                 |
+| center                | `bool`                          | Center aligns the component.                                                 |
+| children              | `array`/[`<Avatar>`](../Avatar) | An [Avatar](../Avatar) component or an array of Avatars.                     |
+| className             | `string`                        | Custom class names to be added to the component.                             |
+| max                   | `number`                        | Number of avatars to display before truncating.                              |
+| outerBorderColor      | `string`                        | Color for the Avatar's outer border.                                         |
+| shape                 | `string`                        | Shape of the avatars.                                                        |
+| showStatusBorderColor | `bool`                          | Renders the [StatusDot](../StatusDot) border.                                |
+| size                  | `string`                        | Size of the avatars.                                                         |

--- a/src/components/AvatarGrid/__tests__/AvatarGrid.test.js
+++ b/src/components/AvatarGrid/__tests__/AvatarGrid.test.js
@@ -83,3 +83,22 @@ describe('Limit', () => {
     expect(additionalCounter.text()).not.toBe('+2')
   })
 })
+
+describe('Avatar Props', () => {
+  test('Passes props to Avatar', () => {
+    const wrapper = mount(
+      <AvatarGrid
+        borderColor="red"
+        outerBorderColor="blue"
+        showStatusBorderColor={true}
+      >
+        <Avatar />
+      </AvatarGrid>
+    )
+    const avatar = wrapper.find(Avatar)
+
+    expect(avatar.prop('borderColor')).toBe('red')
+    expect(avatar.prop('outerBorderColor')).toBe('blue')
+    expect(avatar.prop('showStatusBorderColor')).toBe(true)
+  })
+})

--- a/src/components/AvatarList/AvatarList.js
+++ b/src/components/AvatarList/AvatarList.js
@@ -5,19 +5,23 @@ import Avatar from '../Avatar'
 import AnimateGroup from '../AnimateGroup'
 import Animate from '../Animate'
 import { classNames } from '../../utilities/classNames'
-import { namespaceComponent } from '../../utilities/component'
+import { namespaceComponent, isComponentNamed } from '../../utilities/component'
 import { AvatarListWrapperUI } from './styles/AvatarList.css.js'
 import { COMPONENT_KEY } from './utils'
+import { COMPONENT_KEY as AVATAR_KEY } from '../Avatar/utils'
 
 type Props = {
   animationEasing: string,
   animationSequence: string,
   animationStagger: number,
   avatarsClassName: string,
+  borderColor?: string,
   children?: any,
   className?: string,
   max: number,
+  outerBorderColor?: string,
   shape: AvatarShape,
+  showStatusBorderColor: boolean,
   size: AvatarSize,
 }
 
@@ -28,6 +32,7 @@ class AvatarList extends Component<Props> {
     animationStagger: 10,
     max: 4,
     shape: 'rounded',
+    showStatusBorderColor: false,
     size: 'sm',
   }
 
@@ -37,16 +42,19 @@ class AvatarList extends Component<Props> {
       animationSequence,
       animationStagger,
       avatarsClassName,
+      borderColor,
       children,
       className,
       max,
+      outerBorderColor,
       shape,
+      showStatusBorderColor,
       size,
       ...rest
     } = this.props
 
-    const avatars = React.Children.toArray(children).filter(
-      child => child.type && child.type === Avatar
+    const avatars = React.Children.toArray(children).filter(child =>
+      isComponentNamed(child, AVATAR_KEY)
     )
 
     const totalAvatarCount = avatars.length
@@ -72,11 +80,14 @@ class AvatarList extends Component<Props> {
         sequence={animationSequence}
       >
         <Avatar
+          borderColor={borderColor}
           className={avatarsClassName}
           count={`+${additionalAvatarCount}`}
           light
+          outerBorderColor={outerBorderColor}
           name={`+${additionalAvatarCount}`}
           shape={shape}
+          showStatusBorderColor={showStatusBorderColor}
           size={size}
         />
       </Animate>
@@ -84,8 +95,11 @@ class AvatarList extends Component<Props> {
 
     const avatarMarkup = avatarList.map(avatar => {
       const composedAvatar = React.cloneElement(avatar, {
+        borderColor,
         className: classNames(avatar.props.className, avatarsClassName),
+        outerBorderColor,
         shape,
+        showStatusBorderColor,
         size,
       })
       return (
@@ -103,10 +117,10 @@ class AvatarList extends Component<Props> {
     return (
       <AvatarListWrapperUI className="c-AvatarListWrapper">
         <AnimateGroup
+          {...rest}
           className={componentClassName}
           stagger
           staggerDelay={animationStagger}
-          {...rest}
         >
           {avatarMarkup}
           {additionalAvatarMarkup}

--- a/src/components/AvatarList/README.md
+++ b/src/components/AvatarList/README.md
@@ -16,13 +16,16 @@ This component is similar to [AvatarStack](../AvatarStack) with minor UI and ani
 
 ## Props
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| animationEasing | `string` | Easing of [animation](../Animate) applied to the child [Avatars](../Avatar). |
-| animationSequence | `string` | Style of [animation](../Animate) applied to the child [Avatars](../Avatar). |
-| animationStagger | `number` | Amount (in `ms`) to stagger the [animations](../Animate) of the [Avatars](../Avatar). |
-| avatarsClassName | `string` | Custom className to pass to [Avatars](../Avatar). |
-| className | `string` | Custom class names to be added to the component. |
-| max | `number` | Number of avatars to display before truncating. |
-| shape | `string` | Shape of the avatars. |
-| size | `string` | Size of the avatars. |
+| Prop                  | Type     | Description                                                                           |
+| --------------------- | -------- | ------------------------------------------------------------------------------------- |
+| animationEasing       | `string` | Easing of [animation](../Animate) applied to the child [Avatars](../Avatar).          |
+| animationSequence     | `string` | Style of [animation](../Animate) applied to the child [Avatars](../Avatar).           |
+| animationStagger      | `number` | Amount (in `ms`) to stagger the [animations](../Animate) of the [Avatars](../Avatar). |
+| avatarsClassName      | `string` | Custom className to pass to [Avatars](../Avatar).                                     |
+| borderColor           | `string` | Color for the Avatar border.                                                          |
+| className             | `string` | Custom class names to be added to the component.                                      |
+| max                   | `number` | Number of avatars to display before truncating.                                       |
+| outerBorderColor      | `string` | Color for the Avatar's outer border.                                                  |
+| shape                 | `string` | Shape of the avatars.                                                                 |
+| showStatusBorderColor | `bool`   | Renders the [StatusDot](../StatusDot) border.                                         |
+| size                  | `string` | Size of the avatars.                                                                  |

--- a/src/components/AvatarList/__tests__/AvatarList.test.js
+++ b/src/components/AvatarList/__tests__/AvatarList.test.js
@@ -121,3 +121,22 @@ describe('Limit', () => {
     expect(additionalCounter.text()).not.toBe('+2')
   })
 })
+
+describe('Avatar Props', () => {
+  test('Passes props to Avatar', () => {
+    const wrapper = mount(
+      <AvatarList
+        borderColor="red"
+        outerBorderColor="blue"
+        showStatusBorderColor={true}
+      >
+        <Avatar />
+      </AvatarList>
+    )
+    const avatar = wrapper.find(Avatar)
+
+    expect(avatar.prop('borderColor')).toBe('red')
+    expect(avatar.prop('outerBorderColor')).toBe('blue')
+    expect(avatar.prop('showStatusBorderColor')).toBe(true)
+  })
+})

--- a/src/components/AvatarStack/AvatarStack.js
+++ b/src/components/AvatarStack/AvatarStack.js
@@ -2,23 +2,25 @@
 import type { AvatarShape, AvatarSize } from '../Avatar/types'
 import React, { PureComponent as Component } from 'react'
 import Avatar from '../Avatar'
-import AnimateGroup from '../AnimateGroup'
 import Animate from '../Animate'
 import { classNames } from '../../utilities/classNames'
-import { namespaceComponent } from '../../utilities/component'
+import { namespaceComponent, isComponentNamed } from '../../utilities/component'
 import { AvatarStackUI, ItemUI } from './styles/AvatarStack.css.js'
 import { COMPONENT_KEY } from './utils'
+import { COMPONENT_KEY as AVATAR_KEY } from '../Avatar/utils'
 
 type Props = {
   animationEasing: string,
   animationSequence: string,
   animationStagger: number,
   avatarsClassName: string,
-  borderColor: string,
+  borderColor?: string,
   children?: any,
   className?: string,
   max: number,
+  outerBorderColor?: string,
   shape: AvatarShape,
+  showStatusBorderColor: boolean,
   size: AvatarSize,
 }
 
@@ -30,6 +32,7 @@ class AvatarStack extends Component<Props> {
     borderColor: 'white',
     max: 5,
     shape: 'circle',
+    showStatusBorderColor: true,
     size: 'md',
   }
 
@@ -43,13 +46,15 @@ class AvatarStack extends Component<Props> {
       children,
       className,
       max,
+      outerBorderColor,
       shape,
+      showStatusBorderColor,
       size,
       ...rest
     } = this.props
 
-    const avatars = React.Children.toArray(children).filter(
-      child => child.type && child.type === Avatar
+    const avatars = React.Children.toArray(children).filter(child =>
+      isComponentNamed(child, AVATAR_KEY)
     )
 
     const totalAvatarCount = avatars.length
@@ -71,7 +76,9 @@ class AvatarStack extends Component<Props> {
             className={avatarsClassName}
             count={`+${additionalAvatarCount}`}
             name={`+${additionalAvatarCount}`}
+            outerBorderColor={outerBorderColor}
             shape={shape}
+            showStatusBorderColor={showStatusBorderColor}
             size={size}
           />
         </ItemUI>
@@ -83,7 +90,9 @@ class AvatarStack extends Component<Props> {
       const composedAvatar = React.cloneElement(avatar, {
         borderColor,
         className: classNames(avatar.props.className, avatarsClassName),
+        outerBorderColor,
         shape,
+        showStatusBorderColor,
         size,
       })
 
@@ -101,10 +110,10 @@ class AvatarStack extends Component<Props> {
 
     return (
       <AvatarStackUI
+        {...rest}
         className={componentClassName}
         stagger
         staggerDelay={animationStagger}
-        {...rest}
       >
         {avatarMarkup}
         {additionalAvatarMarkup}

--- a/src/components/AvatarStack/README.md
+++ b/src/components/AvatarStack/README.md
@@ -14,14 +14,16 @@ An AvatarStack component displays an array of [Avatars](../Avatar). This compone
 
 ## Props
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| animationEasing | `string` | Easing of [animation](../Animate) applied to the child [Avatars](../Avatar). |
-| animationSequence | `string` | Style of [animation](../Animate) applied to the child [Avatars](../Avatar). |
-| animationStagger | `number` | Amount (in `ms`) to stagger the [animations](../Animate) of the [Avatars](../Avatar). |
-| avatarsClassName | `string` | Custom className to pass to [Avatars](../Avatar). |
-| borderColor | `string` | Color for the Avatar border. |
-| className | `string` | Custom class names to be added to the component. |
-| max | `number` | Number of avatars to display before truncating. |
-| shape | `string` | Shape of the avatars. |
-| size | `string` | Size of the avatars. |
+| Prop                  | Type     | Description                                                                           |
+| --------------------- | -------- | ------------------------------------------------------------------------------------- |
+| animationEasing       | `string` | Easing of [animation](../Animate) applied to the child [Avatars](../Avatar).          |
+| animationSequence     | `string` | Style of [animation](../Animate) applied to the child [Avatars](../Avatar).           |
+| animationStagger      | `number` | Amount (in `ms`) to stagger the [animations](../Animate) of the [Avatars](../Avatar). |
+| avatarsClassName      | `string` | Custom className to pass to [Avatars](../Avatar).                                     |
+| borderColor           | `string` | Color for the Avatar border.                                                          |
+| className             | `string` | Custom class names to be added to the component.                                      |
+| max                   | `number` | Number of avatars to display before truncating.                                       |
+| outerBorderColor      | `string` | Color for the Avatar's outer border.                                                  |
+| shape                 | `string` | Shape of the avatars.                                                                 |
+| showStatusBorderColor | `bool`   | Renders the [StatusDot](../StatusDot) border.                                         |
+| size                  | `string` | Size of the avatars.                                                                  |

--- a/src/components/AvatarStack/__tests__/AvatarStack.test.js
+++ b/src/components/AvatarStack/__tests__/AvatarStack.test.js
@@ -121,3 +121,22 @@ describe('Limit', () => {
     expect(additionalCounter.text()).not.toBe('+2')
   })
 })
+
+describe('Avatar Props', () => {
+  test('Passes props to Avatar', () => {
+    const wrapper = mount(
+      <AvatarStack
+        borderColor="red"
+        outerBorderColor="blue"
+        showStatusBorderColor={true}
+      >
+        <Avatar />
+      </AvatarStack>
+    )
+    const avatar = wrapper.find(Avatar)
+
+    expect(avatar.prop('borderColor')).toBe('red')
+    expect(avatar.prop('outerBorderColor')).toBe('blue')
+    expect(avatar.prop('showStatusBorderColor')).toBe(true)
+  })
+})

--- a/stories/AvatarGrid/index.js
+++ b/stories/AvatarGrid/index.js
@@ -67,7 +67,13 @@ class TestComponent extends Component {
   }
 }
 
-stories.add('default', () => <AvatarGrid max={14}>{avatarsMarkup}</AvatarGrid>)
+stories.add('default', () => (
+  <div style={{ background: '#eee', padding: 10 }}>
+    <AvatarGrid borderColor="#eee" showStatusBorderColor max={14}>
+      {avatarsMarkup}
+    </AvatarGrid>
+  </div>
+))
 
 stories.add('animations', () => (
   <AvatarGrid animationSequence="scaleLg" animationStagger={100} max={9}>


### PR DESCRIPTION
## Avatar group component fixes

![screen shot 2018-09-24 at 1 58 57 pm](https://user-images.githubusercontent.com/2322354/45969872-08362080-c003-11e8-8418-7dd317862c08.jpg)

This update adjusts `AvatarGrid`, `AvatarList`, and `AvatarStack` to
pass down various props to children `Avatar` components (`borderColor`,
`outerBorderColor`, and `showStatusBorderColor`)

This enables these parent wrapper components to leverage the newly adjusted
component API of `Avatar`.

Test and README have been updated

Follow up for https://github.com/helpscout/blue/pull/356