### PR TITLE
Only call highlightBlock if the ref element is not null

### DIFF
--- a/src/components/CopyCode/CopyCode.js
+++ b/src/components/CopyCode/CopyCode.js
@@ -10,26 +10,26 @@ import { COMPONENT_KEY } from './utils'
 import { CopyButtonUI, CopyCodeUI, WrapperUI } from './styles/CopyCode.css.js'
 
 type Props = {
+  autoFocus: boolean,
   className?: string,
   code: string,
   copyToClipboard: boolean,
   language?: string,
   onCopy: (code: string) => void,
-  selectOnMount: boolean,
 }
 
 class CopyCode extends Component<Props> {
   static defaultProps = {
+    autoFocus: true,
     code: '',
     copyToClipboard: true,
     onCopy: noop,
-    selectOnMount: true,
   }
   codeNode: HTMLElement
 
   componentDidMount() {
     /* istanbul ignore else */
-    if (this.props.selectOnMount) {
+    if (this.props.autoFocus) {
       this.selectText()
     }
   }

--- a/src/components/CopyCode/README.md
+++ b/src/components/CopyCode/README.md
@@ -12,9 +12,9 @@ This component renders a [Highlighted](../Highlight) code snippet with the abili
 
 | Prop            | Type       | Description                                                                                                                                                     |
 | --------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| autoFocus       | `boolean`  | Automatically select `code` when component mounts.                                                                                                              |
 | className       | `string`   | Custom class names to be added to the component.                                                                                                                |
 | code            | `string`   | The code to be displayed within the container.                                                                                                                  |
 | copyToClipboard | `boolean`  | Enables copying to clipboard.                                                                                                                                   |
 | language        | `string`   | The language of the code for syntax highlighting ([available languages in highlight.js](https://github.com/highlightjs/highlight.js/tree/master/src/languages)) |
 | onCopy          | `function` | Callback function when the copy button is clicked.                                                                                                              |
-| selectOnMount   | `boolean`  | Automatically select `code` when component mounts.                                                                                                              |

--- a/src/components/Highlight/Highlight.js
+++ b/src/components/Highlight/Highlight.js
@@ -16,13 +16,17 @@ type Props = {
 class Highlight extends Component<Props> {
   static defaultProps = {}
 
+  highlightBlock(element) {
+    element && hljs.highlightBlock(element)
+  }
+
   render() {
     const { className, children, language, ...rest } = this.props
     const componentClassName = classNames('c-Highlight', className)
 
     return (
       <HighlightUI {...getValidProps(rest)} className={componentClassName}>
-        <code className={language} ref={el => hljs.highlightBlock(el)}>
+        <code className={language} ref={this.highlightBlock}>
           {children}
         </code>
       </HighlightUI>

--- a/src/components/Highlight/Highlight.js
+++ b/src/components/Highlight/Highlight.js
@@ -16,8 +16,8 @@ type Props = {
 class Highlight extends Component<Props> {
   static defaultProps = {}
 
-  highlightBlock(element) {
-    element && hljs.highlightBlock(element)
+  highlightBlock = (node: HTMLElement) => {
+    node && hljs.highlightBlock(node)
   }
 
   render() {


### PR DESCRIPTION
When unmounting the Highlight component the `ref` was being set to null, but this was not guarded against so it was attempting to highlight the `null` element. This change prevents the error by checking element is not `null` before calling `highlightBlock`.