### PR TITLE
Add loading indicator to Message.Embed

### DIFF
--- a/src/components/Message/Embed.js
+++ b/src/components/Message/Embed.js
@@ -1,8 +1,9 @@
 // @flow
 import type { MessageThemeContext } from './types'
-import React, { PureComponent } from 'react'
+import React, { Component } from 'react'
 import styled from '../styled'
 import Chat from './Chat'
+import LoadingDots from '../LoadingDots'
 import classNames from '../../utilities/classNames'
 import { namespaceComponent } from '../../utilities/component'
 import css from './styles/Embed.css.js'
@@ -15,15 +16,45 @@ type Props = {
 
 type Context = MessageThemeContext
 
-class Embed extends PureComponent<Props, Context> {
+class Embed extends Component<Props, Context> {
   static displayName = 'Message.Embed'
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      isLoading: true,
+    }
+    this.toggleLoading = this.toggleLoading.bind(this)
+  }
+
+  componentDidMount() {
+    this.loadContent()
+  }
+
+  loadContent() {
+    const iframes = this.htmlNode.getElementsByTagName('iframe')
+    if (!iframes.length) {
+      return this.toggleLoading()
+    }
+    const iframe = iframes[0]
+    iframe.onload = this.toggleLoading
+  }
+
+  toggleLoading() {
+    this.setState({
+      isLoading: !this.state.isLoading,
+    })
+  }
 
   render() {
     const { className, html, ...rest } = this.props
+    const { isLoading } = this.state
     const { theme } = this.context
 
     const componentClassName = classNames(
       'c-MessageEmbed',
+      isLoading && 'is-loading',
       /* istanbul ignore next */
       // Tested, but Istanbul isn't picking it up.
       theme && `is-theme-${theme}`,
@@ -39,7 +70,9 @@ class Embed extends PureComponent<Props, Context> {
         <div
           dangerouslySetInnerHTML={{ __html: html }}
           className="c-MessageEmbed__html"
+          ref={node => (this.htmlNode = node)}
         />
+        {isLoading && <LoadingDots className="c-MessageEmbed__loading" />}
       </Chat>
     )
   }

--- a/src/components/Message/Embed.js
+++ b/src/components/Message/Embed.js
@@ -1,5 +1,5 @@
 // @flow
-import type { MessageThemeContext } from './types'
+import type { MessageChat, MessageThemeContext } from './types'
 import React, { Component } from 'react'
 import styled from '../styled'
 import Chat from './Chat'
@@ -9,31 +9,36 @@ import { namespaceComponent } from '../../utilities/component'
 import css from './styles/Embed.css.js'
 import { COMPONENT_KEY } from './utils'
 
-type Props = {
+type Props = MessageChat & {
   className?: string,
-  html: string,
+  html?: string,
+}
+
+type State = {
+  isLoading: boolean,
 }
 
 type Context = MessageThemeContext
 
-class Embed extends Component<Props, Context> {
+class Embed extends Component<Props, State, Context> {
   static displayName = 'Message.Embed'
 
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      isLoading: true,
-    }
-    this.toggleLoading = this.toggleLoading.bind(this)
+  state = {
+    isLoading: true,
   }
+
+  node: HTMLDivElement
 
   componentDidMount() {
     this.loadContent()
   }
 
-  loadContent() {
-    const iframes = this.htmlNode.getElementsByTagName('iframe')
+  loadContent = () => {
+    /* istanbul ignore next */
+    if (!this.node) return
+
+    const iframes = this.node.getElementsByTagName('iframe')
+
     if (!iframes.length) {
       return this.toggleLoading()
     }
@@ -41,11 +46,13 @@ class Embed extends Component<Props, Context> {
     iframe.onload = this.toggleLoading
   }
 
-  toggleLoading() {
+  toggleLoading = () => {
     this.setState({
       isLoading: !this.state.isLoading,
     })
   }
+
+  setNodeRef = (node: HTMLDivElement) => (this.node = node)
 
   render() {
     const { className, html, ...rest } = this.props
@@ -70,7 +77,7 @@ class Embed extends Component<Props, Context> {
         <div
           dangerouslySetInnerHTML={{ __html: html }}
           className="c-MessageEmbed__html"
-          ref={node => (this.htmlNode = node)}
+          ref={this.setNodeRef}
         />
         {isLoading && <LoadingDots className="c-MessageEmbed__loading" />}
       </Chat>

--- a/src/components/Message/__tests__/Embed.test.js
+++ b/src/components/Message/__tests__/Embed.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import Embed from '../Embed'
+import LoadingDots from '../../LoadingDots'
 import Message from '../Message'
 
 const cx = 'c-MessageEmbed'
@@ -18,6 +19,18 @@ describe('ClassNames', () => {
     const wrapper = mount(<Embed className="mugatu" />)
     const o = wrapper.find(`.${cx}`)
     expect(o.hasClass('mugatu')).toBeTruthy()
+  })
+
+  test('Does not have an is-loading className when there is no iframe inside the HTML', () => {
+    const wrapper = mount(<Embed html="<div></div>" />)
+    const o = wrapper.find(`.${cx}`)
+    expect(o.hasClass('is-loading')).toBeFalsy()
+  })
+
+  test('Has an is-loading className when there is an iframe inside the HTML', () => {
+    const wrapper = mount(<Embed html={html} />)
+    const o = wrapper.find(`.${cx}`)
+    expect(o.hasClass('is-loading')).toBeTruthy()
   })
 })
 
@@ -44,6 +57,16 @@ describe('Content', () => {
     const wrapper = mount(<Embed html={html} />)
     const o = wrapper.find(`.${cx}`)
     expect(o.html()).toContain(html)
+  })
+
+  test('Renders the loading dots when it is loading', () => {
+    const wrapper = mount(<Embed html={html} />)
+    expect(wrapper.find(LoadingDots)).toHaveLength(1)
+  })
+
+  test('Does not render the loading dots when not loading', () => {
+    const wrapper = mount(<Embed />)
+    expect(wrapper.find(LoadingDots)).toHaveLength(0)
   })
 })
 

--- a/src/components/Message/styles/Embed.css.js
+++ b/src/components/Message/styles/Embed.css.js
@@ -22,6 +22,15 @@ export const css = `
     width: ${config.embedWidth};
   }
 
+  iframe {
+    opacity: 1;
+    transition: opacity .5s ease-in;
+  }
+
+  &.is-loading iframe {
+    opacity: 0;
+  }
+
   ${bem.element('bubble')}.c-MessageBubble {
     background-color: white;
     border: none;
@@ -41,6 +50,13 @@ export const css = `
       background-color: ${getColor('yellow.300')};
       color: ${getColor('yellow.800')};
     }
+  }
+
+  ${bem.element('loading')}.c-LoadingDots {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
   }
 `
 


### PR DESCRIPTION
## Add loading indicator to Message.Embed

This update adds a loading indicator to the Message.Embed component. It works by checking if there is an iframe inside the HTML embed code and if there is, it attaches an onload event that is used to clear the loading indicator. If there is no iframe, the loading indicator is immediately cleared.

![Demo](https://d26i3uk99q2djv.cloudfront.net/items/2m3Z3M1H2S2w2l0b2d1r/Screen%20Recording%202018-10-09%20at%2007.47%20PM.gif?X-CloudApp-Visitor-Id=2338876&v=c8dfe15f)