### PR TITLE
Accordion Updates

### DIFF
--- a/src/components/Accordion/Title.js
+++ b/src/components/Accordion/Title.js
@@ -95,6 +95,7 @@ class Title extends Component<TitleProps> {
     const iconProps = {
       faint: !isOpen,
       name: isOpen ? 'caret-up' : 'caret-down',
+      size: 18,
     }
 
     return (

--- a/src/components/Accordion/styles/Accordion.css.js
+++ b/src/components/Accordion/styles/Accordion.css.js
@@ -32,18 +32,23 @@ export const AccordionUI = styled('div')`
 export const BodyUI = styled('div')`
   ${baseStyles};
 
-  padding: 20px 20px;
+  display: block;
+  padding: 24px 20px;
+
+  .is-closed & {
+    display: none;
+  }
 
   &.is-md {
-    padding: 16px 20px;
+    padding: 20px 20px;
   }
 
   &.is-sm {
-    padding: 12px 20px;
+    padding: 16px 20px;
   }
 
   &.is-xs {
-    padding: 8px 20px;
+    padding: 14px 20px;
   }
 
   &.is-seamless {
@@ -79,7 +84,7 @@ export const SectionUI = styled('div')`
 export const TitleUI = styled('div')`
   ${baseStyles};
   cursor: pointer;
-  padding: 20px 20px;
+  padding: 18px 20px;
 
   &:hover,
   &:focus,
@@ -91,20 +96,20 @@ export const TitleUI = styled('div')`
     border-bottom: 1px solid rgba(193, 203, 212, 0.7);
 
     &.is-seamless {
-      border-bottom: none;
+      border-bottom-color: transparent;
     }
   }
 
   &.is-md {
-    padding: 16px 20px;
+    padding: 14px 20px;
   }
 
   &.is-sm {
-    padding: 12px 20px;
+    padding: 8px 20px;
   }
 
   &.is-xs {
-    padding: 8px 20px;
+    padding: 6px 20px;
   }
 
   &.is-seamless {

--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -182,11 +182,13 @@ class Collapsible extends Component<Props, State> {
     const { animationState, height } = this.state
 
     const animating = animationState !== 'idle'
+    const closed = animationState === 'closed'
 
     const componentClassName = classNames(
       'c-Collapsible',
       isOpen && 'is-open',
       animating && 'is-animating',
+      closed && 'is-closed',
       className
     )
 

--- a/stories/Accordion/index.js
+++ b/stories/Accordion/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Accordion, Page, Text } from '../../src/'
+import { Accordion, Button, Input, Page, Text } from '../../src/'
 
 const stories = storiesOf('Accordion', module)
 
@@ -17,9 +17,16 @@ amet mollit Lorem. Mollit laborum cillum id occaecat et laboris labore pariatur
 do est.
 `
 
+const form = (
+  <form>
+    <Input label="Enter some text" style={{ marginBottom: '7px' }} />
+    <Button primary>Save</Button>
+  </form>
+)
+
 const data = [
   { title: 'Section 1', body },
-  { title: 'Section 2', body },
+  { title: 'Section 2', body: form },
   { title: 'Section 3', body },
   { title: 'Section 4', body },
 ]
@@ -41,6 +48,24 @@ const onClose = id => console.log('Close', id)
 
 stories.add('default', () => (
   <Accordion onOpen={onOpen} onClose={onClose}>
+    {createSections()}
+  </Accordion>
+))
+
+stories.add('extra small', () => (
+  <Accordion onOpen={onOpen} onClose={onClose} size="xs">
+    {createSections()}
+  </Accordion>
+))
+
+stories.add('small', () => (
+  <Accordion onOpen={onOpen} onClose={onClose} size="sm">
+    {createSections()}
+  </Accordion>
+))
+
+stories.add('large', () => (
+  <Accordion onOpen={onOpen} onClose={onClose} size="lg">
     {createSections()}
   </Accordion>
 ))


### PR DESCRIPTION
This PR makes some updates to the accordion component. It includes adjustments to the padding of the Accordion.Title and Accordion.Body components to tighten it up a little bit.

It also includes a fix for an issue where you would open an Accordion.Section containing a form and then tab into next Accordion.Section and open it resulting in the previous Accordion.Section being closed and then tabbing back to the previous Accordion.Section. On tabbing back, it would tab into the hidden form forcing the user to hit shift+tab several times to return the previous Accordion.Section.

This PR includes a change to the Collapsible component to add a `is-closed` class. This class is used by the Accordion to hide the contents of the Accordion.Body when the Accordion is closed. This prevents the above mentioned behaviour from occurring. Now the user can always return the previous Accordion.Section by pressing shift+tab once. This is demonstrated in the video below which shows keyboard navigation through an Accordion with an embedded form. 

![Demo](https://ddwva799xzrph.cloudfront.net/items/3B0U1f2G2X45062C2N0W/Screen%20Recording%202018-10-10%20at%2010.25%20PM.gif?X-CloudApp-Visitor-Id=2338876&v=34448e90)