### PR TITLE
Update Fancy to v2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -190,52 +190,57 @@
       }
     },
     "@emotion/hash": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.5.tgz",
-      "integrity": "sha512-JlZbn5+adseTdDPTUkx/O1/UZbhaGR5fCLLWQDCIJ4eP9fJcVdP/qjlTveEX6mkNoJHWFbZ47wArWQQ0Qk6nMA=="
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
+      "integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ=="
     },
     "@emotion/is-prop-valid": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.5.tgz",
-      "integrity": "sha512-pfjQHT3FCZkAPxqY+sI6MmMTPMCKGIV3DcC1qhf68XkE9pGtKqb5WNN2vfmLgTMGnNVXnaFyx/VjdDYmGFcRaw==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz",
+      "integrity": "sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==",
       "requires": {
-        "@emotion/memoize": "^0.6.5"
+        "@emotion/memoize": "^0.6.6"
       }
     },
     "@emotion/memoize": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.5.tgz",
-      "integrity": "sha512-n1USr7yICA4LFIv7z6kKsXM8rZJxd1btKCBmDewlit+3OJ2j4bDfgXTAxTHYbPkHS/eztHmFWfsbxW2Pu5mDqA=="
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
+      "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
     },
     "@emotion/stylis": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.6.12.tgz",
-      "integrity": "sha512-yS+t7l5FeYeiIyADyqjFBJvdotpphHb2S3mP4qak5BpV7ODvxuyAVF24IchEslW+A1MWHAhn5SiOW6GZIumiEQ=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
+      "integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ=="
     },
     "@emotion/unitless": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.6.tgz",
-      "integrity": "sha512-zbd1vXRpGWCgDLsXqITReL+eqYJ95PYyWrVCCuMLBDb2LGA/HdxrZHJri6Fe+tKHihBOiCK1kbu+3Ij8aNEjzA=="
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
+      "integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg=="
     },
     "@helpscout/fancy": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.0.5.tgz",
-      "integrity": "sha512-mIwpHwczMFCyUpCxhHApAVAgs27Q1O7Bay1I1F6MIlfChwa2vId6WOQHO4LEDUX3ZNHd7SnXRVYpfatMApgaYA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.1.0.tgz",
+      "integrity": "sha512-Awzf8jfZOgUZtBBS9xGGp5t1/E10GBhxUSJEGgUdoyIG7gl9KzzwifT3JcRdLD21pTkhUX/GCinBPf48ET/O/Q==",
       "requires": {
-        "@emotion/hash": "^0.6.2",
-        "@emotion/memoize": "^0.6.1",
-        "@emotion/stylis": "^0.6.10",
-        "@emotion/unitless": "^0.6.2",
-        "@helpscout/react-utils": "^1.0.0",
-        "create-emotion": "9.2.4",
-        "create-emotion-styled": "9.2.3",
-        "csstype": "^2.5.2",
-        "emotion-theming": "9.2.4",
+        "@emotion/hash": "^0.6.6",
+        "@emotion/memoize": "^0.6.6",
+        "@emotion/stylis": "^0.7.1",
+        "@emotion/unitless": "^0.6.7",
+        "@helpscout/react-utils": "^1.0.1",
+        "create-emotion": "9.2.12",
+        "create-emotion-styled": "9.2.8",
+        "csstype": "^2.5.7",
+        "emotion-theming": "9.2.9",
         "prop-types": "15.6.2",
-        "stylis": "^3.5.0",
+        "stylis": "^3.5.3",
         "stylis-rule-sheet": "^0.0.10"
       },
       "dependencies": {
+        "csstype": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.7.tgz",
+          "integrity": "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw=="
+        },
         "prop-types": {
           "version": "15.6.2",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
@@ -7147,13 +7152,13 @@
       }
     },
     "create-emotion": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.4.tgz",
-      "integrity": "sha1-CkN59r8HCMVP4mv81ra9NZLozyM=",
+      "version": "9.2.12",
+      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.12.tgz",
+      "integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
       "requires": {
         "@emotion/hash": "^0.6.2",
         "@emotion/memoize": "^0.6.1",
-        "@emotion/stylis": "^0.6.10",
+        "@emotion/stylis": "^0.7.0",
         "@emotion/unitless": "^0.6.2",
         "csstype": "^2.5.2",
         "stylis": "^3.5.0",
@@ -7161,9 +7166,9 @@
       }
     },
     "create-emotion-styled": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/create-emotion-styled/-/create-emotion-styled-9.2.3.tgz",
-      "integrity": "sha1-F/sTs65MFl6m5aETVquLnKHa2cU=",
+      "version": "9.2.8",
+      "resolved": "https://registry.npmjs.org/create-emotion-styled/-/create-emotion-styled-9.2.8.tgz",
+      "integrity": "sha512-2LrNM5MREWzI5hZK+LyiBHglwE18WE3AEbBQgpHQ1+zmyLSm/dJsUZBeFAwuIMb+TjNZP0KsMZlV776ufOtFdg==",
       "requires": {
         "@emotion/is-prop-valid": "^0.6.1"
       }
@@ -8373,9 +8378,9 @@
       "dev": true
     },
     "emotion-theming": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-9.2.4.tgz",
-      "integrity": "sha1-l1g3hh7yAocEoBSmDGTr+r1DJ1U=",
+      "version": "9.2.9",
+      "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-9.2.9.tgz",
+      "integrity": "sha512-Ncyr1WocmDDrTbuYAzklIUC5iKiGtHy3e5ymoFXcka6SuvZl/EDMawegk4wVp72Agrcm1xemab3QOHfnOkpoMA==",
       "requires": {
         "hoist-non-react-statics": "^2.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-dom": "^15"
   },
   "dependencies": {
-    "@helpscout/fancy": "^2.0.5",
+    "@helpscout/fancy": "^2.1.0",
     "@helpscout/react-utils": "^1.0.1",
     "closest": "0.0.1",
     "highlight.js": "^9.12.0",


### PR DESCRIPTION
## Update Fancy to v2.1.0

This update bumps Fancy to the latest [2.1.0](https://github.com/helpscout/fancy/releases/tag/v2.1.0), which fixes styled-component extensions within ScopeProvider scoped context.

Some very crude tests.

Before:

![screen shot 2018-10-12 at 9 36 20 pm](https://user-images.githubusercontent.com/2322354/46900146-b2b79b80-ce6b-11e8-83e6-fbb01182af8c.jpg)

After:

![screen shot 2018-10-12 at 9 33 59 pm](https://user-images.githubusercontent.com/2322354/46900149-b814e600-ce6b-11e8-92cc-038401ea1335.jpg)

Notice how in the After pic, both lines only have 2 classes, whereas the Before pic, it was 2 and 3.