### PR TITLE
PortalWrapper: Use vendored matchPath from react-router

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
     '!src/components/Popper/**/*.{js,jsx}',
     '!src/tests/helpers/**/*.{js,jsx}',
     '!src/utilities/browser.{js,jsx}',
+    '!src/utilities/react-router/**/*.{js,jsx}',
     '!src/utilities/smoothScroll.{js,jsx}',
     '!src/utilities/index.{js,jsx}',
     '!src/utilities/log.{js,jsx}',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13279,6 +13279,23 @@
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
       }
     },
     "no-case": {
@@ -16682,21 +16699,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        }
-      }
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
     },
     "path-type": {
       "version": "1.1.0",
@@ -18833,6 +18838,21 @@
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.0.tgz",
           "integrity": "sha1-7eFjGML/H5/joCU5a6Bv1MRGCLs=",
           "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
         },
         "warning": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "closest": "0.0.1",
     "highlight.js": "^9.12.0",
     "lodash.get": "^4.4.2",
+    "path-to-regexp": "^2.4.0",
     "pluralize": "^7.0.0",
     "popper.js": "1.14.3",
     "prop-types": "^15.6.1",

--- a/src/components/PortalWrapper/PortalWrapper.js
+++ b/src/components/PortalWrapper/PortalWrapper.js
@@ -1,7 +1,6 @@
 import React, { PureComponent as Component } from 'react'
 import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
-import { matchPath } from 'react-router'
 import getComponentDefaultProp from '@helpscout/react-utils/dist/getComponentDefaultProp'
 import hoistNonReactStatics from '@helpscout/react-utils/dist/hoistNonReactStatics'
 import Animate from '../Animate'
@@ -15,6 +14,7 @@ import {
 import { setupManager } from '../../utilities/globalManager'
 import classNames from '../../utilities/classNames'
 import { requestAnimationFrame } from '../../utilities/other'
+import matchPath from '../../utilities/react-router/matchPath'
 import Content from './Content'
 
 const defaultOptions = {

--- a/src/utilities/react-router/matchPath.js
+++ b/src/utilities/react-router/matchPath.js
@@ -1,0 +1,57 @@
+// Source
+// https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/matchPath.js
+
+import pathToRegexp from 'path-to-regexp'
+
+const cache = {}
+const cacheLimit = 10000
+let cacheCount = 0
+
+function compilePath(path, options) {
+  const cacheKey = `${options.end}${options.strict}${options.sensitive}`
+  const pathCache = cache[cacheKey] || (cache[cacheKey] = {})
+
+  if (pathCache[path]) return pathCache[path]
+
+  const keys = []
+  const regexp = pathToRegexp(path, keys, options)
+  const result = { regexp, keys }
+
+  if (cacheCount < cacheLimit) {
+    pathCache[path] = result
+    cacheCount++
+  }
+
+  return result
+}
+
+/**
+ * Public API for matching a URL pathname to a path.
+ */
+function matchPath(pathname, options = {}) {
+  if (typeof options === 'string') options = { path: options }
+
+  const { path, exact = false, strict = false, sensitive = false } = options
+
+  const { regexp, keys } = compilePath(path, { end: exact, strict, sensitive })
+  const match = regexp.exec(pathname)
+
+  if (!match) return null
+
+  const [url, ...values] = match
+  const isExact = pathname === url
+
+  if (exact && !isExact) return null
+
+  return {
+    path, // the path used to match
+    url: path === '/' && url === '' ? '/' : url, // the matched portion of the URL
+    isExact, // whether or not we matched exactly
+    params: keys.reduce((memo, key, index) => {
+      memo[key.name] = values[index]
+      return memo
+    }, {}),
+  }
+}
+
+export default matchPath


### PR DESCRIPTION
## PortalWrapper: Use vendored matchPath from react-router
This update vendorizes the tiny matchPath utility from `react-router`, used
by `PortalWrapper`. This allows for Blue to ship without `react-router`
as a dependency.