### PR TITLE
Input: ScrollToBottom to account for padding

### DIFF
--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -15,6 +15,7 @@ import Icon from '../Icon'
 import Label from '../Label'
 import { scrollLockY } from '../ScrollLock'
 import Tooltip from '../Tooltip'
+import Keys from '../../constants/Keys'
 import { STATES } from '../../constants/index'
 import { classNames } from '../../utilities/classNames'
 import { namespaceComponent } from '../../utilities/component'
@@ -66,6 +67,7 @@ type Props = {
   onBlur: (event: AnyInputEvent) => void,
   onChange: (value: InputValue) => void,
   onFocus: (event: AnyInputEvent) => void,
+  onKeyDown: (event: AnyInputEvent) => void,
   onResize: (height: number) => void,
   onWheel: (event: AnyInputEvent) => void,
   onStartTyping: (now?: number) => void,
@@ -118,6 +120,7 @@ export class Input extends Component<Props, State> {
     onBlur: noop,
     onChange: noop,
     onFocus: noop,
+    onKeyDown: noop,
     onResize: noop,
     onStartTyping: noop,
     onStopTyping: noop,
@@ -143,6 +146,7 @@ export class Input extends Component<Props, State> {
   static Static = Static
   static Suffix = Suffix
 
+  computedStyles: Object
   inputNode: InputNode
 
   constructor(props: Props) {
@@ -214,26 +218,30 @@ export class Input extends Component<Props, State> {
     }, forceAutoFocusTimeout)
   }
 
-  scrollToBottom() {
-    /* istanbul ignore next */
-    if (!this.props.multiline || !this.inputNode || !isTextArea(this.inputNode))
-      return
-    /* istanbul ignore next */
-    /**
-     * Skipping this test, due to lack of JSDOM DOM property support.
-     */
-    /* istanbul ignore next */
-    const currentLine = getTextAreaLineCurrent(this.inputNode)
-    /* istanbul ignore next */
-    const totalLines = getTextAreaLineTotal(this.inputNode)
+  // JSDOM does not provide the necessary values to test this method.
+  // Mocking it would also be extremely difficult and brittle.
 
-    /* istanbul ignore next */
-    if (
-      currentLine === totalLines &&
-      this.inputNode.hasOwnProperty('scrollTo')
-    ) {
-      // $FlowFixMe
-      this.inputNode.scrollTo(0, this.inputNode.scrollHeight)
+  /* istanbul ignore next */
+  scrollToBottom(event) {
+    if (!this.props.multiline) return
+    if (!this.inputNode || !isTextArea(this.inputNode)) return
+    if (event.keyCode !== Keys.ENTER) return
+
+    const { paddingBottom } = this.computedStyles
+    const { scrollTop, clientHeight } = this.inputNode
+
+    const currentLine = getTextAreaLineCurrent(this.inputNode)
+    const totalLines = getTextAreaLineTotal(this.inputNode)
+    const isLastLine = currentLine === totalLines
+
+    const scrollBottom = scrollTop + clientHeight + paddingBottom
+
+    if (isLastLine) {
+      requestAnimationFrame(() => {
+        if (this.inputNode && this.inputNode.scrollTo) {
+          this.inputNode.scrollTo(0, scrollBottom)
+        }
+      })
     }
   }
 
@@ -303,7 +311,6 @@ export class Input extends Component<Props, State> {
     const value = event.currentTarget.value
     this.setState({ value })
     this.props.onChange(value)
-    this.scrollToBottom()
   }
 
   handleOnInputBlur = (event: InputEvent) => {
@@ -335,9 +342,15 @@ export class Input extends Component<Props, State> {
     onWheel(event)
   }
 
+  handleOnKeyDown = (event: Event) => {
+    this.props.onKeyDown(event)
+    this.scrollToBottom(event)
+  }
+
   handleExpandingResize = (height: number) => {
     this.props.onResize(height)
     this.setState({ height })
+    this.setComputedStylesFromHeight(height)
   }
 
   moveCursorToEnd = () => {
@@ -360,6 +373,22 @@ export class Input extends Component<Props, State> {
     this.inputNode = node
     this.props.inputRef(node)
     this.props.innerRef(node)
+  }
+
+  // Assumption: The padding-bottom does not change after the component is
+  // rendered.
+  setComputedStylesFromHeight = (height: number) => {
+    if (!height) return
+    if (this.computedStyles) return
+    if (!this.inputNode) return
+
+    const computedStyles = window.getComputedStyle(this.inputNode)
+
+    const { paddingBottom } = computedStyles
+
+    this.computedStyles = {
+      paddingBottom: parseInt(paddingBottom, 10),
+    }
   }
 
   getHelpTextMarkup = () => {
@@ -474,6 +503,11 @@ export class Input extends Component<Props, State> {
     )
   }
 
+  getMultilineValue = () => {
+    const { multiline } = this.props
+    return typeof multiline === 'number' ? multiline : 1
+  }
+
   getResizerMarkup = () => {
     const { multiline, offsetAmount, seamless } = this.props
 
@@ -484,7 +518,7 @@ export class Input extends Component<Props, State> {
         <Resizer
           contents={value}
           currentHeight={height}
-          minimumLines={typeof multiline === 'number' ? multiline : 1}
+          minimumLines={this.getMultilineValue()}
           offsetAmount={offsetAmount}
           onResize={this.handleExpandingResize}
           seamless={seamless}
@@ -522,6 +556,7 @@ export class Input extends Component<Props, State> {
       onStartTyping,
       onStopTyping,
       onWheel,
+      onScroll,
       placeholder,
       prefix,
       readOnly,
@@ -567,6 +602,7 @@ export class Input extends Component<Props, State> {
       className: fieldClassName,
       id,
       onChange: this.handleOnChange,
+      onKeyDown: this.handleOnKeyDown,
       // $FlowFixMe
       ref: this.setInputNodeRef,
       disabled,

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -137,6 +137,25 @@ describe('Events', () => {
     expect(spy).toHaveBeenCalled()
   })
 
+  test('onKeydown callback fires when input keyDown occurs', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Input multiline={true} onKeyDown={spy} />)
+    const input = wrapper.find('textarea')
+
+    input.simulate('keydown')
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('onKeydown callback fires scrollToBottom', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Input multiline={true} onKeyDown={spy} />)
+    const input = wrapper.find('textarea')
+    wrapper.instance().scrollToBottom = spy
+
+    input.simulate('keydown')
+    expect(spy).toHaveBeenCalled()
+  })
+
   test('onResize callback is called when Input resizes', () => {
     const spy = jest.fn()
     const wrapper = mount(<Input multiline={true} onResize={spy} />)
@@ -788,5 +807,49 @@ describe('innerRef', () => {
     const o = wrapper.find('input').getNode()
 
     expect(spy).toHaveBeenCalledWith(o)
+  })
+})
+
+describe('computedStyles', () => {
+  test('Does not set computed styles if height is falsey', () => {
+    const wrapper = mount(<Input multiline />)
+    const o = wrapper.instance()
+
+    o.setComputedStylesFromHeight(0)
+
+    expect(o.computedStyles).toBeFalsy()
+  })
+
+  test('Does not set computed styles if inputNode is falsey', () => {
+    const wrapper = mount(<Input multiline />)
+    const o = wrapper.instance()
+
+    o.inputNode = undefined
+    o.setComputedStylesFromHeight(50)
+
+    expect(o.computedStyles).toBeFalsy()
+  })
+
+  test('Sets computed styles from input note', () => {
+    const wrapper = mount(<Input multiline />)
+    const o = wrapper.instance()
+    o.inputNode.style.paddingBottom = '100px'
+
+    o.setComputedStylesFromHeight(50)
+
+    expect(o.computedStyles.paddingBottom).toBe(100)
+  })
+
+  test('Does not set computedStyles again after caching', () => {
+    const wrapper = mount(<Input multiline />)
+    const o = wrapper.instance()
+
+    o.inputNode.style.paddingBottom = '100px'
+    o.setComputedStylesFromHeight(150)
+
+    o.inputNode.style.paddingBottom = '500px'
+    o.setComputedStylesFromHeight(550)
+
+    expect(o.computedStyles.paddingBottom).toBe(100)
   })
 })

--- a/stories/Input.js
+++ b/stories/Input.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Button, Icon, Input } from '../src/index.js'
+import { Button, Icon, Input, styled } from '../src/index.js'
 
 const stories = storiesOf('Input', module)
 
@@ -76,12 +76,24 @@ stories.add('multiline + resizable', () => (
 stories.add('multiline + maxHeight', () => (
   <Input
     autoFocus
-    multiline={1}
+    multiline={3}
     resizable
-    maxHeight={150}
+    maxHeight={160}
     placeholder="This is a resizable textarea with maxHeight!"
     offsetAmount={8}
   />
+))
+
+stories.add('multiline + padded bottom', () => (
+  <PaddedTextArea>
+    <Input
+      autoFocus
+      multiline={3}
+      resizable
+      maxHeight={160}
+      placeholder="This one has a 30px bottom padding. Pressing enter for the last line preserves this spacing!"
+    />
+  </PaddedTextArea>
 ))
 
 stories.add('label', () => <Input label="Labelled" autoFocus />)
@@ -211,3 +223,9 @@ stories.add('onStartTyping', () => {
     </div>
   )
 })
+
+const PaddedTextArea = styled('div')`
+  textarea {
+    padding-bottom: 30px !important;
+  }
+`


### PR DESCRIPTION
## Input: ScrollToBottom to account for padding

![screen recording 2018-10-26 at 04 52 pm](https://user-images.githubusercontent.com/2322354/47593024-d0910000-d943-11e8-9a91-dd425c55db8b.gif)

GIF demo's the bottom 30px padding is preserved on Enter press.

This update improves the Input scrollToBottom handling in `multiline` mode.
The scrolling mechanism now factors `padding-bottom` when pressing `enter`
for new line.

By default, the browser does **not** do this. Padding values are not
taken into consideration with `textarea` or `contentEditable` elements
autoscroll when paging (up/down/enter).

Note: This update doesn't add support for arrow/mid-content overflow paging.
I tried. It was wayy too difficult.
I had something kinda working, but it wasn't reliable.