### PR TITLE
Button V2: Allow content events to pass through

### DIFF
--- a/src/components/Button/ButtonV2.js
+++ b/src/components/Button/ButtonV2.js
@@ -13,6 +13,7 @@ import { COMPONENT_KEY } from './utils'
 import { COMPONENT_KEY as ICON_KEY } from '../Icon/utils'
 
 type Props = {
+  allowContentEventPropogation: boolean,
   buttonRef: (ref: any) => void,
   canRenderFocus: boolean,
   children?: any,
@@ -41,6 +42,7 @@ type State = {
 
 class Button extends Component<Props, State> {
   static defaultProps = {
+    allowContentEventPropogation: true,
     buttonRef: noop,
     canRenderFocus: true,
     disable: false,
@@ -140,6 +142,7 @@ class Button extends Component<Props, State> {
 
   render() {
     const {
+      allowContentEventPropogation,
       children,
       className,
       kind,
@@ -191,7 +194,10 @@ class Button extends Component<Props, State> {
         onFocus={this.handleOnFocus}
         type={type}
       >
-        <ButtonContentUI className="c-ButtonV2__content">
+        <ButtonContentUI
+          className="c-ButtonV2__content"
+          allowContentEventPropogation={allowContentEventPropogation}
+        >
           {childrenMarkup}
         </ButtonContentUI>
         {focusMarkup}

--- a/src/components/Button/__tests__/ButtonV2.test.js
+++ b/src/components/Button/__tests__/ButtonV2.test.js
@@ -281,3 +281,19 @@ describe('Icon', () => {
     expect(wrapper.text()).toContain('News')
   })
 })
+
+describe('Content event propagation', () => {
+  test('Allows content event propagation by default', () => {
+    const spy = jest.fn()
+    const wrapper = mount(
+      <Button onClick={spy}>
+        <Icon />
+      </Button>
+    )
+    const el = wrapper.find('Icon').last()
+
+    el.simulate('click')
+
+    expect(spy).toHaveBeenCalled()
+  })
+})

--- a/src/components/Button/docs/ButtonV2.md
+++ b/src/components/Button/docs/ButtonV2.md
@@ -24,24 +24,25 @@ Alternatively, [PropProvider](../../PropProvider) can be used to set this prop a
 
 ## Props
 
-| Prop      | Type       | Description                                                                     |
-| --------- | ---------- | ------------------------------------------------------------------------------- |
-| className | `string`   | Custom class names to be added to the component.                                |
-| disabled  | `bool`     | Disable the button so it can't be clicked.                                      |
-| fetch     | `function` | function which returns a promise, will be invoked before routing the `to` route |
-| innerRef  | `function` | Retrieves the `button` DOM node.                                                |
-| isFocused | `bool`     | Renders the focused style.                                                      |
-| isSuffix  | `bool`     | Renders suffix styles.                                                          |
-| onBlur    | `function` | `onBlur` event handler.                                                         |
-| onClick   | `function` | `onClick` event handler.                                                        |
-| onFocus   | `function` | `onFocus` event handler.                                                        |
-| kind      | `string`   | Applies the specified style to the button.                                      |
-| size      | `string`   | Sets the size of the button. Can be one of `"sm"`, `"md"` or `"lg"`.            |
-| state     | `string`   | Applies state styles to the button.                                             |
-| submit    | `bool`     | Sets the `type` of the button to `"submit"`.                                    |
-| version   | `number`   | Applies the version `2` variant of the button.                                  |
-| theme     | `string`   | Applies a theme based style to the button.                                      |
-| to        | `string`   | React Router path to navigate on click.                                         |
+| Prop                         | Type       | Description                                                                     |
+| ---------------------------- | ---------- | ------------------------------------------------------------------------------- |
+| allowContentEventPropogation | `bool`     | Enables child events to pass through to Button. Default `true`.                 |
+| className                    | `string`   | Custom class names to be added to the component.                                |
+| disabled                     | `bool`     | Disable the button so it can't be clicked.                                      |
+| fetch                        | `function` | function which returns a promise, will be invoked before routing the `to` route |
+| innerRef                     | `function` | Retrieves the `button` DOM node.                                                |
+| isFocused                    | `bool`     | Renders the focused style.                                                      |
+| isSuffix                     | `bool`     | Renders suffix styles.                                                          |
+| onBlur                       | `function` | `onBlur` event handler.                                                         |
+| onClick                      | `function` | `onClick` event handler.                                                        |
+| onFocus                      | `function` | `onFocus` event handler.                                                        |
+| kind                         | `string`   | Applies the specified style to the button.                                      |
+| size                         | `string`   | Sets the size of the button. Can be one of `"sm"`, `"md"` or `"lg"`.            |
+| state                        | `string`   | Applies state styles to the button.                                             |
+| submit                       | `bool`     | Sets the `type` of the button to `"submit"`.                                    |
+| version                      | `number`   | Applies the version `2` variant of the button.                                  |
+| theme                        | `string`   | Applies a theme based style to the button.                                      |
+| to                           | `string`   | React Router path to navigate on click.                                         |
 
 ## Kinds
 

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -20,4 +20,4 @@ class WrappedButton extends Component<Props> {
 
 namespaceComponent(COMPONENT_KEY)(WrappedButton)
 
-export default propConnect('Button')(WrappedButton)
+export default propConnect(COMPONENT_KEY)(WrappedButton)

--- a/src/components/Button/styles/Button.css.js
+++ b/src/components/Button/styles/Button.css.js
@@ -364,6 +364,16 @@ export const ButtonContentUI = styled('span')`
   justify-content: inherit;
   text-decoration: inherit;
   width: 100%;
+
+  ${({ allowContentEventPropogation }) =>
+    allowContentEventPropogation &&
+    `
+    pointer-events: none;
+
+    * {
+      pointer-events: none;
+    }
+  `};
 `
 
 export const FocusUI = styled('span')`

--- a/stories/Button/ButtonV2.js
+++ b/stories/Button/ButtonV2.js
@@ -97,11 +97,11 @@ stories.add('icon', () => (
   <PropProvider value={{ Button: { version: 2 } }}>
     <ContainerUI>
       <Flexy>
-        <Button kind="secondary">
+        <Button kind="secondary" onClick={e => console.log(e)}>
           <Icon />
           Words
         </Button>
-        <Button kind="secondary">
+        <Button kind="secondary" onClick={e => console.log(e)}>
           Words
           <Icon />
         </Button>


### PR DESCRIPTION
## Button V2: Allow content events to pass through

![screen recording 2018-10-30 at 11 45 am](https://user-images.githubusercontent.com/2322354/47731168-f2d39800-dc39-11e8-9ea3-81007e8b3dbe.gif)


This update updates Button V2 to allow for events (like clicks) to child
components to pass through to the primary `Button` component.

This is enabled by a new prop, `allowContentEventPropogation`, which is
`true` by default.

Buttons should allow for their `onClick` (or whatever events) to happen, regardless of where you click within the button itself.