### PR TITLE
Input: Remove key press event for scrollToBottom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/blue",
-  "version": "1.9.2",
+  "version": "1.9.3-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/blue",
-  "version": "1.9.2",
+  "version": "1.9.3-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -222,10 +222,9 @@ export class Input extends Component<Props, State> {
   // Mocking it would also be extremely difficult and brittle.
 
   /* istanbul ignore next */
-  scrollToBottom(event) {
+  scrollToBottom() {
     if (!this.props.multiline) return
     if (!this.inputNode || !isTextArea(this.inputNode)) return
-    if (event.keyCode !== Keys.ENTER) return
 
     const { paddingBottom } = this.computedStyles
     const { scrollTop, clientHeight } = this.inputNode
@@ -344,7 +343,7 @@ export class Input extends Component<Props, State> {
 
   handleOnKeyDown = (event: Event) => {
     this.props.onKeyDown(event)
-    this.scrollToBottom(event)
+    this.scrollToBottom()
   }
 
   handleExpandingResize = (height: number) => {

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -140,6 +140,11 @@ describe('Events', () => {
   test('onKeydown callback fires when input keyDown occurs', () => {
     const spy = jest.fn()
     const wrapper = mount(<Input multiline={true} onKeyDown={spy} />)
+
+    wrapper.instance().computedStyles = {
+      paddingBottom: 10,
+    }
+
     const input = wrapper.find('textarea')
 
     input.simulate('keydown')


### PR DESCRIPTION
## Input: Remove key press event for scrollToBottom

![](https://media.giphy.com/media/YLHwkqayc1j7a/giphy.gif)

This update adjusts the scrollToBottom requirements for Input. The
ENTER keypress requirement was recently added for extra safety. However,
it appears that this broke an implementation where `scrollToBottom` was
manually called.