### PR TITLE
Fancy: Fix iFrame rendering for Edge/iFrame

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -325,9 +325,9 @@
       }
     },
     "@helpscout/fancy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.1.1.tgz",
-      "integrity": "sha512-4Qy+/ap13VgXGViUP+bU2m9desCt7nkrT6EWaaj6lwyzasaRop8C9EcXjAymC9JE3OZ/u/ArPTpQM6+z87W8Vg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.1.2.tgz",
+      "integrity": "sha512-yh0fwmFGzqPMv9Lzp7VEgkiNNI4b5IGG7SMPN8oJkjCTi5f4VsV1N/7DQp9T6IxMMJ4Dye9KMvHXBIHqI7N0nw==",
       "requires": {
         "@emotion/hash": "^0.6.6",
         "@emotion/memoize": "^0.6.6",
@@ -2499,7 +2499,7 @@
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
@@ -5887,7 +5887,7 @@
     },
     "cacache": {
       "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
       "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "dev": true,
       "requires": {
@@ -7102,7 +7102,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
@@ -13018,9 +13018,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
     "merge-descriptors": {
@@ -13383,7 +13383,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -13703,7 +13703,7 @@
         },
         "ansi-escapes": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
           "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
           "dev": true
         },
@@ -20977,7 +20977,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
           "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-dom": "^15"
   },
   "dependencies": {
-    "@helpscout/fancy": "^2.1.1",
+    "@helpscout/fancy": "^2.1.2",
     "@helpscout/react-utils": "^1.0.1",
     "@seedcss/seed-alert": "0.0.6",
     "@seedcss/seed-button": "0.0.6",

--- a/stories/Fancy/FrameProvider.js
+++ b/stories/Fancy/FrameProvider.js
@@ -19,22 +19,46 @@ const Card = styled('div')`
   `};
 `
 
-stories.add('default', () => (
-  <Frame>
-    <FrameProvider>
-      <ScopeProvider scope="html">
-        <ThemeProvider theme={{ color: '#eee' }}>
-          <div id="App">
-            <Card>
-              <Text>
-                <Tooltip title="Elf!" triggerOn="click">
-                  Buddy!
-                </Tooltip>
-              </Text>
-            </Card>
-          </div>
-        </ThemeProvider>
-      </ScopeProvider>
-    </FrameProvider>
-  </Frame>
-))
+stories.add('default', () => {
+  class Example extends React.Component {
+    state = {
+      showFrame: true,
+    }
+
+    toggle = () => {
+      this.setState({
+        showFrame: !this.state.showFrame,
+      })
+    }
+
+    render() {
+      return (
+        <div>
+          <button onClick={this.toggle}>Toggle Frame</button>
+          <br />
+          {this.state.showFrame && (
+            <Frame>
+              <FrameProvider>
+                <ScopeProvider scope="html">
+                  <ThemeProvider theme={{ color: '#eee' }}>
+                    <div id="App">
+                      <Card>
+                        <Text>
+                          <Tooltip title="Elf!" triggerOn="click">
+                            Buddy!
+                          </Tooltip>
+                        </Text>
+                      </Card>
+                    </div>
+                  </ThemeProvider>
+                </ScopeProvider>
+              </FrameProvider>
+            </Frame>
+          )}
+        </div>
+      )
+    }
+  }
+
+  return <Example />
+})


### PR DESCRIPTION
## Fancy: Fix iFrame rendering for Edge/iFrame

![screen recording 2018-11-07 at 09 46 am](https://user-images.githubusercontent.com/2322354/48138433-51b89300-e272-11e8-8b1e-6da39d298303.gif)

(GIF: Shows the correct CSS rendering within an unmounting/mounting iFrame within IE11)

This update bumps Fancy to the latest version which fixes an iFrame
rendering issue for Edge/IE. This occurs when the iFrame is unmounted/destroyed.

Note: It still throws an error in IE11, however, the styles work 👍 	. No errors in Edge.

Update in [Fancy 2.1.2](https://github.com/helpscout/fancy/releases/tag/v2.1.2)