### PR TITLE
Fix modal body to adapt height based on content, on IE11

### DIFF
--- a/src/components/Modal/styles/Body.css.js
+++ b/src/components/Modal/styles/Body.css.js
@@ -7,7 +7,7 @@ const bem = BEM('.c-ModalBody')
 
 export const BodyUI = styled('div')`
   ${baseStyles} display: flex;
-  flex: 1;
+  flex: 1 1 auto;
   height: 100%;
   max-width: 100%;
   min-height: 0;


### PR DESCRIPTION
On IE11, a modal is not adjusting his height based on the content. I think it's becaused of the shorthand version of `flex: 1`. IE10-11 are interpolating that value the wrong way

Setting it to `flex: 1 1 auto` fixed the issue I was having

There are other places in Blue that used the same shorthand flex property. I didn't want to go in there and change everything without causing unknown side effects

![screen recording 2018-11-07 at 12 27 pm](https://user-images.githubusercontent.com/203992/48154190-fef0d280-e295-11e8-8628-f846f0058f99.gif)
